### PR TITLE
Preflight for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ $ yarn build
 ## Run tests
 
 Tests are written using [Jest] and require [Docker] and [Docker Compose] to be installed.
+To access the github packages docker images, you need to [authenticate docker with a gitub personal access token].
 
 ```shell script
 $ yarn test
@@ -150,6 +151,7 @@ Development is done on the `master` branch. We attempt to do our best to ensure 
 [jest]: https://jestjs.io/
 [docker]: https://www.docker.com/
 [docker compose]: https://docs.docker.com/compose/
+[authenticate docker with a gitub personal access token]: https://docs.github.com/en/free-pro-team@latest/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#authenticating-with-a-personal-access-token
 [npm-badge]: https://img.shields.io/npm/v/@eventstore/db-client.svg
 [npm-badge-url]: https://www.npmjs.com/package/@eventstore/db-client
 [ci-badge]: https://github.com/EventStore/EventStore-Client-NodeJS/workflows/CI/badge.svg?branch=master

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint:eslint": "eslint \"src/**/*.ts\"",
     "test": "jest",
     "test:ci": "cross-env EVENTSTORE_IMAGE=github:ci jest",
+    "test:latest": "cross-env EVENTSTORE_IMAGE=eventstore/eventstore:latest jest",
     "generate": "run-s generate:*",
     "generate:sed": "shx sed -i \"s/int64 ([A-z_]*) = ([0-9]*);/int64 \\$1 = \\$2 [jstype = JS_STRING];/g\" ./protos/*",
     "generate:folder": "shx mkdir -p ./generated",
@@ -39,6 +40,7 @@
   "homepage": "https://github.com/EventStore/EventStore-Client-NodeJS#readme",
   "jest": {
     "preset": "ts-jest",
+    "globalSetup": "./src/__test__/utils/preflight.ts",
     "globals": {
       "ts-jest": {
         "tsConfig": "./src/__test__/tsconfig.json"

--- a/src/__test__/utils/dockerImages.ts
+++ b/src/__test__/utils/dockerImages.ts
@@ -1,0 +1,23 @@
+const esdbImage = ((): string => {
+  const version = process.env.EVENTSTORE_IMAGE ?? "github:ci";
+  switch (true) {
+    case version.startsWith("local:"):
+      return version.replace("local:", "");
+    case version.startsWith("github:"):
+      return version.replace(
+        "github:",
+        "docker.pkg.github.com/eventstore/eventstore/eventstore:"
+      );
+    case version.startsWith("dockerhub:"):
+      return version.replace("dockerhub:", "eventstore/eventstore:");
+    default:
+      return version;
+  }
+})();
+
+export const dockerImages = {
+  volumesProvisioner: "hasnat/volumes-provisioner",
+  certGen:
+    "docker.pkg.github.com/eventstore/es-gencert-cli/es-gencert-cli:1.0.2",
+  esdb: esdbImage,
+};

--- a/src/__test__/utils/preflight.ts
+++ b/src/__test__/utils/preflight.ts
@@ -1,0 +1,50 @@
+import { exec as ex } from "child_process";
+import { promisify } from "util";
+import { dockerImages } from "./dockerImages";
+
+const exec = promisify(ex);
+
+const checkFor = async (dependancy: string) => {
+  try {
+    await exec(`${dependancy} -v`);
+  } catch (error) {
+    console.error(`
+Missing dependancy: ${dependancy}
+
+Tests require docker and docker-compose to run. 
+Please see https://github.com/EventStore/EventStore-Client-NodeJS#run-tests for more details.
+`);
+    process.exit(1);
+  }
+};
+
+const pullImage = async (image: string) => {
+  try {
+    const { stdout } = await exec(`docker image ls ${image} -q`);
+    if (stdout.length) return;
+    console.log(`Pulling ${image}...`);
+    await exec(`docker pull ${image}`);
+  } catch (error) {
+    console.error(`\x1b[1m\x1b[91mFailed to pull ${image}\x1b[39m\x1b[22m`);
+    console.error(
+      "\x1b[1mMake sure you are logged in to docker with github.\x1b[22m"
+    );
+    console.error(
+      "Please see https://github.com/EventStore/EventStore-Client-NodeJS#run-tests for more details."
+    );
+    process.exit(1);
+  }
+};
+
+const pullImages = async () => {
+  console.log("");
+  for (const image of Object.values<string>(dockerImages)) {
+    await pullImage(image);
+  }
+};
+
+module.exports = async () => {
+  await checkFor("docker");
+  await checkFor("docker-compose");
+  await pullImages();
+};


### PR DESCRIPTION
- add a preflight for tests that checks for docker and docker-compose
- pulls required images before starting tests
- give suggestions on how to resolve errors
- reduce test timeout from 5 to 1 minute
- update readme