### PR TITLE
Only return position on $all stream events

### DIFF
--- a/src/command/streams/ReadAllEvents.ts
+++ b/src/command/streams/ReadAllEvents.ts
@@ -7,11 +7,12 @@ import {
   ESDBConnection,
   ReadPosition,
   Direction,
-  ResolvedEvent,
+  AllStreamResolvedEvent,
 } from "../../types";
 
 import { Command } from "../Command";
 import { handleBatchRead } from "../../utils/handleBatchRead";
+import { convertAllStreamGrpcEvent } from "../../utils/convertGrpcEvent";
 
 export class ReadAllEvents extends Command {
   private _position: ReadPosition;
@@ -87,7 +88,7 @@ export class ReadAllEvents extends Command {
   /**
    * Sends asynchronously the read command to the server.
    */
-  async execute(connection: ESDBConnection): Promise<ResolvedEvent[]> {
+  async execute(connection: ESDBConnection): Promise<AllStreamResolvedEvent[]> {
     const req = new ReadReq();
     const options = new ReadReq.Options();
 
@@ -135,6 +136,6 @@ export class ReadAllEvents extends Command {
 
     const client = await connection._client(StreamsClient);
     const stream = client.read(req, this.metadata);
-    return handleBatchRead(stream);
+    return handleBatchRead(stream, convertAllStreamGrpcEvent);
   }
 }

--- a/src/command/streams/ReadEventsFromStream.ts
+++ b/src/command/streams/ReadEventsFromStream.ts
@@ -10,6 +10,7 @@ import {
 } from "../../types";
 import { Command } from "../Command";
 import { handleBatchRead } from "../../utils/handleBatchRead";
+import { convertGrpcEvent } from "../../utils/convertGrpcEvent";
 
 export class ReadEventsFromStream extends Command {
   private _stream: string;
@@ -153,6 +154,6 @@ export class ReadEventsFromStream extends Command {
 
     const client = await connection._client(StreamsClient);
     const stream = client.read(req, this.metadata);
-    return handleBatchRead(stream);
+    return handleBatchRead(stream, convertGrpcEvent);
   }
 }

--- a/src/command/streams/SubscribeToAll.ts
+++ b/src/command/streams/SubscribeToAll.ts
@@ -9,17 +9,19 @@ import {
   SubscriptionHandler,
   ESDBConnection,
   ReadPosition,
+  AllStreamResolvedEvent,
 } from "../../types";
 import { Command } from "../Command";
 import { Filter } from "../../utils/Filter";
 import { handleOneWaySubscription } from "../../utils/handleOneWaySubscription";
+import { convertAllStreamGrpcEvent } from "../../utils/convertGrpcEvent";
 
 export class SubscribeToAll extends Command {
   private _position: ReadPosition;
   private _resolveLinkTos: boolean;
   private _filter?: Filter;
   // TODO: handle no handler
-  private _handler!: SubscriptionHandler;
+  private _handler!: SubscriptionHandler<AllStreamResolvedEvent>;
 
   constructor() {
     super();
@@ -83,7 +85,9 @@ export class SubscribeToAll extends Command {
    * Sets the handler for the subscription
    * @param handler Set of callbacks used during the subscription lifecycle.
    */
-  handler(handler: SubscriptionHandler): SubscribeToAll {
+  handler(
+    handler: SubscriptionHandler<AllStreamResolvedEvent>
+  ): SubscribeToAll {
     this._handler = handler;
     return this;
   }
@@ -140,6 +144,6 @@ export class SubscribeToAll extends Command {
 
     const client = await connection._client(StreamsClient);
     const stream = client.read(req, this.metadata, callOptions);
-    handleOneWaySubscription(stream, this._handler);
+    handleOneWaySubscription(stream, this._handler, convertAllStreamGrpcEvent);
   }
 }

--- a/src/command/streams/SubscribeToStream.ts
+++ b/src/command/streams/SubscribeToStream.ts
@@ -6,16 +6,22 @@ import { Empty, StreamIdentifier } from "../../../generated/shared_pb";
 import UUIDOption = ReadReq.Options.UUIDOption;
 import SubscriptionOptions = ReadReq.Options.SubscriptionOptions;
 
-import { SubscriptionHandler, ESDBConnection, ReadRevision } from "../../types";
+import {
+  SubscriptionHandler,
+  ESDBConnection,
+  ReadRevision,
+  ResolvedEvent,
+} from "../../types";
 import { Command } from "../Command";
 import { handleOneWaySubscription } from "../../utils/handleOneWaySubscription";
+import { convertGrpcEvent } from "../../utils/convertGrpcEvent";
 
 export class SubscribeToStream extends Command {
   private _stream: string;
   private _revision: ReadRevision;
   private _resolveLinkTos: boolean;
   // TODO: handle no handler
-  private _handler!: SubscriptionHandler;
+  private _handler!: SubscriptionHandler<ResolvedEvent>;
 
   constructor(stream: string) {
     super();
@@ -71,7 +77,7 @@ export class SubscribeToStream extends Command {
    * Sets the handler for the subscription
    * @param handler Set of callbacks used during the subscription lifecycle.
    */
-  handler(handler: SubscriptionHandler): SubscribeToStream {
+  handler(handler: SubscriptionHandler<ResolvedEvent>): SubscribeToStream {
     this._handler = handler;
     return this;
   }
@@ -123,6 +129,6 @@ export class SubscribeToStream extends Command {
 
     const client = await connection._client(StreamsClient);
     const stream = client.read(req, this.metadata, callOptions);
-    handleOneWaySubscription(stream, this._handler);
+    handleOneWaySubscription(stream, this._handler, convertGrpcEvent);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,27 +75,6 @@ export type WriteResult = {
 };
 
 /**
- * A structure representing a single event or an resolved link event.
- */
-export type ResolvedEvent = {
-  /**
-   * The event, or the resolved link event if this {@link ResolvedEvent} is a link event.
-   */
-  event?: RecordedEvent;
-
-  /**
-   *
-   The link event if this ResolvedEvent is a link event.
-   */
-  link?: RecordedEvent;
-
-  /**
-   * Commit position of the record.
-   */
-  commitPosition?: bigint;
-};
-
-/**
  * Represents a previously written event.
  */
 export interface RecordedEventBase {
@@ -123,11 +102,6 @@ export interface RecordedEventBase {
    * Representing when this event was created in the database system.
    */
   created: number;
-
-  /**
-   * Position of this event in the transaction log.
-   */
-  position: Position;
 }
 
 export interface JSONRecordedEvent extends RecordedEventBase {
@@ -164,15 +138,74 @@ export interface BinaryRecordedEvent extends RecordedEventBase {
   metadata: Uint8Array;
 }
 
-export type RecordedEvent = JSONRecordedEvent | BinaryRecordedEvent;
+export interface AllStreamJSONRecordedEvent extends JSONRecordedEvent {
+  /**
+   * Position of this event in the transaction log.
+   */
+  position: Position;
+}
 
-export type SubscriptionHandler = {
-  onEvent: (report: SubscriptionReport, event: ResolvedEvent) => void;
+export interface AllStreamBinaryRecordedEvent extends BinaryRecordedEvent {
+  /**
+   * Position of this event in the transaction log.
+   */
+  position: Position;
+}
+
+export type RecordedEvent = JSONRecordedEvent | BinaryRecordedEvent;
+export type AllStreamRecordedEvent =
+  | AllStreamJSONRecordedEvent
+  | AllStreamBinaryRecordedEvent;
+
+/**
+ * A structure representing a single event or an resolved link event.
+ */
+export type ResolvedEvent = {
+  /**
+   * The event, or the resolved link event if this {@link ResolvedEvent} is a link event.
+   */
+  event?: RecordedEvent;
+
+  /**
+   *
+   The link event if this ResolvedEvent is a link event.
+   */
+  link?: RecordedEvent;
+
+  /**
+   * Commit position of the record.
+   */
+  commitPosition?: bigint;
+};
+
+/**
+ * A structure representing a single event or an resolved link event.
+ */
+export type AllStreamResolvedEvent = {
+  /**
+   * The event, or the resolved link event if this {@link ResolvedEvent} is a link event.
+   */
+  event?: AllStreamRecordedEvent;
+
+  /**
+   *
+   The link event if this ResolvedEvent is a link event.
+   */
+  link?: AllStreamRecordedEvent;
+
+  /**
+   * Commit position of the record.
+   */
+  commitPosition?: bigint;
+};
+
+export interface SubscriptionHandler<T> {
+  onEvent: (report: SubscriptionReport, event: T) => void;
   onEnd?: () => void;
   onConfirmation?: () => void;
   onError?: (error: Error) => void;
   onClose?: () => void;
-};
+}
 
 export type PersistentSubscriptionHandler = {
   onEvent: (report: PersistentReport, event: ResolvedEvent) => void;

--- a/src/utils/handleBatchRead.ts
+++ b/src/utils/handleBatchRead.ts
@@ -1,15 +1,14 @@
 import { ClientReadableStream, ServiceError } from "@grpc/grpc-js";
 import { ReadResp } from "../../generated/streams_pb";
 
-import { ResolvedEvent } from "../types";
 import { convertToCommandError, StreamNotFoundError } from "./CommandError";
-import { convertGrpcEvent } from "./convertGrpcEvent";
 
-export function handleBatchRead(
-  stream: ClientReadableStream<ReadResp>
-): Promise<ResolvedEvent[]> {
-  return new Promise<ResolvedEvent[]>((resolve, reject) => {
-    const resolvedEvents: ResolvedEvent[] = [];
+export const handleBatchRead = <T>(
+  stream: ClientReadableStream<ReadResp>,
+  convertGrpcEvent: (e: ReadResp.ReadEvent) => T
+): Promise<T[]> =>
+  new Promise<T[]>((resolve, reject) => {
+    const resolvedEvents: T[] = [];
     let streamNotFound: ReadResp.StreamNotFound | undefined;
 
     stream.on("data", (resp: ReadResp) => {
@@ -38,4 +37,3 @@ export function handleBatchRead(
       return reject(convertToCommandError(error));
     });
   });
-}

--- a/src/utils/handleOneWaySubscription.ts
+++ b/src/utils/handleOneWaySubscription.ts
@@ -1,11 +1,6 @@
 import { ClientReadableStream } from "@grpc/grpc-js";
 import { ReadResp } from "../../generated/streams_pb";
-import {
-  SubscriptionHandler,
-  ResolvedEvent,
-  SubscriptionReport,
-} from "../types";
-import { convertGrpcEvent } from "./convertGrpcEvent";
+import { SubscriptionHandler, SubscriptionReport } from "../types";
 
 export class SubscriptionReportImpl implements SubscriptionReport {
   private _stream: ClientReadableStream<ReadResp>;
@@ -18,9 +13,10 @@ export class SubscriptionReportImpl implements SubscriptionReport {
   }
 }
 
-export function handleOneWaySubscription(
+export function handleOneWaySubscription<T>(
   stream: ClientReadableStream<ReadResp>,
-  handler: SubscriptionHandler
+  handler: SubscriptionHandler<T>,
+  convertGrpcEvent: (e: ReadResp.ReadEvent) => T
 ): void {
   const report = new SubscriptionReportImpl(stream);
 
@@ -30,7 +26,7 @@ export function handleOneWaySubscription(
     }
 
     if (resp.hasEvent()) {
-      const resolved: ResolvedEvent = convertGrpcEvent(resp.getEvent()!);
+      const resolved = convertGrpcEvent(resp.getEvent()!);
       handler.onEvent(report, resolved);
     }
   });


### PR DESCRIPTION
- `position` only exists on reads from $all, data on stream reads was nonsense.
- Add types to reflect different read events
- Make read utils more generic to handle both event types
- fix and unskip readAllEvents from position test

![image](https://user-images.githubusercontent.com/11861797/94138337-42dc2900-fe68-11ea-9d41-21294410f1d1.png)
