### PR TITLE
Added metadata to EventData

### DIFF
--- a/src/command/streams/WriteEventsToStream.ts
+++ b/src/command/streams/WriteEventsToStream.ts
@@ -164,6 +164,20 @@ export class WriteEventsToStream extends Command {
             break;
           }
         }
+
+        switch (event.metadata?.__typename) {
+          case "json": {
+            const metadata = JSON.stringify(event.metadata.payload);
+            message.setCustomMetadata(
+              Buffer.from(metadata, "binary").toString("base64")
+            );
+            break;
+          }
+          case "binary": {
+            message.setCustomMetadata(event.metadata.payload);
+          }
+        }
+
         message.getMetadataMap().set("type", event.eventType);
         entry.setProposedMessage(message);
         sink.write(entry);

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,7 +121,7 @@ export interface JSONRecordedEvent extends RecordedEventBase {
 
 export interface BinaryRecordedEvent extends RecordedEventBase {
   /**
-   * Indicates wheter the content is internally marked as JSON.
+   * Indicates whether the content is internally marked as JSON.
    */
   isJson: false;
 


### PR DESCRIPTION
While CustomMetadata is exposed via the grpc interface and available for writing the the event store, it is not easily surfaced via the `EventData` class. This update adds `metadata` to the `EventData` and `EventDataBuilder` classes and methods.

- The exposed methods take advantage of optional parameters in order to simplify _json_ and _binary_ events
- The metadata is added to CustomMetadata if `event.metadata` is not null and written via `WriteEventsToStream`