### PR TITLE
Update write events to give correct expected version

### DIFF
--- a/generated/streams_pb.d.ts
+++ b/generated/streams_pb.d.ts
@@ -978,6 +978,36 @@ export namespace AppendResp {
 
     export class WrongExpectedVersion extends jspb.Message { 
 
+        hasCurrentRevision2060(): boolean;
+        clearCurrentRevision2060(): void;
+        getCurrentRevision2060(): number;
+        setCurrentRevision2060(value: number): WrongExpectedVersion;
+
+
+        hasNoStream2060(): boolean;
+        clearNoStream2060(): void;
+        getNoStream2060(): shared_pb.Empty | undefined;
+        setNoStream2060(value?: shared_pb.Empty): WrongExpectedVersion;
+
+
+        hasExpectedRevision2060(): boolean;
+        clearExpectedRevision2060(): void;
+        getExpectedRevision2060(): number;
+        setExpectedRevision2060(value: number): WrongExpectedVersion;
+
+
+        hasAny2060(): boolean;
+        clearAny2060(): void;
+        getAny2060(): shared_pb.Empty | undefined;
+        setAny2060(value?: shared_pb.Empty): WrongExpectedVersion;
+
+
+        hasStreamExists2060(): boolean;
+        clearStreamExists2060(): void;
+        getStreamExists2060(): shared_pb.Empty | undefined;
+        setStreamExists2060(value?: shared_pb.Empty): WrongExpectedVersion;
+
+
         hasCurrentRevision(): boolean;
         clearCurrentRevision(): void;
         getCurrentRevision(): string;
@@ -1014,6 +1044,8 @@ export namespace AppendResp {
         setExpectedNoStream(value?: shared_pb.Empty): WrongExpectedVersion;
 
 
+        getCurrentRevisionOption2060Case(): WrongExpectedVersion.CurrentRevisionOption2060Case;
+        getExpectedRevisionOption2060Case(): WrongExpectedVersion.ExpectedRevisionOption2060Case;
         getCurrentRevisionOptionCase(): WrongExpectedVersion.CurrentRevisionOptionCase;
         getExpectedRevisionOptionCase(): WrongExpectedVersion.ExpectedRevisionOptionCase;
 
@@ -1029,6 +1061,11 @@ export namespace AppendResp {
 
     export namespace WrongExpectedVersion {
         export type AsObject = {
+            currentRevision2060: number,
+            noStream2060?: shared_pb.Empty.AsObject,
+            expectedRevision2060: number,
+            any2060?: shared_pb.Empty.AsObject,
+            streamExists2060?: shared_pb.Empty.AsObject,
             currentRevision: string,
             currentNoStream?: shared_pb.Empty.AsObject,
             expectedRevision: string,
@@ -1037,25 +1074,45 @@ export namespace AppendResp {
             expectedNoStream?: shared_pb.Empty.AsObject,
         }
 
+        export enum CurrentRevisionOption2060Case {
+            CURRENT_REVISION_OPTION_20_6_0_NOT_SET = 0,
+        
+    CURRENT_REVISION_20_6_0 = 1,
+
+    NO_STREAM_20_6_0 = 2,
+
+        }
+
+        export enum ExpectedRevisionOption2060Case {
+            EXPECTED_REVISION_OPTION_20_6_0_NOT_SET = 0,
+        
+    EXPECTED_REVISION_20_6_0 = 3,
+
+    ANY_20_6_0 = 4,
+
+    STREAM_EXISTS_20_6_0 = 5,
+
+        }
+
         export enum CurrentRevisionOptionCase {
             CURRENT_REVISION_OPTION_NOT_SET = 0,
         
-    CURRENT_REVISION = 1,
+    CURRENT_REVISION = 6,
 
-    CURRENT_NO_STREAM = 2,
+    CURRENT_NO_STREAM = 7,
 
         }
 
         export enum ExpectedRevisionOptionCase {
             EXPECTED_REVISION_OPTION_NOT_SET = 0,
         
-    EXPECTED_REVISION = 3,
+    EXPECTED_REVISION = 8,
 
-    EXPECTED_ANY = 4,
+    EXPECTED_ANY = 9,
 
-    EXPECTED_STREAM_EXISTS = 5,
+    EXPECTED_STREAM_EXISTS = 10,
 
-    EXPECTED_NO_STREAM = 6,
+    EXPECTED_NO_STREAM = 11,
 
         }
 

--- a/generated/streams_pb.d.ts
+++ b/generated/streams_pb.d.ts
@@ -984,10 +984,10 @@ export namespace AppendResp {
         setCurrentRevision(value: string): WrongExpectedVersion;
 
 
-        hasNoStream(): boolean;
-        clearNoStream(): void;
-        getNoStream(): shared_pb.Empty | undefined;
-        setNoStream(value?: shared_pb.Empty): WrongExpectedVersion;
+        hasCurrentNoStream(): boolean;
+        clearCurrentNoStream(): void;
+        getCurrentNoStream(): shared_pb.Empty | undefined;
+        setCurrentNoStream(value?: shared_pb.Empty): WrongExpectedVersion;
 
 
         hasExpectedRevision(): boolean;
@@ -996,16 +996,22 @@ export namespace AppendResp {
         setExpectedRevision(value: string): WrongExpectedVersion;
 
 
-        hasAny(): boolean;
-        clearAny(): void;
-        getAny(): shared_pb.Empty | undefined;
-        setAny(value?: shared_pb.Empty): WrongExpectedVersion;
+        hasExpectedAny(): boolean;
+        clearExpectedAny(): void;
+        getExpectedAny(): shared_pb.Empty | undefined;
+        setExpectedAny(value?: shared_pb.Empty): WrongExpectedVersion;
 
 
-        hasStreamExists(): boolean;
-        clearStreamExists(): void;
-        getStreamExists(): shared_pb.Empty | undefined;
-        setStreamExists(value?: shared_pb.Empty): WrongExpectedVersion;
+        hasExpectedStreamExists(): boolean;
+        clearExpectedStreamExists(): void;
+        getExpectedStreamExists(): shared_pb.Empty | undefined;
+        setExpectedStreamExists(value?: shared_pb.Empty): WrongExpectedVersion;
+
+
+        hasExpectedNoStream(): boolean;
+        clearExpectedNoStream(): void;
+        getExpectedNoStream(): shared_pb.Empty | undefined;
+        setExpectedNoStream(value?: shared_pb.Empty): WrongExpectedVersion;
 
 
         getCurrentRevisionOptionCase(): WrongExpectedVersion.CurrentRevisionOptionCase;
@@ -1024,10 +1030,11 @@ export namespace AppendResp {
     export namespace WrongExpectedVersion {
         export type AsObject = {
             currentRevision: string,
-            noStream?: shared_pb.Empty.AsObject,
+            currentNoStream?: shared_pb.Empty.AsObject,
             expectedRevision: string,
-            any?: shared_pb.Empty.AsObject,
-            streamExists?: shared_pb.Empty.AsObject,
+            expectedAny?: shared_pb.Empty.AsObject,
+            expectedStreamExists?: shared_pb.Empty.AsObject,
+            expectedNoStream?: shared_pb.Empty.AsObject,
         }
 
         export enum CurrentRevisionOptionCase {
@@ -1035,7 +1042,7 @@ export namespace AppendResp {
         
     CURRENT_REVISION = 1,
 
-    NO_STREAM = 2,
+    CURRENT_NO_STREAM = 2,
 
         }
 
@@ -1044,9 +1051,11 @@ export namespace AppendResp {
         
     EXPECTED_REVISION = 3,
 
-    ANY = 4,
+    EXPECTED_ANY = 4,
 
-    STREAM_EXISTS = 5,
+    EXPECTED_STREAM_EXISTS = 5,
+
+    EXPECTED_NO_STREAM = 6,
 
         }
 

--- a/generated/streams_pb.js
+++ b/generated/streams_pb.js
@@ -26,7 +26,9 @@ goog.exportSymbol('proto.event_store.client.streams.AppendResp.Success', null, g
 goog.exportSymbol('proto.event_store.client.streams.AppendResp.Success.CurrentRevisionOptionCase', null, global);
 goog.exportSymbol('proto.event_store.client.streams.AppendResp.Success.PositionOptionCase', null, global);
 goog.exportSymbol('proto.event_store.client.streams.AppendResp.WrongExpectedVersion', null, global);
+goog.exportSymbol('proto.event_store.client.streams.AppendResp.WrongExpectedVersion.CurrentRevisionOption2060Case', null, global);
 goog.exportSymbol('proto.event_store.client.streams.AppendResp.WrongExpectedVersion.CurrentRevisionOptionCase', null, global);
+goog.exportSymbol('proto.event_store.client.streams.AppendResp.WrongExpectedVersion.ExpectedRevisionOption2060Case', null, global);
 goog.exportSymbol('proto.event_store.client.streams.AppendResp.WrongExpectedVersion.ExpectedRevisionOptionCase', null, global);
 goog.exportSymbol('proto.event_store.client.streams.DeleteReq', null, global);
 goog.exportSymbol('proto.event_store.client.streams.DeleteReq.Options', null, global);
@@ -6182,22 +6184,55 @@ proto.event_store.client.streams.AppendResp.Success.prototype.hasNoPosition = fu
  * @private {!Array<!Array<number>>}
  * @const
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_ = [[1,2],[3,4,5,6]];
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_ = [[1,2],[3,4,5],[6,7],[8,9,10,11]];
+
+/**
+ * @enum {number}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.CurrentRevisionOption2060Case = {
+  CURRENT_REVISION_OPTION_20_6_0_NOT_SET: 0,
+  CURRENT_REVISION_20_6_0: 1,
+  NO_STREAM_20_6_0: 2
+};
+
+/**
+ * @return {proto.event_store.client.streams.AppendResp.WrongExpectedVersion.CurrentRevisionOption2060Case}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getCurrentRevisionOption2060Case = function() {
+  return /** @type {proto.event_store.client.streams.AppendResp.WrongExpectedVersion.CurrentRevisionOption2060Case} */(jspb.Message.computeOneofCase(this, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[0]));
+};
+
+/**
+ * @enum {number}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.ExpectedRevisionOption2060Case = {
+  EXPECTED_REVISION_OPTION_20_6_0_NOT_SET: 0,
+  EXPECTED_REVISION_20_6_0: 3,
+  ANY_20_6_0: 4,
+  STREAM_EXISTS_20_6_0: 5
+};
+
+/**
+ * @return {proto.event_store.client.streams.AppendResp.WrongExpectedVersion.ExpectedRevisionOption2060Case}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getExpectedRevisionOption2060Case = function() {
+  return /** @type {proto.event_store.client.streams.AppendResp.WrongExpectedVersion.ExpectedRevisionOption2060Case} */(jspb.Message.computeOneofCase(this, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[1]));
+};
 
 /**
  * @enum {number}
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.CurrentRevisionOptionCase = {
   CURRENT_REVISION_OPTION_NOT_SET: 0,
-  CURRENT_REVISION: 1,
-  CURRENT_NO_STREAM: 2
+  CURRENT_REVISION: 6,
+  CURRENT_NO_STREAM: 7
 };
 
 /**
  * @return {proto.event_store.client.streams.AppendResp.WrongExpectedVersion.CurrentRevisionOptionCase}
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getCurrentRevisionOptionCase = function() {
-  return /** @type {proto.event_store.client.streams.AppendResp.WrongExpectedVersion.CurrentRevisionOptionCase} */(jspb.Message.computeOneofCase(this, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[0]));
+  return /** @type {proto.event_store.client.streams.AppendResp.WrongExpectedVersion.CurrentRevisionOptionCase} */(jspb.Message.computeOneofCase(this, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[2]));
 };
 
 /**
@@ -6205,17 +6240,17 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getCu
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.ExpectedRevisionOptionCase = {
   EXPECTED_REVISION_OPTION_NOT_SET: 0,
-  EXPECTED_REVISION: 3,
-  EXPECTED_ANY: 4,
-  EXPECTED_STREAM_EXISTS: 5,
-  EXPECTED_NO_STREAM: 6
+  EXPECTED_REVISION: 8,
+  EXPECTED_ANY: 9,
+  EXPECTED_STREAM_EXISTS: 10,
+  EXPECTED_NO_STREAM: 11
 };
 
 /**
  * @return {proto.event_store.client.streams.AppendResp.WrongExpectedVersion.ExpectedRevisionOptionCase}
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getExpectedRevisionOptionCase = function() {
-  return /** @type {proto.event_store.client.streams.AppendResp.WrongExpectedVersion.ExpectedRevisionOptionCase} */(jspb.Message.computeOneofCase(this, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[1]));
+  return /** @type {proto.event_store.client.streams.AppendResp.WrongExpectedVersion.ExpectedRevisionOptionCase} */(jspb.Message.computeOneofCase(this, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[3]));
 };
 
 
@@ -6249,9 +6284,14 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.toObj
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.toObject = function(includeInstance, msg) {
   var f, obj = {
-    currentRevision: jspb.Message.getFieldWithDefault(msg, 1, "0"),
+    currentRevision2060: jspb.Message.getFieldWithDefault(msg, 1, 0),
+    noStream2060: (f = msg.getNoStream2060()) && shared_pb.Empty.toObject(includeInstance, f),
+    expectedRevision2060: jspb.Message.getFieldWithDefault(msg, 3, 0),
+    any2060: (f = msg.getAny2060()) && shared_pb.Empty.toObject(includeInstance, f),
+    streamExists2060: (f = msg.getStreamExists2060()) && shared_pb.Empty.toObject(includeInstance, f),
+    currentRevision: jspb.Message.getFieldWithDefault(msg, 6, "0"),
     currentNoStream: (f = msg.getCurrentNoStream()) && shared_pb.Empty.toObject(includeInstance, f),
-    expectedRevision: jspb.Message.getFieldWithDefault(msg, 3, "0"),
+    expectedRevision: jspb.Message.getFieldWithDefault(msg, 8, "0"),
     expectedAny: (f = msg.getExpectedAny()) && shared_pb.Empty.toObject(includeInstance, f),
     expectedStreamExists: (f = msg.getExpectedStreamExists()) && shared_pb.Empty.toObject(includeInstance, f),
     expectedNoStream: (f = msg.getExpectedNoStream()) && shared_pb.Empty.toObject(includeInstance, f)
@@ -6292,29 +6332,52 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.deserializeBina
     var field = reader.getFieldNumber();
     switch (field) {
     case 1:
-      var value = /** @type {string} */ (reader.readUint64String());
-      msg.setCurrentRevision(value);
+      var value = /** @type {number} */ (reader.readUint64());
+      msg.setCurrentRevision2060(value);
       break;
     case 2:
       var value = new shared_pb.Empty;
       reader.readMessage(value,shared_pb.Empty.deserializeBinaryFromReader);
-      msg.setCurrentNoStream(value);
+      msg.setNoStream2060(value);
       break;
     case 3:
-      var value = /** @type {string} */ (reader.readUint64String());
-      msg.setExpectedRevision(value);
+      var value = /** @type {number} */ (reader.readUint64());
+      msg.setExpectedRevision2060(value);
       break;
     case 4:
       var value = new shared_pb.Empty;
       reader.readMessage(value,shared_pb.Empty.deserializeBinaryFromReader);
-      msg.setExpectedAny(value);
+      msg.setAny2060(value);
       break;
     case 5:
       var value = new shared_pb.Empty;
       reader.readMessage(value,shared_pb.Empty.deserializeBinaryFromReader);
-      msg.setExpectedStreamExists(value);
+      msg.setStreamExists2060(value);
       break;
     case 6:
+      var value = /** @type {string} */ (reader.readUint64String());
+      msg.setCurrentRevision(value);
+      break;
+    case 7:
+      var value = new shared_pb.Empty;
+      reader.readMessage(value,shared_pb.Empty.deserializeBinaryFromReader);
+      msg.setCurrentNoStream(value);
+      break;
+    case 8:
+      var value = /** @type {string} */ (reader.readUint64String());
+      msg.setExpectedRevision(value);
+      break;
+    case 9:
+      var value = new shared_pb.Empty;
+      reader.readMessage(value,shared_pb.Empty.deserializeBinaryFromReader);
+      msg.setExpectedAny(value);
+      break;
+    case 10:
+      var value = new shared_pb.Empty;
+      reader.readMessage(value,shared_pb.Empty.deserializeBinaryFromReader);
+      msg.setExpectedStreamExists(value);
+      break;
+    case 11:
       var value = new shared_pb.Empty;
       reader.readMessage(value,shared_pb.Empty.deserializeBinaryFromReader);
       msg.setExpectedNoStream(value);
@@ -6348,14 +6411,14 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.seria
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = /** @type {string} */ (jspb.Message.getField(message, 1));
+  f = /** @type {number} */ (jspb.Message.getField(message, 1));
   if (f != null) {
-    writer.writeUint64String(
+    writer.writeUint64(
       1,
       f
     );
   }
-  f = message.getCurrentNoStream();
+  f = message.getNoStream2060();
   if (f != null) {
     writer.writeMessage(
       2,
@@ -6363,14 +6426,14 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.serializeBinary
       shared_pb.Empty.serializeBinaryToWriter
     );
   }
-  f = /** @type {string} */ (jspb.Message.getField(message, 3));
+  f = /** @type {number} */ (jspb.Message.getField(message, 3));
   if (f != null) {
-    writer.writeUint64String(
+    writer.writeUint64(
       3,
       f
     );
   }
-  f = message.getExpectedAny();
+  f = message.getAny2060();
   if (f != null) {
     writer.writeMessage(
       4,
@@ -6378,7 +6441,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.serializeBinary
       shared_pb.Empty.serializeBinaryToWriter
     );
   }
-  f = message.getExpectedStreamExists();
+  f = message.getStreamExists2060();
   if (f != null) {
     writer.writeMessage(
       5,
@@ -6386,10 +6449,48 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.serializeBinary
       shared_pb.Empty.serializeBinaryToWriter
     );
   }
+  f = /** @type {string} */ (jspb.Message.getField(message, 6));
+  if (f != null) {
+    writer.writeUint64String(
+      6,
+      f
+    );
+  }
+  f = message.getCurrentNoStream();
+  if (f != null) {
+    writer.writeMessage(
+      7,
+      f,
+      shared_pb.Empty.serializeBinaryToWriter
+    );
+  }
+  f = /** @type {string} */ (jspb.Message.getField(message, 8));
+  if (f != null) {
+    writer.writeUint64String(
+      8,
+      f
+    );
+  }
+  f = message.getExpectedAny();
+  if (f != null) {
+    writer.writeMessage(
+      9,
+      f,
+      shared_pb.Empty.serializeBinaryToWriter
+    );
+  }
+  f = message.getExpectedStreamExists();
+  if (f != null) {
+    writer.writeMessage(
+      10,
+      f,
+      shared_pb.Empty.serializeBinaryToWriter
+    );
+  }
   f = message.getExpectedNoStream();
   if (f != null) {
     writer.writeMessage(
-      6,
+      11,
       f,
       shared_pb.Empty.serializeBinaryToWriter
     );
@@ -6398,19 +6499,19 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.serializeBinary
 
 
 /**
- * optional uint64 current_revision = 1;
- * @return {string}
+ * optional uint64 current_revision_20_6_0 = 1;
+ * @return {number}
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getCurrentRevision = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, "0"));
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getCurrentRevision2060 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 1, 0));
 };
 
 
 /**
- * @param {string} value
+ * @param {number} value
  * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setCurrentRevision = function(value) {
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setCurrentRevision2060 = function(value) {
   return jspb.Message.setOneofField(this, 1, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[0], value);
 };
 
@@ -6419,7 +6520,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setCu
  * Clears the field making it undefined.
  * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clearCurrentRevision = function() {
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clearCurrentRevision2060 = function() {
   return jspb.Message.setOneofField(this, 1, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[0], undefined);
 };
 
@@ -6428,16 +6529,16 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clear
  * Returns whether this field is set.
  * @return {boolean}
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasCurrentRevision = function() {
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasCurrentRevision2060 = function() {
   return jspb.Message.getField(this, 1) != null;
 };
 
 
 /**
- * optional event_store.client.shared.Empty current_no_stream = 2;
+ * optional event_store.client.shared.Empty no_stream_20_6_0 = 2;
  * @return {?proto.event_store.client.shared.Empty}
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getCurrentNoStream = function() {
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getNoStream2060 = function() {
   return /** @type{?proto.event_store.client.shared.Empty} */ (
     jspb.Message.getWrapperField(this, shared_pb.Empty, 2));
 };
@@ -6447,8 +6548,191 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getCu
  * @param {?proto.event_store.client.shared.Empty|undefined} value
  * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
 */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setCurrentNoStream = function(value) {
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setNoStream2060 = function(value) {
   return jspb.Message.setOneofWrapperField(this, 2, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[0], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clearNoStream2060 = function() {
+  return this.setNoStream2060(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasNoStream2060 = function() {
+  return jspb.Message.getField(this, 2) != null;
+};
+
+
+/**
+ * optional uint64 expected_revision_20_6_0 = 3;
+ * @return {number}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getExpectedRevision2060 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setExpectedRevision2060 = function(value) {
+  return jspb.Message.setOneofField(this, 3, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[1], value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clearExpectedRevision2060 = function() {
+  return jspb.Message.setOneofField(this, 3, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[1], undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasExpectedRevision2060 = function() {
+  return jspb.Message.getField(this, 3) != null;
+};
+
+
+/**
+ * optional event_store.client.shared.Empty any_20_6_0 = 4;
+ * @return {?proto.event_store.client.shared.Empty}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getAny2060 = function() {
+  return /** @type{?proto.event_store.client.shared.Empty} */ (
+    jspb.Message.getWrapperField(this, shared_pb.Empty, 4));
+};
+
+
+/**
+ * @param {?proto.event_store.client.shared.Empty|undefined} value
+ * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
+*/
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setAny2060 = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 4, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[1], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clearAny2060 = function() {
+  return this.setAny2060(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasAny2060 = function() {
+  return jspb.Message.getField(this, 4) != null;
+};
+
+
+/**
+ * optional event_store.client.shared.Empty stream_exists_20_6_0 = 5;
+ * @return {?proto.event_store.client.shared.Empty}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getStreamExists2060 = function() {
+  return /** @type{?proto.event_store.client.shared.Empty} */ (
+    jspb.Message.getWrapperField(this, shared_pb.Empty, 5));
+};
+
+
+/**
+ * @param {?proto.event_store.client.shared.Empty|undefined} value
+ * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
+*/
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setStreamExists2060 = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 5, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[1], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clearStreamExists2060 = function() {
+  return this.setStreamExists2060(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasStreamExists2060 = function() {
+  return jspb.Message.getField(this, 5) != null;
+};
+
+
+/**
+ * optional uint64 current_revision = 6;
+ * @return {string}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getCurrentRevision = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 6, "0"));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setCurrentRevision = function(value) {
+  return jspb.Message.setOneofField(this, 6, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[2], value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clearCurrentRevision = function() {
+  return jspb.Message.setOneofField(this, 6, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[2], undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasCurrentRevision = function() {
+  return jspb.Message.getField(this, 6) != null;
+};
+
+
+/**
+ * optional event_store.client.shared.Empty current_no_stream = 7;
+ * @return {?proto.event_store.client.shared.Empty}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getCurrentNoStream = function() {
+  return /** @type{?proto.event_store.client.shared.Empty} */ (
+    jspb.Message.getWrapperField(this, shared_pb.Empty, 7));
+};
+
+
+/**
+ * @param {?proto.event_store.client.shared.Empty|undefined} value
+ * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
+*/
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setCurrentNoStream = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 7, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[2], value);
 };
 
 
@@ -6466,16 +6750,16 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clear
  * @return {boolean}
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasCurrentNoStream = function() {
-  return jspb.Message.getField(this, 2) != null;
+  return jspb.Message.getField(this, 7) != null;
 };
 
 
 /**
- * optional uint64 expected_revision = 3;
+ * optional uint64 expected_revision = 8;
  * @return {string}
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getExpectedRevision = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, "0"));
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 8, "0"));
 };
 
 
@@ -6484,7 +6768,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getEx
  * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setExpectedRevision = function(value) {
-  return jspb.Message.setOneofField(this, 3, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[1], value);
+  return jspb.Message.setOneofField(this, 8, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[3], value);
 };
 
 
@@ -6493,7 +6777,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setEx
  * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clearExpectedRevision = function() {
-  return jspb.Message.setOneofField(this, 3, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[1], undefined);
+  return jspb.Message.setOneofField(this, 8, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[3], undefined);
 };
 
 
@@ -6502,17 +6786,17 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clear
  * @return {boolean}
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasExpectedRevision = function() {
-  return jspb.Message.getField(this, 3) != null;
+  return jspb.Message.getField(this, 8) != null;
 };
 
 
 /**
- * optional event_store.client.shared.Empty expected_any = 4;
+ * optional event_store.client.shared.Empty expected_any = 9;
  * @return {?proto.event_store.client.shared.Empty}
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getExpectedAny = function() {
   return /** @type{?proto.event_store.client.shared.Empty} */ (
-    jspb.Message.getWrapperField(this, shared_pb.Empty, 4));
+    jspb.Message.getWrapperField(this, shared_pb.Empty, 9));
 };
 
 
@@ -6521,7 +6805,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getEx
  * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
 */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setExpectedAny = function(value) {
-  return jspb.Message.setOneofWrapperField(this, 4, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[1], value);
+  return jspb.Message.setOneofWrapperField(this, 9, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[3], value);
 };
 
 
@@ -6539,17 +6823,17 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clear
  * @return {boolean}
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasExpectedAny = function() {
-  return jspb.Message.getField(this, 4) != null;
+  return jspb.Message.getField(this, 9) != null;
 };
 
 
 /**
- * optional event_store.client.shared.Empty expected_stream_exists = 5;
+ * optional event_store.client.shared.Empty expected_stream_exists = 10;
  * @return {?proto.event_store.client.shared.Empty}
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getExpectedStreamExists = function() {
   return /** @type{?proto.event_store.client.shared.Empty} */ (
-    jspb.Message.getWrapperField(this, shared_pb.Empty, 5));
+    jspb.Message.getWrapperField(this, shared_pb.Empty, 10));
 };
 
 
@@ -6558,7 +6842,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getEx
  * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
 */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setExpectedStreamExists = function(value) {
-  return jspb.Message.setOneofWrapperField(this, 5, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[1], value);
+  return jspb.Message.setOneofWrapperField(this, 10, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[3], value);
 };
 
 
@@ -6576,17 +6860,17 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clear
  * @return {boolean}
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasExpectedStreamExists = function() {
-  return jspb.Message.getField(this, 5) != null;
+  return jspb.Message.getField(this, 10) != null;
 };
 
 
 /**
- * optional event_store.client.shared.Empty expected_no_stream = 6;
+ * optional event_store.client.shared.Empty expected_no_stream = 11;
  * @return {?proto.event_store.client.shared.Empty}
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getExpectedNoStream = function() {
   return /** @type{?proto.event_store.client.shared.Empty} */ (
-    jspb.Message.getWrapperField(this, shared_pb.Empty, 6));
+    jspb.Message.getWrapperField(this, shared_pb.Empty, 11));
 };
 
 
@@ -6595,7 +6879,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getEx
  * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
 */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setExpectedNoStream = function(value) {
-  return jspb.Message.setOneofWrapperField(this, 6, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[1], value);
+  return jspb.Message.setOneofWrapperField(this, 11, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[3], value);
 };
 
 
@@ -6613,7 +6897,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clear
  * @return {boolean}
  */
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasExpectedNoStream = function() {
-  return jspb.Message.getField(this, 6) != null;
+  return jspb.Message.getField(this, 11) != null;
 };
 
 

--- a/generated/streams_pb.js
+++ b/generated/streams_pb.js
@@ -6182,7 +6182,7 @@ proto.event_store.client.streams.AppendResp.Success.prototype.hasNoPosition = fu
  * @private {!Array<!Array<number>>}
  * @const
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_ = [[1,2],[3,4,5]];
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_ = [[1,2],[3,4,5,6]];
 
 /**
  * @enum {number}
@@ -6190,7 +6190,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_ = 
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.CurrentRevisionOptionCase = {
   CURRENT_REVISION_OPTION_NOT_SET: 0,
   CURRENT_REVISION: 1,
-  NO_STREAM: 2
+  CURRENT_NO_STREAM: 2
 };
 
 /**
@@ -6206,8 +6206,9 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getCu
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.ExpectedRevisionOptionCase = {
   EXPECTED_REVISION_OPTION_NOT_SET: 0,
   EXPECTED_REVISION: 3,
-  ANY: 4,
-  STREAM_EXISTS: 5
+  EXPECTED_ANY: 4,
+  EXPECTED_STREAM_EXISTS: 5,
+  EXPECTED_NO_STREAM: 6
 };
 
 /**
@@ -6249,10 +6250,11 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.toObj
 proto.event_store.client.streams.AppendResp.WrongExpectedVersion.toObject = function(includeInstance, msg) {
   var f, obj = {
     currentRevision: jspb.Message.getFieldWithDefault(msg, 1, "0"),
-    noStream: (f = msg.getNoStream()) && shared_pb.Empty.toObject(includeInstance, f),
+    currentNoStream: (f = msg.getCurrentNoStream()) && shared_pb.Empty.toObject(includeInstance, f),
     expectedRevision: jspb.Message.getFieldWithDefault(msg, 3, "0"),
-    any: (f = msg.getAny()) && shared_pb.Empty.toObject(includeInstance, f),
-    streamExists: (f = msg.getStreamExists()) && shared_pb.Empty.toObject(includeInstance, f)
+    expectedAny: (f = msg.getExpectedAny()) && shared_pb.Empty.toObject(includeInstance, f),
+    expectedStreamExists: (f = msg.getExpectedStreamExists()) && shared_pb.Empty.toObject(includeInstance, f),
+    expectedNoStream: (f = msg.getExpectedNoStream()) && shared_pb.Empty.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -6296,7 +6298,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.deserializeBina
     case 2:
       var value = new shared_pb.Empty;
       reader.readMessage(value,shared_pb.Empty.deserializeBinaryFromReader);
-      msg.setNoStream(value);
+      msg.setCurrentNoStream(value);
       break;
     case 3:
       var value = /** @type {string} */ (reader.readUint64String());
@@ -6305,12 +6307,17 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.deserializeBina
     case 4:
       var value = new shared_pb.Empty;
       reader.readMessage(value,shared_pb.Empty.deserializeBinaryFromReader);
-      msg.setAny(value);
+      msg.setExpectedAny(value);
       break;
     case 5:
       var value = new shared_pb.Empty;
       reader.readMessage(value,shared_pb.Empty.deserializeBinaryFromReader);
-      msg.setStreamExists(value);
+      msg.setExpectedStreamExists(value);
+      break;
+    case 6:
+      var value = new shared_pb.Empty;
+      reader.readMessage(value,shared_pb.Empty.deserializeBinaryFromReader);
+      msg.setExpectedNoStream(value);
       break;
     default:
       reader.skipField();
@@ -6348,7 +6355,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.serializeBinary
       f
     );
   }
-  f = message.getNoStream();
+  f = message.getCurrentNoStream();
   if (f != null) {
     writer.writeMessage(
       2,
@@ -6363,7 +6370,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.serializeBinary
       f
     );
   }
-  f = message.getAny();
+  f = message.getExpectedAny();
   if (f != null) {
     writer.writeMessage(
       4,
@@ -6371,10 +6378,18 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.serializeBinary
       shared_pb.Empty.serializeBinaryToWriter
     );
   }
-  f = message.getStreamExists();
+  f = message.getExpectedStreamExists();
   if (f != null) {
     writer.writeMessage(
       5,
+      f,
+      shared_pb.Empty.serializeBinaryToWriter
+    );
+  }
+  f = message.getExpectedNoStream();
+  if (f != null) {
+    writer.writeMessage(
+      6,
       f,
       shared_pb.Empty.serializeBinaryToWriter
     );
@@ -6419,10 +6434,10 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasCu
 
 
 /**
- * optional event_store.client.shared.Empty no_stream = 2;
+ * optional event_store.client.shared.Empty current_no_stream = 2;
  * @return {?proto.event_store.client.shared.Empty}
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getNoStream = function() {
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getCurrentNoStream = function() {
   return /** @type{?proto.event_store.client.shared.Empty} */ (
     jspb.Message.getWrapperField(this, shared_pb.Empty, 2));
 };
@@ -6432,7 +6447,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getNo
  * @param {?proto.event_store.client.shared.Empty|undefined} value
  * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
 */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setNoStream = function(value) {
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setCurrentNoStream = function(value) {
   return jspb.Message.setOneofWrapperField(this, 2, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[0], value);
 };
 
@@ -6441,8 +6456,8 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setNo
  * Clears the message field making it undefined.
  * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clearNoStream = function() {
-  return this.setNoStream(undefined);
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clearCurrentNoStream = function() {
+  return this.setCurrentNoStream(undefined);
 };
 
 
@@ -6450,7 +6465,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clear
  * Returns whether this field is set.
  * @return {boolean}
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasNoStream = function() {
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasCurrentNoStream = function() {
   return jspb.Message.getField(this, 2) != null;
 };
 
@@ -6492,10 +6507,10 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasEx
 
 
 /**
- * optional event_store.client.shared.Empty any = 4;
+ * optional event_store.client.shared.Empty expected_any = 4;
  * @return {?proto.event_store.client.shared.Empty}
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getAny = function() {
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getExpectedAny = function() {
   return /** @type{?proto.event_store.client.shared.Empty} */ (
     jspb.Message.getWrapperField(this, shared_pb.Empty, 4));
 };
@@ -6505,7 +6520,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getAn
  * @param {?proto.event_store.client.shared.Empty|undefined} value
  * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
 */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setAny = function(value) {
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setExpectedAny = function(value) {
   return jspb.Message.setOneofWrapperField(this, 4, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[1], value);
 };
 
@@ -6514,8 +6529,8 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setAn
  * Clears the message field making it undefined.
  * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clearAny = function() {
-  return this.setAny(undefined);
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clearExpectedAny = function() {
+  return this.setExpectedAny(undefined);
 };
 
 
@@ -6523,16 +6538,16 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clear
  * Returns whether this field is set.
  * @return {boolean}
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasAny = function() {
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasExpectedAny = function() {
   return jspb.Message.getField(this, 4) != null;
 };
 
 
 /**
- * optional event_store.client.shared.Empty stream_exists = 5;
+ * optional event_store.client.shared.Empty expected_stream_exists = 5;
  * @return {?proto.event_store.client.shared.Empty}
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getStreamExists = function() {
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getExpectedStreamExists = function() {
   return /** @type{?proto.event_store.client.shared.Empty} */ (
     jspb.Message.getWrapperField(this, shared_pb.Empty, 5));
 };
@@ -6542,7 +6557,7 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getSt
  * @param {?proto.event_store.client.shared.Empty|undefined} value
  * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
 */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setStreamExists = function(value) {
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setExpectedStreamExists = function(value) {
   return jspb.Message.setOneofWrapperField(this, 5, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[1], value);
 };
 
@@ -6551,8 +6566,8 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setSt
  * Clears the message field making it undefined.
  * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clearStreamExists = function() {
-  return this.setStreamExists(undefined);
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clearExpectedStreamExists = function() {
+  return this.setExpectedStreamExists(undefined);
 };
 
 
@@ -6560,8 +6575,45 @@ proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clear
  * Returns whether this field is set.
  * @return {boolean}
  */
-proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasStreamExists = function() {
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasExpectedStreamExists = function() {
   return jspb.Message.getField(this, 5) != null;
+};
+
+
+/**
+ * optional event_store.client.shared.Empty expected_no_stream = 6;
+ * @return {?proto.event_store.client.shared.Empty}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.getExpectedNoStream = function() {
+  return /** @type{?proto.event_store.client.shared.Empty} */ (
+    jspb.Message.getWrapperField(this, shared_pb.Empty, 6));
+};
+
+
+/**
+ * @param {?proto.event_store.client.shared.Empty|undefined} value
+ * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
+*/
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.setExpectedNoStream = function(value) {
+  return jspb.Message.setOneofWrapperField(this, 6, proto.event_store.client.streams.AppendResp.WrongExpectedVersion.oneofGroups_[1], value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.event_store.client.streams.AppendResp.WrongExpectedVersion} returns this
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.clearExpectedNoStream = function() {
+  return this.setExpectedNoStream(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.event_store.client.streams.AppendResp.WrongExpectedVersion.prototype.hasExpectedNoStream = function() {
+  return jspb.Message.getField(this, 6) != null;
 };
 
 

--- a/protos/streams.proto
+++ b/protos/streams.proto
@@ -168,12 +168,13 @@ message AppendResp {
 	message WrongExpectedVersion {
 	  oneof current_revision_option {
 		  uint64 current_revision = 1 [jstype = JS_STRING];
-		  event_store.client.shared.Empty no_stream = 2;
+		  event_store.client.shared.Empty current_no_stream = 2;
 	  }
 	  oneof expected_revision_option {
 		  uint64 expected_revision = 3 [jstype = JS_STRING];
-		  event_store.client.shared.Empty any = 4;
-		  event_store.client.shared.Empty stream_exists = 5;
+		  event_store.client.shared.Empty expected_any = 4;
+		  event_store.client.shared.Empty expected_stream_exists = 5;
+		  event_store.client.shared.Empty expected_no_stream = 6;
 		}
 	}
 }

--- a/protos/streams.proto
+++ b/protos/streams.proto
@@ -166,16 +166,26 @@ message AppendResp {
 	}
 
 	message WrongExpectedVersion {
-	  oneof current_revision_option {
-		  uint64 current_revision = 1 [jstype = JS_STRING];
-		  event_store.client.shared.Empty current_no_stream = 2;
-	  }
-	  oneof expected_revision_option {
-		  uint64 expected_revision = 3 [jstype = JS_STRING];
-		  event_store.client.shared.Empty expected_any = 4;
-		  event_store.client.shared.Empty expected_stream_exists = 5;
-		  event_store.client.shared.Empty expected_no_stream = 6;
+		oneof current_revision_option_20_6_0 {
+			uint64 current_revision_20_6_0 = 1;
+			event_store.client.shared.Empty no_stream_20_6_0 = 2;
 		}
+		oneof expected_revision_option_20_6_0 {
+			uint64 expected_revision_20_6_0 = 3;
+			event_store.client.shared.Empty any_20_6_0 = 4;
+			event_store.client.shared.Empty stream_exists_20_6_0 = 5;
+		}
+		oneof current_revision_option {
+			uint64 current_revision = 6 [jstype = JS_STRING];
+			event_store.client.shared.Empty current_no_stream = 7;
+		}
+		oneof expected_revision_option {
+			uint64 expected_revision = 8 [jstype = JS_STRING];
+			event_store.client.shared.Empty expected_any = 9;
+			event_store.client.shared.Empty expected_stream_exists = 10;
+			event_store.client.shared.Empty expected_no_stream = 11;
+		}
+
 	}
 }
 

--- a/src/__test__/streams/writeEventsToStream.test.ts
+++ b/src/__test__/streams/writeEventsToStream.test.ts
@@ -84,8 +84,7 @@ describe("writeEventsToStream", () => {
           expect(result.nextExpectedVersion).toBeGreaterThanOrEqual(0);
         });
 
-        // issue on server
-        test.skip("fails", async () => {
+        test("fails", async () => {
           const STREAM_NAME = "no_stream_here_but_there_is";
 
           await writeEventsToStream(STREAM_NAME)

--- a/src/command/streams/WriteEventsToStream.ts
+++ b/src/command/streams/WriteEventsToStream.ts
@@ -89,16 +89,18 @@ export class WriteEventsToStream extends Command {
 
           let expected: ExpectedRevision = "any";
 
+          console.log(grpcError.toObject());
+
           switch (true) {
             case grpcError.hasExpectedRevision(): {
               expected = BigInt(grpcError.getExpectedRevision()!);
               break;
             }
-            case grpcError.hasStreamExists(): {
+            case grpcError.hasExpectedStreamExists(): {
               expected = "stream_exists";
               break;
             }
-            case grpcError.hasNoStream(): {
+            case grpcError.hasExpectedNoStream(): {
               expected = "no_stream";
               break;
             }

--- a/src/command/streams/WriteEventsToStream.ts
+++ b/src/command/streams/WriteEventsToStream.ts
@@ -89,8 +89,6 @@ export class WriteEventsToStream extends Command {
 
           let expected: ExpectedRevision = "any";
 
-          console.log(grpcError.toObject());
-
           switch (true) {
             case grpcError.hasExpectedRevision(): {
               expected = BigInt(grpcError.getExpectedRevision()!);


### PR DESCRIPTION
- update to new proto
- enable previously failing test

Blocked by: https://github.com/EventStore/EventStore/pull/2679