### PR TITLE
Allow tests to run on LTS node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: "14.x"
+          node-version: "12.x"
       - name: Login to GitHub Package Registry
         uses: docker/login-action@v1
         with:

--- a/src/__test__/persistentSubscription/connectToPersistentSubscription.test.ts
+++ b/src/__test__/persistentSubscription/connectToPersistentSubscription.test.ts
@@ -98,7 +98,7 @@ describe("connectToPersistentSubscription", () => {
 
       await createPersistentSubscription(STREAM_NAME, GROUP_NAME)
         .authenticated("admin", "changeit")
-        .fromRevision(1n)
+        .fromRevision(BigInt(1))
         .execute(connection);
 
       const defer = new Defer();

--- a/src/__test__/persistentSubscription/createPersistentSubscription.test.ts
+++ b/src/__test__/persistentSubscription/createPersistentSubscription.test.ts
@@ -40,7 +40,7 @@ describe("createPersistentSubscription", () => {
       await expect(
         createPersistentSubscription(STREAM_NAME, GROUP_NAME)
           .authenticated("admin", "changeit")
-          .fromRevision(1n)
+          .fromRevision(BigInt(1))
           .execute(connection)
       ).resolves.toBeUndefined();
     });

--- a/src/__test__/streams/deleteStream.test.ts
+++ b/src/__test__/streams/deleteStream.test.ts
@@ -66,7 +66,7 @@ describe("deleteStream", () => {
         it("fails", async () => {
           try {
             const result = await deleteStream(STREAM)
-              .expectedRevision(2n)
+              .expectedRevision(BigInt(2))
               .execute(connection);
 
             expect(result).toBe("Unreachable");
@@ -74,7 +74,7 @@ describe("deleteStream", () => {
             expect(error).toBeInstanceOf(WrongExpectedVersionError);
             if (error instanceof WrongExpectedVersionError) {
               expect(error.streamName).toBe(STREAM);
-              expect(error.expectedVersion).toBe(2n);
+              expect(error.expectedVersion).toBe(BigInt(2));
             }
           }
         });

--- a/src/__test__/streams/readEventsFromStream.test.ts
+++ b/src/__test__/streams/readEventsFromStream.test.ts
@@ -59,7 +59,7 @@ describe("readEventsFromStream", () => {
     describe("Event types", () => {
       test("json event", async () => {
         const [resolvedEvent] = await readEventsFromStream(STREAM_NAME)
-          .fromRevision(1n)
+          .fromRevision(BigInt(1))
           .count(1)
           .execute(connection);
 
@@ -75,7 +75,7 @@ describe("readEventsFromStream", () => {
 
       test("binary event", async () => {
         const [resolvedEvent] = await readEventsFromStream(STREAM_NAME)
-          .fromRevision(5n)
+          .fromRevision(BigInt(5))
           .count(1)
           .execute(connection);
 
@@ -100,7 +100,7 @@ describe("readEventsFromStream", () => {
 
       test("from revision", async () => {
         const events = await readEventsFromStream(STREAM_NAME)
-          .fromRevision(1n)
+          .fromRevision(BigInt(1))
           .count(Number.MAX_SAFE_INTEGER)
           .execute(connection);
 
@@ -119,7 +119,7 @@ describe("readEventsFromStream", () => {
 
       test("backward from revision", async () => {
         const events = await readEventsFromStream(STREAM_NAME)
-          .fromRevision(1n)
+          .fromRevision(BigInt(1))
           .backward()
           .count(Number.MAX_SAFE_INTEGER)
           .execute(connection);

--- a/src/__test__/streams/subscribeToStream.test.ts
+++ b/src/__test__/streams/subscribeToStream.test.ts
@@ -148,7 +148,7 @@ describe("subscribeToStream", () => {
 
       await subscribeToStream(STREAM_NAME)
         .authenticated("admin", "changeit")
-        .fromRevision(2n)
+        .fromRevision(BigInt(2))
         .on("close", handleClose)
         .on("error", handleError)
         .on("event", handleEvent)

--- a/src/__test__/streams/tombstoneStream.test.ts
+++ b/src/__test__/streams/tombstoneStream.test.ts
@@ -76,7 +76,7 @@ describe("tombstoneStream", () => {
         it("fails", async () => {
           try {
             const result = await tombstoneStream(STREAM)
-              .expectedRevision(2n)
+              .expectedRevision(BigInt(2))
               .execute(connection);
 
             expect(result).toBe("Unreachable");
@@ -84,7 +84,7 @@ describe("tombstoneStream", () => {
             expect(error).toBeInstanceOf(WrongExpectedVersionError);
             if (error instanceof WrongExpectedVersionError) {
               expect(error.streamName).toBe(STREAM);
-              expect(error.expectedVersion).toBe(2n);
+              expect(error.expectedVersion).toBe(BigInt(2));
             }
           }
         });

--- a/src/__test__/streams/writeEventsToStream.test.ts
+++ b/src/__test__/streams/writeEventsToStream.test.ts
@@ -172,7 +172,7 @@ describe("writeEventsToStream", () => {
 
             try {
               const result = await writeEventsToStream(STREAM_NAME)
-                .expectedRevision(1n)
+                .expectedRevision(BigInt(1))
                 .send(...testEvents())
                 .execute(connection);
 
@@ -182,7 +182,7 @@ describe("writeEventsToStream", () => {
 
               if (error instanceof WrongExpectedVersionError) {
                 expect(error.streamName).toBe(STREAM_NAME);
-                expect(error.expectedVersion).toBe(1n);
+                expect(error.expectedVersion).toBe(BigInt(1));
                 expect(error.actualVersion).toBe(NO_STREAM);
               }
             }
@@ -199,7 +199,7 @@ describe("writeEventsToStream", () => {
 
             try {
               const result = await writeEventsToStream(STREAM_NAME)
-                .expectedRevision(nextExpectedVersion + 1n)
+                .expectedRevision(nextExpectedVersion + BigInt(1))
                 .send(...testEvents())
                 .execute(connection);
 
@@ -209,7 +209,9 @@ describe("writeEventsToStream", () => {
 
               if (error instanceof WrongExpectedVersionError) {
                 expect(error.streamName).toBe(STREAM_NAME);
-                expect(error.expectedVersion).toBe(nextExpectedVersion + 1n);
+                expect(error.expectedVersion).toBe(
+                  nextExpectedVersion + BigInt(1)
+                );
                 expect(error.actualVersion).toBe(nextExpectedVersion);
               }
             }

--- a/src/__test__/tsconfig.json
+++ b/src/__test__/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "target": "ES2020"
-  },
   "include": ["**/*.test.ts"],
   "exclude": []
 }


### PR DESCRIPTION
- inherit test target from project
- convert all bigint literals to BigInt(n)
- run ci against node 12

fixes: #43