### PR TITLE
Dont allow expectedRevision "stream_exists" in deleteStream

### DIFF
--- a/src/__test__/streams/deleteStream.test.ts
+++ b/src/__test__/streams/deleteStream.test.ts
@@ -9,7 +9,7 @@ import {
   WrongExpectedVersionError,
   deleteStream,
 } from "../..";
-import { NO_STREAM, STREAM_EXISTS } from "../../constants";
+import { NO_STREAM } from "../../constants";
 import { StreamNotFoundError } from "../../utils/CommandError";
 
 describe("deleteStream", () => {
@@ -90,38 +90,6 @@ describe("deleteStream", () => {
 
           const result = await deleteStream(STREAM)
             .expectedRevision(revision)
-            .execute(connection);
-
-          expect(result).toBeDefined();
-
-          await expect(
-            readEventsFromStream(STREAM).execute(connection)
-          ).rejects.toThrowError(StreamNotFoundError);
-        });
-      });
-
-      // throws error: 2 UNKNOWN: Exception was thrown by handler.
-      describe.skip(STREAM_EXISTS, () => {
-        const STREAM = "expected_revision_stream_exists";
-        const NOT_A_STREAM = "i_dont_exist_hopefully";
-
-        beforeAll(async () => {
-          await writeEventsToStream(STREAM)
-            .send(event, event, event, event)
-            .execute(connection);
-        });
-
-        it("fails", async () => {
-          await expect(
-            deleteStream(NOT_A_STREAM)
-              .expectedRevision(STREAM_EXISTS)
-              .execute(connection)
-          ).rejects.toThrowError(`error here`);
-        });
-
-        it("succeeds", async () => {
-          const result = await deleteStream(STREAM)
-            .expectedRevision(STREAM_EXISTS)
             .execute(connection);
 
           expect(result).toBeDefined();

--- a/src/command/streams/DeleteStream.ts
+++ b/src/command/streams/DeleteStream.ts
@@ -1,13 +1,17 @@
 import { DeleteReq } from "../../../generated/streams_pb";
 import { StreamIdentifier, Empty } from "../../../generated/shared_pb";
 import { StreamsClient } from "../../../generated/streams_grpc_pb";
-import { DeleteResult, ESDBConnection, ExpectedRevision } from "../../types";
+import {
+  DeleteResult,
+  ESDBConnection,
+  DeleteStreamExpectedRevision,
+} from "../../types";
 import { Command } from "../Command";
 import { convertToCommandError } from "../../utils/CommandError";
 
 export class DeleteStream extends Command {
   private readonly _stream: string;
-  private _revision: ExpectedRevision;
+  private _revision: DeleteStreamExpectedRevision;
 
   constructor(stream: string) {
     super();
@@ -19,7 +23,7 @@ export class DeleteStream extends Command {
    * Asks the server to check the stream is at specific revision before writing events.
    * @param revision
    */
-  expectedRevision(revision: ExpectedRevision): DeleteStream {
+  expectedRevision(revision: DeleteStreamExpectedRevision): DeleteStream {
     this._revision = revision;
     return this;
   }
@@ -42,10 +46,6 @@ export class DeleteStream extends Command {
       }
       case "no_stream": {
         options.setNoStream(new Empty());
-        break;
-      }
-      case "stream_exists": {
-        options.setStreamExists(new Empty());
         break;
       }
       default: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,14 @@ export type ExpectedRevision =
    */
   | number;
 
+/**
+ * Delete stream does not support "stream_exists". see: {@link ExpectedRevision}.
+ */
+export type DeleteStreamExpectedRevision = Exclude<
+  ExpectedRevision,
+  typeof constants.STREAM_EXISTS
+>;
+
 export type CurrentRevision =
   /**
    * The stream being written to does not yet exist.


### PR DESCRIPTION
- despite being present in the proto, this is not supported by the server
- remove from type signature
- remove test