### PR TITLE
Projections API

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,5 +6,7 @@ module.exports = {
   rules: {
     "no-constant-condition": ["error", { checkLoops: false }],
     "@typescript-eslint/no-non-null-assertion": ["off"],
+    // better handled by ts itself
+    "@typescript-eslint/no-unused-vars": ["off"],
   },
 };

--- a/src/__test__/projections/createContinuousProjection.test.ts
+++ b/src/__test__/projections/createContinuousProjection.test.ts
@@ -1,0 +1,64 @@
+import { createTestNode } from "../utils";
+
+import {
+  ESDBConnection,
+  EventStoreConnection,
+  createContinuousProjection,
+} from "../..";
+
+describe("createContinuousProjection", () => {
+  const node = createTestNode();
+  let connection!: ESDBConnection;
+
+  beforeAll(async () => {
+    await node.up();
+    connection = EventStoreConnection.builder()
+      .sslRootCertificate(node.certPath)
+      .singleNodeConnection(node.uri);
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  test("track emitted streams", async () => {
+    const PROJECTION_NAME = "track and field";
+
+    await expect(
+      createContinuousProjection(
+        PROJECTION_NAME,
+        `
+        fromAll()
+          .when({
+            $init: function (state, ev) {
+              return {};
+            }
+          });
+        `
+      )
+        .trackEmittedStreams()
+        .authenticated("admin", "changeit")
+        .execute(connection)
+    ).resolves.toBeUndefined();
+  });
+
+  test("do not track", async () => {
+    const PROJECTION_NAME = "do not track";
+    await expect(
+      createContinuousProjection(
+        PROJECTION_NAME,
+        `
+        fromAll()
+          .when({
+            $init: function (state, ev) {
+              return {};
+            }
+          });
+        `
+      )
+        .doNotTrackEmittedStreams()
+        .authenticated("admin", "changeit")
+        .execute(connection)
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/__test__/projections/createOneTimeProjection.test.ts
+++ b/src/__test__/projections/createOneTimeProjection.test.ts
@@ -1,0 +1,38 @@
+import { createTestNode } from "../utils";
+
+import {
+  ESDBConnection,
+  EventStoreConnection,
+  createOneTimeProjection,
+} from "../..";
+
+describe("createOneTimeProjection", () => {
+  const node = createTestNode();
+  let connection!: ESDBConnection;
+
+  beforeAll(async () => {
+    await node.up();
+    connection = EventStoreConnection.builder()
+      .sslRootCertificate(node.certPath)
+      .singleNodeConnection(node.uri);
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  it("succeeds", async () => {
+    await expect(
+      createOneTimeProjection(`
+        fromAll()
+          .when({
+            $init: function (state, ev) {
+              return {};
+            }
+          });
+      `)
+        .authenticated("admin", "changeit")
+        .execute(connection)
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/__test__/projections/createTransientProjection.test.ts
+++ b/src/__test__/projections/createTransientProjection.test.ts
@@ -1,0 +1,43 @@
+import { createTestNode } from "../utils";
+
+import {
+  ESDBConnection,
+  EventStoreConnection,
+  createTransientProjection,
+} from "../..";
+
+describe("createOneTimeProjection", () => {
+  const node = createTestNode();
+  let connection!: ESDBConnection;
+
+  beforeAll(async () => {
+    await node.up();
+    connection = EventStoreConnection.builder()
+      .sslRootCertificate(node.certPath)
+      .singleNodeConnection(node.uri);
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  it("succeeds", async () => {
+    const PROJECTION_NAME = "transient";
+
+    await expect(
+      createTransientProjection(
+        PROJECTION_NAME,
+        `
+        fromAll()
+          .when({
+            $init: function (state, ev) {
+              return {};
+            }
+          });
+      `
+      )
+        .authenticated("admin", "changeit")
+        .execute(connection)
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/__test__/projections/deleteProjection.test.ts
+++ b/src/__test__/projections/deleteProjection.test.ts
@@ -1,0 +1,91 @@
+import { createTestNode } from "../utils";
+
+import {
+  ESDBConnection,
+  EventStoreConnection,
+  createContinuousProjection,
+  disableProjection,
+  deleteProjection,
+  getProjectionStatistics,
+  RUNNING,
+  DELETING,
+  STOPPED,
+  UnknownError,
+} from "../..";
+
+describe("deleteProjection", () => {
+  const node = createTestNode();
+  let connection!: ESDBConnection;
+
+  const projection = `
+  fromAll()
+    .when({
+      $init: function (state, ev) {
+        return {
+          last: ev,
+        };
+      },
+    });
+  `;
+
+  beforeAll(async () => {
+    await node.up();
+    connection = EventStoreConnection.builder()
+      .sslRootCertificate(node.certPath)
+      .singleNodeConnection(node.uri);
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  test("delete the projection", async () => {
+    const PROJECTION_NAME = "projection_to_delete_everything";
+
+    await createContinuousProjection(PROJECTION_NAME, projection)
+      .authenticated("admin", "changeit")
+      .execute(connection);
+
+    const beforeDetails = await getProjectionStatistics(PROJECTION_NAME)
+      .authenticated("admin", "changeit")
+      .execute(connection);
+
+    expect(beforeDetails).toBeDefined();
+    expect(beforeDetails.projectionStatus).toBe(RUNNING);
+
+    await disableProjection(PROJECTION_NAME)
+      .doNotWriteCheckpoint()
+      .authenticated("admin", "changeit")
+      .execute(connection);
+
+    const disabledDetails = await getProjectionStatistics(PROJECTION_NAME)
+      .authenticated("admin", "changeit")
+      .execute(connection);
+
+    expect(disabledDetails).toBeDefined();
+    expect(disabledDetails.projectionStatus).toBe(STOPPED);
+
+    await deleteProjection(PROJECTION_NAME)
+      .authenticated("admin", "changeit")
+      .execute(connection);
+
+    const afterDetails = await getProjectionStatistics(PROJECTION_NAME)
+      .authenticated("admin", "changeit")
+      .execute(connection);
+
+    expect(afterDetails).toBeDefined();
+    expect(afterDetails.projectionStatus).toBe(DELETING);
+  });
+
+  describe("errors", () => {
+    test("projection doesnt exist", async () => {
+      const PROJECTION_NAME = "doesnt exist";
+
+      await expect(
+        deleteProjection(PROJECTION_NAME)
+          .authenticated("admin", "changeit")
+          .execute(connection)
+      ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+    });
+  });
+});

--- a/src/__test__/projections/disableProjection.test.ts
+++ b/src/__test__/projections/disableProjection.test.ts
@@ -1,0 +1,108 @@
+import { createTestNode } from "../utils";
+
+import {
+  ESDBConnection,
+  EventStoreConnection,
+  createContinuousProjection,
+  disableProjection,
+  getProjectionStatistics,
+  ABORTED,
+  RUNNING,
+  STOPPED,
+  UnknownError,
+} from "../..";
+
+describe("disableProjection", () => {
+  const node = createTestNode();
+  let connection!: ESDBConnection;
+
+  const projection = `
+  fromAll()
+    .when({
+      $init: function (state, ev) {
+        return {
+          last: ev,
+        };
+      },
+    });
+  `;
+
+  beforeAll(async () => {
+    await node.up();
+    connection = EventStoreConnection.builder()
+      .sslRootCertificate(node.certPath)
+      .singleNodeConnection(node.uri);
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  describe("disables the projection", () => {
+    test("write a checkpoint", async () => {
+      const PROJECTION_NAME = "projection_to_disable_with_checkpoint";
+
+      await createContinuousProjection(PROJECTION_NAME, projection)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      const beforeDetails = await getProjectionStatistics(PROJECTION_NAME)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      expect(beforeDetails).toBeDefined();
+      expect(beforeDetails.projectionStatus).toBe(RUNNING);
+
+      await disableProjection(PROJECTION_NAME)
+        .writeCheckpoint()
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      const afterDetails = await getProjectionStatistics(PROJECTION_NAME)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      expect(afterDetails).toBeDefined();
+      expect(afterDetails.projectionStatus).toBe(ABORTED);
+    });
+
+    test("do not write a checkpoint", async () => {
+      const PROJECTION_NAME = "projection_to_disable_without_checkpoint";
+
+      await createContinuousProjection(PROJECTION_NAME, projection)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      const beforeDetails = await getProjectionStatistics(PROJECTION_NAME)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      expect(beforeDetails).toBeDefined();
+      expect(beforeDetails.projectionStatus).toBe(RUNNING);
+
+      await disableProjection(PROJECTION_NAME)
+        .doNotWriteCheckpoint()
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      const afterDetails = await getProjectionStatistics(PROJECTION_NAME)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      expect(afterDetails).toBeDefined();
+      expect(afterDetails.projectionStatus).toBe(STOPPED);
+    });
+  });
+
+  describe("errors", () => {
+    test("projection doesnt exist", async () => {
+      const PROJECTION_NAME = "doesnt exist";
+
+      await expect(
+        disableProjection(PROJECTION_NAME)
+          .authenticated("admin", "changeit")
+          .execute(connection)
+      ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+    });
+  });
+});

--- a/src/__test__/projections/enableProjection.test.ts
+++ b/src/__test__/projections/enableProjection.test.ts
@@ -1,0 +1,81 @@
+import { createTestNode } from "../utils";
+
+import {
+  ESDBConnection,
+  EventStoreConnection,
+  createContinuousProjection,
+  disableProjection,
+  getProjectionStatistics,
+  enableProjection,
+  ABORTED,
+  RUNNING,
+  UnknownError,
+} from "../..";
+
+describe("enableProjection", () => {
+  const node = createTestNode();
+  let connection!: ESDBConnection;
+
+  const projection = `
+  fromAll()
+    .when({
+      $init: function (state, ev) {
+        return {
+          last: ev,
+        };
+      },
+    });
+  `;
+
+  beforeAll(async () => {
+    await node.up();
+    connection = EventStoreConnection.builder()
+      .sslRootCertificate(node.certPath)
+      .singleNodeConnection(node.uri);
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  test("enables the projection", async () => {
+    const PROJECTION_NAME = "projection_to_enable";
+
+    await createContinuousProjection(PROJECTION_NAME, projection)
+      .authenticated("admin", "changeit")
+      .execute(connection);
+
+    await disableProjection(PROJECTION_NAME)
+      .writeCheckpoint()
+      .authenticated("admin", "changeit")
+      .execute(connection);
+
+    const beforeDetails = await getProjectionStatistics(PROJECTION_NAME)
+      .authenticated("admin", "changeit")
+      .execute(connection);
+
+    expect(beforeDetails).toBeDefined();
+    expect(beforeDetails.projectionStatus).toBe(ABORTED);
+
+    await enableProjection(PROJECTION_NAME)
+      .authenticated("admin", "changeit")
+      .execute(connection);
+
+    const afterDetails = await getProjectionStatistics(PROJECTION_NAME)
+      .authenticated("admin", "changeit")
+      .execute(connection);
+
+    expect(afterDetails).toBeDefined();
+    expect(afterDetails.projectionStatus).toBe(RUNNING);
+  });
+
+  test("projection doesnt exist", async () => {
+    const PROJECTION_NAME = "doesnt exist";
+
+    await expect(
+      enableProjection(PROJECTION_NAME)
+        .authenticated("admin", "changeit")
+        .execute(connection)
+    ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+  });
+});

--- a/src/__test__/projections/getProjectionResult.test.ts
+++ b/src/__test__/projections/getProjectionResult.test.ts
@@ -1,0 +1,186 @@
+import { createTestNode, delay, testEvents } from "../utils";
+
+import {
+  ESDBConnection,
+  EventStoreConnection,
+  createContinuousProjection,
+  writeEventsToStream,
+  UnknownError,
+  getProjectionResult,
+  EventData,
+} from "../..";
+import { enableProjection, getProjectionStatistics } from "../../command";
+import { RUNNING } from "../../constants";
+
+describe("getProjectionResult", () => {
+  const node = createTestNode();
+  let connection!: ESDBConnection;
+
+  beforeAll(async () => {
+    await node.up();
+    connection = EventStoreConnection.builder()
+      .sslRootCertificate(node.certPath)
+      .singleNodeConnection(node.uri);
+
+    await enableProjection("$by_category")
+      .authenticated("admin", "changeit")
+      .execute(connection);
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  describe("gets the result of a projection", () => {
+    test("without partition", async () => {
+      const PROJECTION_NAME = "count events";
+      const EVENT_TYPE = "count_this";
+      const STREAM_NAME = "some_stream_name";
+      const projection = `
+        fromStream("${STREAM_NAME}")
+          .when({
+            $init() {
+              return 0;
+            },
+            ${EVENT_TYPE}(state, event) {
+              return state + 1
+            }
+          });
+    `;
+
+      const count = 12;
+
+      await createContinuousProjection(PROJECTION_NAME, projection)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      await writeEventsToStream(STREAM_NAME)
+        .send(...testEvents(count, EVENT_TYPE))
+        .execute(connection);
+
+      const state = await getProjectionResult<number>(PROJECTION_NAME)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      expect(state).toBe(count);
+    });
+
+    test("with partition", async () => {
+      const PARTITION_PROJECTION_NAME = "partition_projection";
+      const COUNTER_PROJECTION_NAME = "cat_activity_counter";
+
+      const STREAM_NAME = "What cat is doing";
+
+      const NAPPED_EVENT = "napped";
+      const SNACKED_EVENT = "snacked";
+
+      type CatActivity = typeof NAPPED_EVENT | typeof SNACKED_EVENT;
+      type CatCounter = Record<CatActivity, number>;
+
+      const SMUDGES = "Smudges";
+      const PEANUT_BUTTER = "PeanutButter";
+      const MR_WHISKERS = "MrWhiskers";
+
+      const paritionProjection = `
+        fromStream("${STREAM_NAME}")
+          .when({
+            $any: function(state, ev) {
+              linkTo('cat-' + ev.data.catName, ev)
+            }
+          });
+      `;
+
+      const countProjection = `
+        fromCategory('cat')
+          .foreachStream()
+          .when({
+            "$init": function(state, ev) {
+              return { naps: 0, snacks: 0 };
+            },
+            "${NAPPED_EVENT}": function(state, ev) {
+              state.naps++;
+            },
+            "${SNACKED_EVENT}": function(state, ev) {
+              state.snacks++;
+            }
+          });
+      `;
+
+      const createCatEvent = (catName: string, eventType: string) =>
+        EventData.json(eventType, {
+          catName,
+        }).build();
+
+      await createContinuousProjection(
+        PARTITION_PROJECTION_NAME,
+        paritionProjection
+      )
+        .trackEmittedStreams()
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      const partitionStats = await getProjectionStatistics(
+        PARTITION_PROJECTION_NAME
+      )
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      expect(partitionStats.projectionStatus).toBe(RUNNING);
+
+      await createContinuousProjection(COUNTER_PROJECTION_NAME, countProjection)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      const counterStats = await getProjectionStatistics(
+        COUNTER_PROJECTION_NAME
+      )
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      expect(counterStats.projectionStatus).toBe(RUNNING);
+
+      const byCategoryStats = await getProjectionStatistics("$by_category")
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      expect(byCategoryStats.projectionStatus).toBe(RUNNING);
+
+      await writeEventsToStream(STREAM_NAME)
+        .send(
+          createCatEvent(MR_WHISKERS, NAPPED_EVENT),
+          createCatEvent(SMUDGES, NAPPED_EVENT),
+          createCatEvent(MR_WHISKERS, SNACKED_EVENT),
+          createCatEvent(PEANUT_BUTTER, NAPPED_EVENT),
+          createCatEvent(MR_WHISKERS, NAPPED_EVENT),
+          createCatEvent(PEANUT_BUTTER, SNACKED_EVENT)
+        )
+        .execute(connection);
+
+      await delay(10000);
+
+      const result = await getProjectionResult<CatCounter>(
+        COUNTER_PROJECTION_NAME
+      )
+        .fromPartition(`cat-${MR_WHISKERS}`)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      expect(result).toMatchObject({
+        naps: 2,
+        snacks: 1,
+      });
+    });
+  });
+
+  describe("errors", () => {
+    test("projection doesnt exist", async () => {
+      const PROJECTION_NAME = "doesnt exist";
+
+      await expect(
+        getProjectionResult(PROJECTION_NAME)
+          .authenticated("admin", "changeit")
+          .execute(connection)
+      ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+    });
+  });
+});

--- a/src/__test__/projections/getProjectionState.test.ts
+++ b/src/__test__/projections/getProjectionState.test.ts
@@ -1,0 +1,69 @@
+import { createTestNode, testEvents } from "../utils";
+
+import {
+  ESDBConnection,
+  EventStoreConnection,
+  createContinuousProjection,
+  getProjectionState,
+  writeEventsToStream,
+  UnknownError,
+} from "../..";
+
+describe("getProjectionState", () => {
+  const node = createTestNode();
+  let connection!: ESDBConnection;
+
+  const EVENT_TYPE = "count_this";
+  const STREAM_NAME = "some_stream_name";
+  const projection = `
+  fromStream("${STREAM_NAME}")
+    .when({
+      $init() {
+        return 0;
+      },
+      ${EVENT_TYPE}(state, event) {
+        return state + 1
+      }
+    });
+  `;
+
+  beforeAll(async () => {
+    await node.up();
+    connection = EventStoreConnection.builder()
+      .sslRootCertificate(node.certPath)
+      .singleNodeConnection(node.uri);
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  test("gets the state of a projection", async () => {
+    const PROJECTION_NAME = "count events";
+    const count = 3;
+
+    await createContinuousProjection(PROJECTION_NAME, projection)
+      .authenticated("admin", "changeit")
+      .execute(connection);
+
+    await writeEventsToStream(STREAM_NAME)
+      .send(...testEvents(count, EVENT_TYPE))
+      .execute(connection);
+
+    const state = await getProjectionState<number>(PROJECTION_NAME)
+      .authenticated("admin", "changeit")
+      .execute(connection);
+
+    expect(state).toBe(count);
+  });
+
+  test("projection doesnt exist", async () => {
+    const PROJECTION_NAME = "doesnt exist";
+
+    await expect(
+      getProjectionState(PROJECTION_NAME)
+        .authenticated("admin", "changeit")
+        .execute(connection)
+    ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+  });
+});

--- a/src/__test__/projections/getProjectionStatistics.test.ts
+++ b/src/__test__/projections/getProjectionStatistics.test.ts
@@ -1,0 +1,90 @@
+import { createTestNode } from "../utils";
+
+import {
+  ESDBConnection,
+  EventStoreConnection,
+  createContinuousProjection,
+  createTransientProjection,
+  getProjectionStatistics,
+  CONTINUOUS,
+  TRANSIENT,
+  UnknownError,
+} from "../..";
+
+describe("getProjectionStatistics", () => {
+  const node = createTestNode();
+  let connection!: ESDBConnection;
+
+  const basicProjection = `
+  fromAll()
+    .when({
+      $init: function (state, ev) {
+        return {};
+      }
+    });
+  `;
+
+  const continuousProjections = [
+    "continuous-1",
+    "continuous-2",
+    "continuous-3",
+  ];
+  const transientProjections = ["transient-1", "transient-2", "transient-3"];
+
+  beforeAll(async () => {
+    await node.up();
+    connection = EventStoreConnection.builder()
+      .sslRootCertificate(node.certPath)
+      .singleNodeConnection(node.uri);
+
+    for (const name of continuousProjections) {
+      await createContinuousProjection(name, basicProjection)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+    }
+
+    for (const name of transientProjections) {
+      await createTransientProjection(name, basicProjection)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+    }
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  describe("gets Projection Statistics", () => {
+    test("continuous", async () => {
+      const REQUESTED_NAME = continuousProjections[2];
+
+      const details = await getProjectionStatistics(REQUESTED_NAME)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      expect(details).toBeDefined();
+      expect(details.mode).toBe(CONTINUOUS);
+      expect(details.name).toBe(REQUESTED_NAME);
+    });
+
+    test("transient", async () => {
+      const REQUESTED_NAME = transientProjections[1];
+      const details = await getProjectionStatistics(REQUESTED_NAME)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      expect(details).toBeDefined();
+      expect(details.mode).toBe(TRANSIENT);
+      expect(details.name).toBe(REQUESTED_NAME);
+    });
+
+    test("non-existant", async () => {
+      const REQUESTED_NAME = "some-non-existant-projection";
+      await expect(
+        getProjectionStatistics(REQUESTED_NAME)
+          .authenticated("admin", "changeit")
+          .execute(connection)
+      ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+    });
+  });
+});

--- a/src/__test__/projections/listProjections.test.ts
+++ b/src/__test__/projections/listProjections.test.ts
@@ -1,0 +1,112 @@
+import { createTestNode } from "../utils";
+
+import {
+  ESDBConnection,
+  EventStoreConnection,
+  createOneTimeProjection,
+  createContinuousProjection,
+  createTransientProjection,
+  listContinuousProjections,
+  listOneTimeProjections,
+  listTransientProjections,
+  CONTINUOUS,
+  ONE_TIME,
+  TRANSIENT,
+} from "../..";
+
+describe("list projections", () => {
+  const node = createTestNode();
+  let connection!: ESDBConnection;
+
+  const basicProjection = `
+  fromAll()
+    .when({
+      $init: function (state, ev) {
+        return {};
+      }
+    });
+  `;
+
+  const continuousProjections = [
+    "continuous-1",
+    "continuous-2",
+    "continuous-3",
+  ];
+  const oneTimeProjections = [1, 2, 3];
+  const transientProjections = ["transient-1", "transient-2", "transient-3"];
+
+  beforeAll(async () => {
+    await node.up();
+    connection = EventStoreConnection.builder()
+      .sslRootCertificate(node.certPath)
+      .singleNodeConnection(node.uri);
+
+    for (const name of continuousProjections) {
+      await createContinuousProjection(name, basicProjection)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+    }
+
+    for (const _ of oneTimeProjections) {
+      await createOneTimeProjection(basicProjection)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+    }
+
+    for (const name of transientProjections) {
+      await createTransientProjection(name, basicProjection)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+    }
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  describe("lists projections", () => {
+    test("listContinuousProjections", async () => {
+      const projections = await listContinuousProjections()
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      // includes system projections
+      expect(projections.length).toBeGreaterThan(continuousProjections.length);
+
+      projections.forEach((details) => {
+        expect(details).toBeDefined();
+        expect(details.mode).toBe(CONTINUOUS);
+        if (!details.name.startsWith("$")) {
+          expect(continuousProjections).toContain(details.name);
+        }
+      });
+    });
+
+    test("listOneTimeProjections", async () => {
+      const projections = await listOneTimeProjections()
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      expect(projections).toHaveLength(oneTimeProjections.length);
+
+      projections.forEach((details) => {
+        expect(details).toBeDefined();
+        expect(details.mode).toBe(ONE_TIME);
+      });
+    });
+
+    test("listTransientProjections", async () => {
+      const projections = await listTransientProjections()
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      expect(projections).toHaveLength(transientProjections.length);
+
+      projections.forEach((details) => {
+        expect(details).toBeDefined();
+        expect(details.mode).toBe(TRANSIENT);
+        expect(transientProjections).toContain(details.name);
+      });
+    });
+  });
+});

--- a/src/__test__/projections/resetProjection.test.ts
+++ b/src/__test__/projections/resetProjection.test.ts
@@ -1,0 +1,76 @@
+import { createTestNode } from "../utils";
+
+import {
+  ESDBConnection,
+  EventStoreConnection,
+  createContinuousProjection,
+  resetProjection,
+  UnknownError,
+} from "../..";
+
+describe("resetProjection", () => {
+  const node = createTestNode();
+  let connection!: ESDBConnection;
+
+  const projection = `
+  fromAll()
+    .when({
+      $init: function (state, ev) {
+        return {
+          last: ev,
+        };
+      },
+    });
+  `;
+
+  beforeAll(async () => {
+    await node.up();
+    connection = EventStoreConnection.builder()
+      .sslRootCertificate(node.certPath)
+      .singleNodeConnection(node.uri);
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  describe("resets the projection", () => {
+    test("write a checkpoint", async () => {
+      const PROJECTION_NAME = "projection_to_disable_with_checkpoint";
+
+      await createContinuousProjection(PROJECTION_NAME, projection)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      await resetProjection(PROJECTION_NAME)
+        .writeCheckpoint()
+        .authenticated("admin", "changeit")
+        .execute(connection);
+    });
+
+    test("do not write a checkpoint", async () => {
+      const PROJECTION_NAME = "projection_to_disable_without_checkpoint";
+
+      await createContinuousProjection(PROJECTION_NAME, projection)
+        .authenticated("admin", "changeit")
+        .execute(connection);
+
+      await resetProjection(PROJECTION_NAME)
+        .doNotWriteCheckpoint()
+        .authenticated("admin", "changeit")
+        .execute(connection);
+    });
+  });
+
+  describe("errors", () => {
+    test("projection doesnt exist", async () => {
+      const PROJECTION_NAME = "doesnt exist";
+
+      await expect(
+        resetProjection(PROJECTION_NAME)
+          .authenticated("admin", "changeit")
+          .execute(connection)
+      ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+    });
+  });
+});

--- a/src/__test__/projections/restartSubsystem.test.ts
+++ b/src/__test__/projections/restartSubsystem.test.ts
@@ -1,0 +1,25 @@
+import { createTestNode } from "../utils";
+
+import { ESDBConnection, EventStoreConnection, restartSubsystem } from "../..";
+
+describe("restartSubsystem", () => {
+  const node = createTestNode();
+  let connection!: ESDBConnection;
+
+  beforeAll(async () => {
+    await node.up();
+    connection = EventStoreConnection.builder()
+      .sslRootCertificate(node.certPath)
+      .singleNodeConnection(node.uri);
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  test("Doesnt error", async () => {
+    await expect(
+      restartSubsystem().authenticated("admin", "changeit").execute(connection)
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/command/index.ts
+++ b/src/command/index.ts
@@ -1,2 +1,3 @@
 export * from "./persistentSubscription";
+export * from "./projections";
 export * from "./streams";

--- a/src/command/projections/CreateContinuousProjection.ts
+++ b/src/command/projections/CreateContinuousProjection.ts
@@ -1,0 +1,68 @@
+import { ProjectionsClient } from "../../../generated/projections_grpc_pb";
+import { CreateReq } from "../../../generated/projections_pb";
+
+import { ESDBConnection } from "../../types";
+import { Command } from "../Command";
+import { convertToCommandError } from "../../utils/CommandError";
+import { debug } from "../../utils/debug";
+
+export class CreateContinuousProjection extends Command {
+  private _name: string;
+  private _query: string;
+  private _trackEmittedStreams: boolean;
+
+  constructor(name: string, query: string) {
+    super();
+    this._query = query;
+    this._name = name;
+    this._trackEmittedStreams = false;
+  }
+
+  /**
+   * Enables tracking emitted streams.
+   */
+  trackEmittedStreams(): CreateContinuousProjection {
+    this._trackEmittedStreams = true;
+    return this;
+  }
+
+  /**
+   * Disables tracking emitted streams. See {@link trackEmittedStreams}. Default behavior.
+   */
+  doNotTrackEmittedStreams(): CreateContinuousProjection {
+    this._trackEmittedStreams = false;
+    return this;
+  }
+
+  /**
+   * Creates a continuous projection
+   */
+  async execute(connection: ESDBConnection): Promise<void> {
+    const req = new CreateReq();
+    const options = new CreateReq.Options();
+    const continuous = new CreateReq.Options.Continuous();
+
+    continuous.setName(this._name);
+    continuous.setTrackEmittedStreams(this._trackEmittedStreams);
+
+    options.setContinuous(continuous);
+    options.setQuery(this._query);
+
+    req.setOptions(options);
+
+    debug.command("CreateContinuousProjection: %c", this);
+    debug.command_grpc("CreateContinuousProjection: %g", req);
+
+    const client = await connection._client(
+      ProjectionsClient,
+      "CreateContinuousProjection"
+    );
+
+    return new Promise<void>((resolve, reject) => {
+      client.create(req, this.metadata, (error) => {
+        if (error) return reject(convertToCommandError(error));
+        return resolve();
+      });
+    });
+  }
+}

--- a/src/command/projections/CreateOneTimeProjection.ts
+++ b/src/command/projections/CreateOneTimeProjection.ts
@@ -1,0 +1,45 @@
+import { Empty } from "../../../generated/shared_pb";
+import { ProjectionsClient } from "../../../generated/projections_grpc_pb";
+import { CreateReq } from "../../../generated/projections_pb";
+
+import { ESDBConnection } from "../../types";
+import { Command } from "../Command";
+import { convertToCommandError } from "../../utils/CommandError";
+import { debug } from "../../utils/debug";
+
+export class CreateOneTimeProjection extends Command {
+  private _query: string;
+
+  constructor(query: string) {
+    super();
+    this._query = query;
+  }
+
+  /**
+   * Creates a one time projection
+   */
+  async execute(connection: ESDBConnection): Promise<void> {
+    const req = new CreateReq();
+    const options = new CreateReq.Options();
+
+    options.setOneTime(new Empty());
+    options.setQuery(this._query);
+
+    req.setOptions(options);
+
+    debug.command("CreateOneTimeProjection: %c", this);
+    debug.command_grpc("CreateOneTimeProjection: %g", req);
+
+    const client = await connection._client(
+      ProjectionsClient,
+      "CreateOneTimeProjection"
+    );
+
+    return new Promise<void>((resolve, reject) => {
+      client.create(req, this.metadata, (error) => {
+        if (error) return reject(convertToCommandError(error));
+        return resolve();
+      });
+    });
+  }
+}

--- a/src/command/projections/CreateTransientProjection.ts
+++ b/src/command/projections/CreateTransientProjection.ts
@@ -1,0 +1,49 @@
+import { ProjectionsClient } from "../../../generated/projections_grpc_pb";
+import { CreateReq } from "../../../generated/projections_pb";
+
+import { ESDBConnection } from "../../types";
+import { Command } from "../Command";
+import { convertToCommandError } from "../../utils/CommandError";
+import { debug } from "../../utils/debug";
+
+export class CreateTransientProjection extends Command {
+  private _name: string;
+  private _query: string;
+
+  constructor(name: string, query: string) {
+    super();
+    this._query = query;
+    this._name = name;
+  }
+
+  /**
+   * Creates a transient projection
+   */
+  async execute(connection: ESDBConnection): Promise<void> {
+    const req = new CreateReq();
+    const options = new CreateReq.Options();
+    const transient = new CreateReq.Options.Transient();
+
+    transient.setName(this._name);
+
+    options.setTransient(transient);
+    options.setQuery(this._query);
+
+    req.setOptions(options);
+
+    debug.command("CreateTransientProjection: %c", this);
+    debug.command_grpc("CreateTransientProjection: %g", req);
+
+    const client = await connection._client(
+      ProjectionsClient,
+      "CreateTransientProjection"
+    );
+
+    return new Promise<void>((resolve, reject) => {
+      client.create(req, this.metadata, (error) => {
+        if (error) return reject(convertToCommandError(error));
+        return resolve();
+      });
+    });
+  }
+}

--- a/src/command/projections/DeleteProjection.ts
+++ b/src/command/projections/DeleteProjection.ts
@@ -1,0 +1,100 @@
+import { ProjectionsClient } from "../../../generated/projections_grpc_pb";
+import { DeleteReq } from "../../../generated/projections_pb";
+
+import { ESDBConnection } from "../../types";
+import { Command } from "../Command";
+import { convertToCommandError } from "../../utils/CommandError";
+import { debug } from "../../utils/debug";
+
+export class DeleteProjection extends Command {
+  private _name: string;
+  private _deleteEmittedStreams: boolean;
+  private _deleteStateStream: boolean;
+  private _deleteCheckpointStream: boolean;
+
+  constructor(name: string) {
+    super();
+    this._name = name;
+    this._deleteEmittedStreams = true;
+    this._deleteStateStream = true;
+    this._deleteCheckpointStream = true;
+  }
+
+  /**
+   * Deletes emitted streams. Default behaviour
+   */
+  deleteEmittedStreams(): DeleteProjection {
+    this._deleteEmittedStreams = true;
+    return this;
+  }
+
+  /**
+   * Does not delete emitted streams
+   */
+  keepEmittedStreams(): DeleteProjection {
+    this._deleteEmittedStreams = false;
+    return this;
+  }
+
+  /**
+   * Deletes state streams. Default behaviour
+   */
+  deleteStateStream(): DeleteProjection {
+    this._deleteStateStream = true;
+    return this;
+  }
+
+  /**
+   * Does not delete state streams
+   */
+  keepStateStream(): DeleteProjection {
+    this._deleteStateStream = false;
+    return this;
+  }
+
+  /**
+   * Does not delete checkpoint stream
+   */
+  keepCheckpointStream(): DeleteProjection {
+    this._deleteCheckpointStream = false;
+    return this;
+  }
+
+  /**
+   * Deletes checkpoint stream. Default behaviour
+   */
+  deleteCheckpointStream(): DeleteProjection {
+    this._deleteCheckpointStream = true;
+    return this;
+  }
+
+  /**
+   * Creates a transient projection
+   */
+  async execute(connection: ESDBConnection): Promise<void> {
+    const req = new DeleteReq();
+    const options = new DeleteReq.Options();
+
+    options.setName(this._name);
+    options.setDeleteEmittedStreams(this._deleteEmittedStreams);
+    options.setDeleteStateStream(this._deleteStateStream);
+    options.setDeleteCheckpointStream(this._deleteCheckpointStream);
+
+    req.setOptions(options);
+
+    debug.command("DeleteProjection: %c", this);
+    debug.command_grpc("DeleteProjection: %g", req);
+
+    const client = await connection._client(
+      ProjectionsClient,
+      "DeleteProjection"
+    );
+
+    return new Promise<void>((resolve, reject) => {
+      client.delete(req, this.metadata, (error) => {
+        if (error) return reject(convertToCommandError(error));
+        return resolve();
+      });
+    });
+  }
+}

--- a/src/command/projections/DisableProjection.ts
+++ b/src/command/projections/DisableProjection.ts
@@ -1,0 +1,62 @@
+import { ProjectionsClient } from "../../../generated/projections_grpc_pb";
+import { DisableReq } from "../../../generated/projections_pb";
+
+import { ESDBConnection } from "../../types";
+import { Command } from "../Command";
+import { convertToCommandError } from "../../utils/CommandError";
+import { debug } from "../../utils/debug";
+
+export class DisableProjection extends Command {
+  private _name: string;
+  private _writeCheckpoint: boolean;
+
+  constructor(name: string) {
+    super();
+    this._name = name;
+    this._writeCheckpoint = true;
+  }
+
+  /**
+   * Write a checkpoint. Default behaviour
+   */
+  writeCheckpoint(): DisableProjection {
+    this._writeCheckpoint = true;
+    return this;
+  }
+
+  /**
+   * Do not write a checkpoint. See {@link writeCheckpoint}
+   */
+  doNotWriteCheckpoint(): DisableProjection {
+    this._writeCheckpoint = false;
+    return this;
+  }
+
+  /**
+   * Disables a projection
+   */
+  async execute(connection: ESDBConnection): Promise<void> {
+    const req = new DisableReq();
+    const options = new DisableReq.Options();
+
+    options.setName(this._name);
+    options.setWriteCheckpoint(this._writeCheckpoint);
+
+    req.setOptions(options);
+
+    debug.command("DisableProjection: %c", this);
+    debug.command_grpc("DisableProjection: %g", req);
+
+    const client = await connection._client(
+      ProjectionsClient,
+      "DisableProjection"
+    );
+
+    return new Promise<void>((resolve, reject) => {
+      client.disable(req, this.metadata, (error) => {
+        if (error) return reject(convertToCommandError(error));
+        return resolve();
+      });
+    });
+  }
+}

--- a/src/command/projections/EnableProjection.ts
+++ b/src/command/projections/EnableProjection.ts
@@ -1,0 +1,43 @@
+import { ProjectionsClient } from "../../../generated/projections_grpc_pb";
+import { EnableReq } from "../../../generated/projections_pb";
+
+import { ESDBConnection } from "../../types";
+import { Command } from "../Command";
+import { convertToCommandError } from "../../utils/CommandError";
+import { debug } from "../../utils/debug";
+
+export class EnableProjection extends Command {
+  private _name: string;
+
+  constructor(name: string) {
+    super();
+    this._name = name;
+  }
+
+  /**
+   * Enables a projection
+   */
+  async execute(connection: ESDBConnection): Promise<void> {
+    const req = new EnableReq();
+    const options = new EnableReq.Options();
+
+    options.setName(this._name);
+
+    req.setOptions(options);
+
+    debug.command("EnableProjection: %c", this);
+    debug.command_grpc("EnableProjection: %g", req);
+
+    const client = await connection._client(
+      ProjectionsClient,
+      "EnableProjection"
+    );
+
+    return new Promise<void>((resolve, reject) => {
+      client.enable(req, this.metadata, (error) => {
+        if (error) return reject(convertToCommandError(error));
+        return resolve();
+      });
+    });
+  }
+}

--- a/src/command/projections/GetProjectionResult.ts
+++ b/src/command/projections/GetProjectionResult.ts
@@ -1,0 +1,53 @@
+import { ProjectionsClient } from "../../../generated/projections_grpc_pb";
+import { ResultReq } from "../../../generated/projections_pb";
+
+import { ESDBConnection } from "../../types";
+import { Command } from "../Command";
+import { debug } from "../../utils/debug";
+import { convertToCommandError } from "../../utils/CommandError";
+
+export class GetProjectionResult<S = unknown> extends Command {
+  private _name: string;
+  private _partition: string;
+
+  constructor(name: string) {
+    super();
+    this._name = name;
+    this._partition = "";
+  }
+
+  /**
+   * Sets partition
+   */
+  fromPartition(partition: string): GetProjectionResult<S> {
+    this._partition = partition;
+    return this;
+  }
+
+  /**
+   * gets the result of the projection
+   */
+  async execute(connection: ESDBConnection): Promise<S> {
+    const req = new ResultReq();
+    const options = new ResultReq.Options();
+    options.setName(this._name);
+    options.setPartition(this._partition);
+
+    req.setOptions(options);
+
+    debug.command("GetProjectionResult: %c", this);
+    debug.command_grpc("GetProjectionResult: %g", req);
+
+    const client = await connection._client(
+      ProjectionsClient,
+      "GetProjectionResult"
+    );
+
+    return new Promise<S>((resolve, reject) => {
+      client.result(req, this.metadata, (error, response) => {
+        if (error) return reject(convertToCommandError(error));
+        return resolve(response.getResult()?.toJavaScript() as S);
+      });
+    });
+  }
+}

--- a/src/command/projections/GetProjectionState.ts
+++ b/src/command/projections/GetProjectionState.ts
@@ -1,0 +1,40 @@
+import { ProjectionsClient } from "../../../generated/projections_grpc_pb";
+import { StateReq } from "../../../generated/projections_pb";
+
+import { ESDBConnection } from "../../types";
+import { Command } from "../Command";
+import { debug } from "../../utils/debug";
+import { convertToCommandError } from "../../utils/CommandError";
+
+export class GetProjectionState<S = unknown> extends Command {
+  private _name: string;
+
+  constructor(name: string) {
+    super();
+    this._name = name;
+  }
+  /**
+   * gets the state of the projection
+   */
+  async execute(connection: ESDBConnection): Promise<S> {
+    const req = new StateReq();
+    const options = new StateReq.Options();
+    options.setName(this._name);
+    req.setOptions(options);
+
+    debug.command("GetProjectionState: %c", this);
+    debug.command_grpc("GetProjectionState: %g", req);
+
+    const client = await connection._client(
+      ProjectionsClient,
+      "GetProjectionState"
+    );
+
+    return new Promise<S>((resolve, reject) => {
+      client.state(req, this.metadata, (error, response) => {
+        if (error) return reject(convertToCommandError(error));
+        return resolve(response.getState()?.toJavaScript() as S);
+      });
+    });
+  }
+}

--- a/src/command/projections/GetProjectionStatistics.ts
+++ b/src/command/projections/GetProjectionStatistics.ts
@@ -1,0 +1,57 @@
+import { ServiceError } from "@grpc/grpc-js";
+import { ProjectionsClient } from "../../../generated/projections_grpc_pb";
+import {
+  StatisticsReq,
+  StatisticsResp,
+} from "../../../generated/projections_pb";
+
+import { ESDBConnection, ProjectionDetails } from "../../types";
+import { Command } from "../Command";
+import { debug } from "../../utils/debug";
+import { convertToCommandError } from "../../utils/CommandError";
+import { convertGrpcProjectionDetails } from "../../utils/convertGrpcProjectionDetails";
+
+export class GetProjectionStatistics extends Command {
+  private _name: string;
+
+  constructor(name: string) {
+    super();
+    this._name = name;
+  }
+  /**
+   * Lists all transient projections
+   */
+  async execute(connection: ESDBConnection): Promise<ProjectionDetails> {
+    const req = new StatisticsReq();
+    const options = new StatisticsReq.Options();
+    options.setName(this._name);
+    req.setOptions(options);
+
+    debug.command("GetProjectionStatistics: %c", this);
+    debug.command_grpc("GetProjectionStatistics: %g", req);
+
+    const client = await connection._client(
+      ProjectionsClient,
+      "GetProjectionStatistics"
+    );
+
+    const stream = client.statistics(req, this.metadata);
+
+    return new Promise((resolve, reject) => {
+      let projectionDetail: ProjectionDetails;
+
+      stream.on("error", (error: ServiceError) => {
+        reject(convertToCommandError(error));
+      });
+
+      stream.on("data", (resp: StatisticsResp) => {
+        if (!resp.hasDetails()) return;
+        projectionDetail = convertGrpcProjectionDetails(resp.getDetails()!);
+      });
+
+      stream.on("end", () => {
+        resolve(projectionDetail);
+      });
+    });
+  }
+}

--- a/src/command/projections/ListProjections.ts
+++ b/src/command/projections/ListProjections.ts
@@ -1,0 +1,98 @@
+import { ServiceError } from "@grpc/grpc-js";
+import { Empty } from "../../../generated/shared_pb";
+import { ProjectionsClient } from "../../../generated/projections_grpc_pb";
+import {
+  StatisticsReq,
+  StatisticsResp,
+} from "../../../generated/projections_pb";
+
+import { ESDBConnection, ProjectionDetails } from "../../types";
+import { Command } from "../Command";
+import { debug } from "../../utils/debug";
+import { convertToCommandError } from "../../utils/CommandError";
+import { convertGrpcProjectionDetails } from "../../utils/convertGrpcProjectionDetails";
+
+const fetchAndTransformProjectionList = async (
+  connection: ESDBConnection,
+  options: StatisticsReq.Options,
+  command: Command,
+  debugName: string
+): Promise<ProjectionDetails[]> => {
+  const req = new StatisticsReq();
+  req.setOptions(options);
+
+  debug.command("%s: %c", debugName, command);
+  debug.command_grpc("%s: %g", debugName, req);
+
+  const client = await connection._client(ProjectionsClient, debugName);
+
+  const stream = client.statistics(req, command.metadata);
+
+  return new Promise((resolve, reject) => {
+    const projectionDetails: ProjectionDetails[] = [];
+
+    stream.on("error", (error: ServiceError) => {
+      reject(convertToCommandError(error));
+    });
+
+    stream.on("data", (resp: StatisticsResp) => {
+      if (!resp.hasDetails()) return;
+      projectionDetails.push(convertGrpcProjectionDetails(resp.getDetails()!));
+    });
+
+    stream.on("end", () => {
+      resolve(projectionDetails);
+    });
+  });
+};
+
+export class ListContinuousProjections extends Command {
+  /**
+   * Lists all continuous projections
+   */
+  async execute(connection: ESDBConnection): Promise<ProjectionDetails[]> {
+    const options = new StatisticsReq.Options();
+    options.setContinuous(new Empty());
+
+    return fetchAndTransformProjectionList(
+      connection,
+      options,
+      this,
+      "ListContinuousProjections"
+    );
+  }
+}
+
+export class ListOneTimeProjections extends Command {
+  /**
+   * Lists all one time projections
+   */
+  async execute(connection: ESDBConnection): Promise<ProjectionDetails[]> {
+    const options = new StatisticsReq.Options();
+    options.setOneTime(new Empty());
+
+    return fetchAndTransformProjectionList(
+      connection,
+      options,
+      this,
+      "ListOneTimeProjections"
+    );
+  }
+}
+
+export class ListTransientProjections extends Command {
+  /**
+   * Lists all transient projections
+   */
+  async execute(connection: ESDBConnection): Promise<ProjectionDetails[]> {
+    const options = new StatisticsReq.Options();
+    options.setTransient(new Empty());
+
+    return fetchAndTransformProjectionList(
+      connection,
+      options,
+      this,
+      "ListTransientProjections"
+    );
+  }
+}

--- a/src/command/projections/ResetProjection.ts
+++ b/src/command/projections/ResetProjection.ts
@@ -1,0 +1,62 @@
+import { ProjectionsClient } from "../../../generated/projections_grpc_pb";
+import { ResetReq } from "../../../generated/projections_pb";
+
+import { ESDBConnection } from "../../types";
+import { Command } from "../Command";
+import { convertToCommandError } from "../../utils/CommandError";
+import { debug } from "../../utils/debug";
+
+export class ResetProjection extends Command {
+  private _name: string;
+  private _writeCheckpoint: boolean;
+
+  constructor(name: string) {
+    super();
+    this._name = name;
+    this._writeCheckpoint = true;
+  }
+
+  /**
+   * Write a checkpoint. Default behaviour
+   */
+  writeCheckpoint(): ResetProjection {
+    this._writeCheckpoint = true;
+    return this;
+  }
+
+  /**
+   * Do not write a checkpoint. See {@link writeCheckpoint}
+   */
+  doNotWriteCheckpoint(): ResetProjection {
+    this._writeCheckpoint = false;
+    return this;
+  }
+
+  /**
+   * Resets a projection. This will re-emit events. Streams that are written to from the projection will also be soft deleted.
+   */
+  async execute(connection: ESDBConnection): Promise<void> {
+    const req = new ResetReq();
+    const options = new ResetReq.Options();
+
+    options.setName(this._name);
+    options.setWriteCheckpoint(this._writeCheckpoint);
+
+    req.setOptions(options);
+
+    debug.command("ResetProjection: %c", this);
+    debug.command_grpc("ResetProjection: %g", req);
+
+    const client = await connection._client(
+      ProjectionsClient,
+      "ResetProjection"
+    );
+
+    return new Promise<void>((resolve, reject) => {
+      client.reset(req, this.metadata, (error) => {
+        if (error) return reject(convertToCommandError(error));
+        return resolve();
+      });
+    });
+  }
+}

--- a/src/command/projections/RestartSubsystem.ts
+++ b/src/command/projections/RestartSubsystem.ts
@@ -1,0 +1,31 @@
+import { ProjectionsClient } from "../../../generated/projections_grpc_pb";
+
+import { ESDBConnection } from "../../types";
+import { Command } from "../Command";
+import { convertToCommandError } from "../../utils/CommandError";
+import { debug } from "../../utils/debug";
+import { Empty } from "../../../generated/shared_pb";
+
+export class RestartSubsystem extends Command {
+  /**
+   * Restarts sub system
+   */
+  async execute(connection: ESDBConnection): Promise<void> {
+    const req = new Empty();
+
+    debug.command("RestartSubsystem: %c", this);
+    debug.command_grpc("RestartSubsystem: %g", req);
+
+    const client = await connection._client(
+      ProjectionsClient,
+      "RestartSubsystem"
+    );
+
+    return new Promise<void>((resolve, reject) => {
+      client.restartSubsystem(req, this.metadata, (error) => {
+        if (error) return reject(convertToCommandError(error));
+        return resolve();
+      });
+    });
+  }
+}

--- a/src/command/projections/UpdateProjection.ts
+++ b/src/command/projections/UpdateProjection.ts
@@ -1,0 +1,70 @@
+import { ProjectionsClient } from "../../../generated/projections_grpc_pb";
+import { Empty } from "../../../generated/shared_pb";
+import { UpdateReq } from "../../../generated/projections_pb";
+
+import { ESDBConnection } from "../../types";
+import { Command } from "../Command";
+import { convertToCommandError } from "../../utils/CommandError";
+import { debug } from "../../utils/debug";
+
+export class UpdateProjection extends Command {
+  private _name: string;
+  private _query: string;
+  private _trackEmittedStreams?: boolean;
+
+  constructor(name: string, query: string) {
+    super();
+    this._query = query;
+    this._name = name;
+  }
+
+  /**
+   * Enables tracking emitted streams.
+   */
+  trackEmittedStreams(): UpdateProjection {
+    this._trackEmittedStreams = true;
+    return this;
+  }
+
+  /**
+   * Disables tracking emitted streams. See {@link trackEmittedStreams}
+   */
+  doNotTrackEmittedStreams(): UpdateProjection {
+    this._trackEmittedStreams = false;
+    return this;
+  }
+
+  /**
+   * Creates a transient projection
+   */
+  async execute(connection: ESDBConnection): Promise<void> {
+    const req = new UpdateReq();
+    const options = new UpdateReq.Options();
+
+    options.setName(this._name);
+    options.setQuery(this._query);
+
+    if (this._trackEmittedStreams == null) {
+      options.setNoEmitOptions(new Empty());
+    } else {
+      options.setEmitEnabled(this._trackEmittedStreams);
+    }
+
+    req.setOptions(options);
+
+    debug.command("UpdateProjection: %c", this);
+    debug.command_grpc("UpdateProjection: %g", req);
+
+    const client = await connection._client(
+      ProjectionsClient,
+      "UpdateProjection"
+    );
+
+    return new Promise<void>((resolve, reject) => {
+      client.update(req, this.metadata, (error) => {
+        if (error) return reject(convertToCommandError(error));
+        return resolve();
+      });
+    });
+  }
+}

--- a/src/command/projections/index.ts
+++ b/src/command/projections/index.ts
@@ -1,0 +1,129 @@
+import { CreateContinuousProjection } from "./CreateContinuousProjection";
+import { CreateOneTimeProjection } from "./CreateOneTimeProjection";
+import { CreateTransientProjection } from "./CreateTransientProjection";
+import { DeleteProjection } from "./DeleteProjection";
+import { DisableProjection } from "./DisableProjection";
+import { EnableProjection } from "./EnableProjection";
+import { GetProjectionResult } from "./GetProjectionResult";
+import { GetProjectionState } from "./GetProjectionState";
+import { GetProjectionStatistics } from "./GetProjectionStatistics";
+import {
+  ListContinuousProjections,
+  ListOneTimeProjections,
+  ListTransientProjections,
+} from "./ListProjections";
+import { ResetProjection } from "./ResetProjection";
+import { RestartSubsystem } from "./RestartSubsystem";
+import { UpdateProjection } from "./UpdateProjection";
+
+/**
+ * Creates a continuous projection.
+ * @param name
+ * @param query
+ */
+export const createContinuousProjection = (
+  name: string,
+  query: string
+): CreateContinuousProjection => new CreateContinuousProjection(name, query);
+
+/**
+ * Creates a one-time projection.
+ * @param query
+ */
+export const createOneTimeProjection = (
+  query: string
+): CreateOneTimeProjection => new CreateOneTimeProjection(query);
+
+/**
+ * Creates a transient projection.
+ * @param name
+ * @param query
+ */
+export const createTransientProjection = (
+  name: string,
+  query: string
+): CreateTransientProjection => new CreateTransientProjection(name, query);
+
+/**
+ * Deletes a projection
+ * @param name
+ */
+export const deleteProjection = (name: string): DeleteProjection =>
+  new DeleteProjection(name);
+
+/**
+ * Disables a projection
+ * @param name
+ */
+export const disableProjection = (name: string): DisableProjection =>
+  new DisableProjection(name);
+
+/**
+ * Enables a projection
+ * @param name
+ */
+export const enableProjection = (name: string): EnableProjection =>
+  new EnableProjection(name);
+
+/**
+ * Gets the result of a projection
+ * @param name
+ */
+export const getProjectionResult = <S = unknown>(
+  name: string
+): GetProjectionResult<S> => new GetProjectionResult<S>(name);
+
+/**
+ * Gets the state of a projection
+ * @param name
+ */
+export const getProjectionState = <S = unknown>(
+  name: string
+): GetProjectionState<S> => new GetProjectionState<S>(name);
+
+/**
+ * Gets statistics of a single projection
+ * @param name
+ */
+export const getProjectionStatistics = (
+  name: string
+): GetProjectionStatistics => new GetProjectionStatistics(name);
+
+/**
+ * Lists all continuous projections.
+ */
+export const listContinuousProjections = (): ListContinuousProjections =>
+  new ListContinuousProjections();
+
+/**
+ * Lists all one-time projections.
+ */
+export const listOneTimeProjections = (): ListOneTimeProjections =>
+  new ListOneTimeProjections();
+
+/**
+ * Lists all transient projections.
+ */
+export const listTransientProjections = (): ListTransientProjections =>
+  new ListTransientProjections();
+
+/**
+ * Resets a projection. This will re-emit events. Streams that are written to from the projection will also be soft deleted.
+ * @param name
+ */
+export const resetProjection = (name: string): ResetProjection =>
+  new ResetProjection(name);
+
+/**
+ * Restarts the entire projection subsystem
+ */
+export const restartSubsystem = (): RestartSubsystem => new RestartSubsystem();
+
+/**
+ * Updates a projection
+ * @param name
+ */
+export const updateProjection = (
+  name: string,
+  query: string
+): UpdateProjection => new UpdateProjection(name, query);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,3 +33,30 @@ export const END_EVENT = "end";
 export const CONFIRMATION_EVENT = "confirmation";
 export const ERROR_EVENT = "error";
 export const CLOSE_EVENT = "close";
+
+// projection modes
+export const CONTINUOUS = "Continuous";
+export const ONE_TIME = "OneTime";
+export const TRANSIENT = "Transient";
+
+// projection status
+export const CREATING = "Creating";
+export const LOADING = "Loading";
+export const LOADED = "Loaded";
+export const PREPARING = "Preparing";
+export const PREPARED = "Prepared";
+export const STARTING = "Starting";
+export const LOADING_STOPPED = "LoadingStopped";
+export const RUNNING = "Running";
+export const STOPPING = "Stopping";
+export const ABORTING = "Aborting";
+export const STOPPED = "Stopped";
+export const COMPLETED = "Completed";
+export const ABORTED = "Aborted";
+export const FAULTED = "Faulted";
+export const DELETING = "Deleting";
+
+// processing status
+export const PAUSED = "Paused";
+export const WRITING_RESULTS = "Writing results";
+// STOPPED

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,10 +67,10 @@ export type CurrentRevision =
  */
 export type Direction = typeof constants.FORWARD | typeof constants.BACKWARD;
 
-export type WriteResult = {
+export interface WriteResult {
   nextExpectedVersion: bigint;
   position?: Position;
-};
+}
 
 /**
  * Represents a previously written event.
@@ -158,7 +158,7 @@ export type AllStreamRecordedEvent =
 /**
  * A structure representing a single event or an resolved link event.
  */
-export type ResolvedEvent = {
+export interface ResolvedEvent {
   /**
    * The event, or the resolved link event if this {@link ResolvedEvent} is a link event.
    */
@@ -174,12 +174,12 @@ export type ResolvedEvent = {
    * Commit position of the record.
    */
   commitPosition?: bigint;
-};
+}
 
 /**
  * A structure representing a single event or an resolved link event.
  */
-export type AllStreamResolvedEvent = {
+export interface AllStreamResolvedEvent {
   /**
    * The event, or the resolved link event if this {@link ResolvedEvent} is a link event.
    */
@@ -195,7 +195,146 @@ export type AllStreamResolvedEvent = {
    * Commit position of the record.
    */
   commitPosition?: bigint;
-};
+}
+
+export type ProjectionMode =
+  | typeof constants.CONTINUOUS
+  | typeof constants.ONE_TIME
+  | typeof constants.TRANSIENT;
+
+export type ProjectionStatus =
+  | typeof constants.CREATING
+  | typeof constants.LOADING
+  | typeof constants.LOADED
+  | typeof constants.PREPARING
+  | typeof constants.PREPARED
+  | typeof constants.STARTING
+  | typeof constants.LOADING_STOPPED
+  | typeof constants.RUNNING
+  | typeof constants.STOPPING
+  | typeof constants.ABORTING
+  | typeof constants.STOPPED
+  | typeof constants.COMPLETED
+  | typeof constants.ABORTED
+  | typeof constants.FAULTED
+  | typeof constants.DELETING;
+
+export type ProcessingStatus =
+  | typeof constants.PAUSED
+  | typeof constants.WRITING_RESULTS
+  | typeof constants.STOPPED
+  | "";
+
+/**
+ * Provides the details for a projection.
+ */
+export interface ProjectionDetails {
+  /**
+   * The CoreProcessingTime
+   * */
+  coreProcessingTime: BigInt;
+
+  /**
+   * The projection version
+   * */
+  version: BigInt;
+
+  /**
+   * The Epoch
+   * */
+  epoch: BigInt;
+
+  /**
+   * The projection EffectiveName
+   * */
+  effectiveName: string;
+
+  /**
+   * The projection WritesInProgress
+   * */
+  writesInProgress: number;
+
+  /**
+   * The projection ReadsInProgress
+   * */
+  readsInProgress: number;
+
+  /**
+   * The projection PartitionsCached
+   * */
+  partitionsCached: number;
+
+  /**
+   * The raw status of the projection.
+   * Split into {@link projectionStatus} and {@link processingStatus} for convenience.
+   * */
+  status: string;
+
+  /**
+   * The current status of the projection
+   * */
+  projectionStatus: ProjectionStatus;
+
+  /**
+   * The current status of the projection
+   * */
+  processingStatus: ProcessingStatus;
+
+  /**
+   * The projection StateReason
+   * */
+  stateReason: string;
+
+  /**
+   * The projection Name
+   * */
+  name: string;
+
+  /**
+   * The projection Mode
+   * */
+  mode: ProjectionMode;
+
+  /**
+   * The projection Position
+   * */
+  position: string;
+
+  /**
+   * The projection Progress
+   * */
+  progress: number;
+
+  /**
+   * LastCheckpoint
+   * */
+  lastCheckpoint: string;
+
+  /**
+   * The projection EventsProcessedAfterRestart
+   * */
+  eventsProcessedAfterRestart: BigInt;
+
+  /**
+   * The projection CheckpointStatus
+   * */
+  checkpointStatus: string;
+
+  /**
+   * The projection BufferedEvents
+   * */
+  bufferedEvents: BigInt;
+
+  /**
+   * The projection WritePendingEventsBeforeCheckpoint
+   * */
+  writePendingEventsBeforeCheckpoint: number;
+
+  /**
+   * The projection WritePendingEventsAfterCheckpoint
+   * */
+  writePendingEventsAfterCheckpoint: number;
+}
 
 export interface SubscriptionHandler<T> {
   onEvent: (report: SubscriptionReport, event: T) => void;

--- a/src/utils/convertGrpcProjectionDetails.ts
+++ b/src/utils/convertGrpcProjectionDetails.ts
@@ -1,0 +1,40 @@
+import { StatisticsResp } from "../../generated/projections_pb";
+import {
+  ProcessingStatus,
+  ProjectionDetails,
+  ProjectionMode,
+  ProjectionStatus,
+} from "../types";
+
+export const convertGrpcProjectionDetails = (
+  grpcProjectionDetails: StatisticsResp.Details
+): ProjectionDetails => {
+  const details = grpcProjectionDetails.toObject();
+  const [projectionStatus, processingStatus = ""] = details.status.split("/");
+
+  return {
+    coreProcessingTime: BigInt(details.coreprocessingtime),
+    version: BigInt(details.version),
+    epoch: BigInt(details.epoch),
+    effectiveName: details.effectivename,
+    writesInProgress: details.writesinprogress,
+    readsInProgress: details.readsinprogress,
+    partitionsCached: details.partitionscached,
+    status: details.status,
+    projectionStatus: projectionStatus as ProjectionStatus,
+    processingStatus: processingStatus as ProcessingStatus,
+    stateReason: details.statereason,
+    name: details.name,
+    mode: details.mode as ProjectionMode,
+    position: details.position,
+    progress: details.progress,
+    lastCheckpoint: details.lastcheckpoint,
+    eventsProcessedAfterRestart: BigInt(details.eventsprocessedafterrestart),
+    checkpointStatus: details.checkpointstatus,
+    bufferedEvents: BigInt(details.bufferedevents),
+    writePendingEventsBeforeCheckpoint:
+      details.writependingeventsbeforecheckpoint,
+    writePendingEventsAfterCheckpoint:
+      details.writependingeventsaftercheckpoint,
+  };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "ES2019",
     "declaration": true,
     "strict": true,
+    "noUnusedLocals": true,
     "outDir": "./dist"
   },
   "include": ["./src", "./generated"],


### PR DESCRIPTION
- Add projections api
- Add projections api tests
- Add ability to open cluster in browser from test (for debug)
- Move responsibility of `noUnusedLocals` to typescript (from eslint)


fixes: #48 