### PR TITLE
Remove no_stream expectedRevision from tombstone

### DIFF
--- a/src/__test__/streams/tombstoneStream.test.ts
+++ b/src/__test__/streams/tombstoneStream.test.ts
@@ -10,7 +10,6 @@ import {
   tombstoneStream,
   StreamDeletedError,
   NO_STREAM,
-  STREAM_EXISTS,
 } from "../..";
 
 describe("tombstoneStream", () => {
@@ -101,38 +100,6 @@ describe("tombstoneStream", () => {
 
           const result = await tombstoneStream(STREAM)
             .expectedRevision(revision)
-            .execute(connection);
-
-          expect(result).toBeDefined();
-
-          await expect(() =>
-            readEventsFromStream(STREAM).execute(connection)
-          ).rejects.toThrowError(StreamDeletedError);
-        });
-      });
-
-      // throws error: 2 UNKNOWN: Exception was thrown by handler.
-      describe.skip("exists", () => {
-        const STREAM = "expected_revision_stream_exists";
-        const NOT_A_STREAM = "i_dont_exist_hopefully";
-
-        beforeAll(async () => {
-          await writeEventsToStream(STREAM)
-            .send(event, event, event, event)
-            .execute(connection);
-        });
-
-        it("fails", async () => {
-          await expect(
-            tombstoneStream(NOT_A_STREAM)
-              .expectedRevision(STREAM_EXISTS)
-              .execute(connection)
-          ).rejects.toThrowError(`error here`);
-        });
-
-        it("succeeds", async () => {
-          const result = await tombstoneStream(STREAM)
-            .expectedRevision(STREAM_EXISTS)
             .execute(connection);
 
           expect(result).toBeDefined();

--- a/src/command/streams/DeleteStream.ts
+++ b/src/command/streams/DeleteStream.ts
@@ -1,17 +1,13 @@
 import { DeleteReq } from "../../../generated/streams_pb";
 import { StreamIdentifier, Empty } from "../../../generated/shared_pb";
 import { StreamsClient } from "../../../generated/streams_grpc_pb";
-import {
-  DeleteResult,
-  ESDBConnection,
-  DeleteStreamExpectedRevision,
-} from "../../types";
+import { DeleteResult, ESDBConnection, ExpectedRevision } from "../../types";
 import { Command } from "../Command";
 import { convertToCommandError } from "../../utils/CommandError";
 
 export class DeleteStream extends Command {
   private readonly _stream: string;
-  private _revision: DeleteStreamExpectedRevision;
+  private _revision: ExpectedRevision;
 
   constructor(stream: string) {
     super();
@@ -23,7 +19,7 @@ export class DeleteStream extends Command {
    * Asks the server to check the stream is at specific revision before writing events.
    * @param revision
    */
-  expectedRevision(revision: DeleteStreamExpectedRevision): DeleteStream {
+  expectedRevision(revision: ExpectedRevision): DeleteStream {
     this._revision = revision;
     return this;
   }

--- a/src/command/streams/WriteEventsToStream.ts
+++ b/src/command/streams/WriteEventsToStream.ts
@@ -2,7 +2,11 @@ import { AppendReq } from "../../../generated/streams_pb";
 import { StreamIdentifier, Empty, UUID } from "../../../generated/shared_pb";
 import { StreamsClient } from "../../../generated/streams_grpc_pb";
 
-import { WriteResult, ESDBConnection, ExpectedRevision } from "../../types";
+import {
+  WriteResult,
+  ESDBConnection,
+  WriteEventsExpectedRevision,
+} from "../../types";
 import { Command } from "../Command";
 import { EventData } from "../../events";
 import {
@@ -12,7 +16,7 @@ import {
 
 export class WriteEventsToStream extends Command {
   private readonly _stream: string;
-  private _revision: ExpectedRevision;
+  private _revision: WriteEventsExpectedRevision;
   private _events: EventData[] = [];
 
   constructor(stream: string) {
@@ -25,7 +29,7 @@ export class WriteEventsToStream extends Command {
    * Asks the server to check the stream is at specific revision before writing events.
    * @param revision
    */
-  expectedRevision(revision: ExpectedRevision): WriteEventsToStream {
+  expectedRevision(revision: WriteEventsExpectedRevision): WriteEventsToStream {
     this._revision = revision;
     return this;
   }
@@ -87,7 +91,7 @@ export class WriteEventsToStream extends Command {
         if (resp.hasWrongExpectedVersion()) {
           const grpcError = resp.getWrongExpectedVersion()!;
 
-          let expected: ExpectedRevision = "any";
+          let expected: WriteEventsExpectedRevision = "any";
 
           switch (true) {
             case grpcError.hasExpectedRevision(): {

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,10 +34,6 @@ export type ReadPosition =
 export type ExpectedRevision =
   | typeof constants.ANY
   /**
-   * The stream should exist. If it or a metadata stream does not exist, treats that as a concurrency problem.
-   */
-  | typeof constants.STREAM_EXISTS
-  /**
    * The stream being written to should not yet exist. If it does exist, treats that as a concurrency problem.
    */
   | typeof constants.NO_STREAM
@@ -46,13 +42,15 @@ export type ExpectedRevision =
    */
   | bigint;
 
-/**
- * Delete stream does not support "stream_exists". see: {@link ExpectedRevision}.
- */
-export type DeleteStreamExpectedRevision = Exclude<
-  ExpectedRevision,
-  typeof constants.STREAM_EXISTS
->;
+export type WriteEventsExpectedRevision =
+  /**
+   * The stream should exist. If it or a metadata stream does not exist, treats that as a concurrency problem.
+   */
+  | typeof constants.STREAM_EXISTS
+  /**
+   * see: {@link ExpectedRevision}.
+   */
+  | ExpectedRevision;
 
 export type CurrentRevision =
   /**

--- a/src/utils/CommandError.ts
+++ b/src/utils/CommandError.ts
@@ -1,5 +1,9 @@
 import { status as StatusCode, ServiceError } from "@grpc/grpc-js";
-import { CurrentRevision, EndPoint, ExpectedRevision } from "../types";
+import {
+  CurrentRevision,
+  EndPoint,
+  WriteEventsExpectedRevision,
+} from "../types";
 
 export enum ErrorType {
   TIMEOUT = "timeout",
@@ -119,7 +123,7 @@ export class ScavengeNotFoundError extends CommandErrorBase {
 
 interface WrongExpectedVersion {
   streamName: string;
-  expected: ExpectedRevision;
+  expected: WriteEventsExpectedRevision;
   current: CurrentRevision;
 }
 
@@ -127,7 +131,7 @@ export class WrongExpectedVersionError extends CommandErrorBase {
   public type: ErrorType.WRONG_EXPECTED_VERSION =
     ErrorType.WRONG_EXPECTED_VERSION;
   public streamName: string;
-  public expectedVersion: ExpectedRevision;
+  public expectedVersion: WriteEventsExpectedRevision;
   public actualVersion: CurrentRevision;
 
   constructor(error?: ServiceError, versions?: WrongExpectedVersion) {


### PR DESCRIPTION
- not supported by server
- As this in only supported by WriteEvents, the type names have been changed to reflect that
- remove tombstone no_stream skipped test