### PR TITLE
Implement defaultCredentials

### DIFF
--- a/src/__test__/connection/connectionStringMockups.ts
+++ b/src/__test__/connection/connectionStringMockups.ts
@@ -54,7 +54,7 @@ export const valid: Array<[
       tlsVerifyCert: true,
       throwOnAppendFailure: true,
       defaultCredentials: {
-        login: "user",
+        username: "user",
         password: "pass",
       },
       hosts: [
@@ -77,7 +77,7 @@ export const valid: Array<[
       tlsVerifyCert: true,
       throwOnAppendFailure: true,
       defaultCredentials: {
-        login: "user",
+        username: "user",
         password: "pass",
       },
       hosts: [
@@ -100,7 +100,7 @@ export const valid: Array<[
       tlsVerifyCert: false,
       throwOnAppendFailure: true,
       defaultCredentials: {
-        login: "user",
+        username: "user",
         password: "pass",
       },
       hosts: [
@@ -123,7 +123,7 @@ export const valid: Array<[
       tlsVerifyCert: false,
       throwOnAppendFailure: true,
       defaultCredentials: {
-        login: "user",
+        username: "user",
         password: "pass",
       },
       hosts: [
@@ -146,7 +146,7 @@ export const valid: Array<[
       tlsVerifyCert: true,
       throwOnAppendFailure: true,
       defaultCredentials: {
-        login: "user",
+        username: "user",
         password: "pass",
       },
       hosts: [
@@ -250,7 +250,7 @@ export const valid: Array<[
       tlsVerifyCert: true,
       throwOnAppendFailure: true,
       defaultCredentials: {
-        login: "user",
+        username: "user",
         password: "pass",
       },
       hosts: [
@@ -354,7 +354,7 @@ export const valid: Array<[
       tlsVerifyCert: false,
       throwOnAppendFailure: true,
       defaultCredentials: {
-        login: "user",
+        username: "user",
         password: "pass",
       },
       hosts: [
@@ -377,7 +377,7 @@ export const valid: Array<[
       tlsVerifyCert: false,
       throwOnAppendFailure: true,
       defaultCredentials: {
-        login: "my:great@username",
+        username: "my:great@username",
         password: "UyeXx8$^PsOo4jG88FlCauR1Coz25q",
       },
       hosts: [
@@ -400,7 +400,7 @@ export const valid: Array<[
       tlsVerifyCert: false,
       throwOnAppendFailure: true,
       defaultCredentials: {
-        login: "user",
+        username: "user",
         password: "pass",
       },
       hosts: [

--- a/src/__test__/connection/defaultCredentials.test.ts
+++ b/src/__test__/connection/defaultCredentials.test.ts
@@ -1,0 +1,53 @@
+import { createTestNode } from "../utils";
+
+import { AccessDeniedError, EventStoreConnection, readAllEvents } from "../..";
+
+describe("defaultCredentials", () => {
+  const node = createTestNode();
+
+  beforeAll(async () => {
+    await node.up();
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  describe("should set default credentials to be used by commands", () => {
+    test("bad override", async () => {
+      const connection = EventStoreConnection.builder()
+        .defaultCredentials({ username: "admin", password: "changeit" })
+        .sslRootCertificate(node.certPath)
+        .singleNodeConnection(node.uri);
+
+      await expect(
+        readAllEvents().fromStart().execute(connection)
+      ).resolves.toBeDefined();
+
+      await expect(
+        readAllEvents()
+          .authenticated({ username: "AzureDiamond", password: "hunter2" })
+          .fromStart()
+          .execute(connection)
+      ).rejects.toThrowError(AccessDeniedError);
+    });
+
+    test("good override", async () => {
+      const connection = EventStoreConnection.builder()
+        .defaultCredentials({ username: "AzureDiamond", password: "hunter2" })
+        .sslRootCertificate(node.certPath)
+        .singleNodeConnection(node.uri);
+
+      await expect(
+        readAllEvents().fromStart().execute(connection)
+      ).rejects.toThrowError(AccessDeniedError);
+
+      await expect(
+        readAllEvents()
+          .authenticated({ username: "admin", password: "changeit" })
+          .fromStart()
+          .execute(connection)
+      ).resolves.toBeDefined();
+    });
+  });
+});

--- a/src/__test__/persistentSubscription/connectToPersistentSubscription.test.ts
+++ b/src/__test__/persistentSubscription/connectToPersistentSubscription.test.ts
@@ -23,6 +23,7 @@ describe("connectToPersistentSubscription", () => {
     await node.up();
 
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });
@@ -41,7 +42,6 @@ describe("connectToPersistentSubscription", () => {
         .execute(connection);
 
       await createPersistentSubscription(STREAM_NAME, GROUP_NAME)
-        .authenticated("admin", "changeit")
         .fromStart()
         .execute(connection);
 
@@ -66,7 +66,6 @@ describe("connectToPersistentSubscription", () => {
       );
 
       await connectToPersistentSubscription(STREAM_NAME, GROUP_NAME)
-        .authenticated("admin", "changeit")
         .on("error", onError)
         .on("event", onEvent)
         .on("close", onClose)
@@ -97,7 +96,6 @@ describe("connectToPersistentSubscription", () => {
         .execute(connection);
 
       await createPersistentSubscription(STREAM_NAME, GROUP_NAME)
-        .authenticated("admin", "changeit")
         .fromRevision(BigInt(1))
         .execute(connection);
 
@@ -122,7 +120,6 @@ describe("connectToPersistentSubscription", () => {
       );
 
       await connectToPersistentSubscription(STREAM_NAME, GROUP_NAME)
-        .authenticated("admin", "changeit")
         .on("error", onError)
         .on("event", onEvent)
         .on("close", onClose)
@@ -162,7 +159,6 @@ describe("connectToPersistentSubscription", () => {
         .execute(connection);
 
       await createPersistentSubscription(STREAM_NAME, GROUP_NAME)
-        .authenticated("admin", "changeit")
         .fromStart()
         .execute(connection);
 
@@ -201,7 +197,6 @@ describe("connectToPersistentSubscription", () => {
       );
 
       await connectToPersistentSubscription(STREAM_NAME, GROUP_NAME)
-        .authenticated("admin", "changeit")
         .on("error", onError)
         .on("event", onEvent)
         .on("close", onClose)
@@ -233,7 +228,6 @@ describe("connectToPersistentSubscription", () => {
         const doSomething = jest.fn();
 
         await createPersistentSubscription(STREAM_NAME, GROUP_NAME)
-          .authenticated("admin", "changeit")
           .fromStart()
           .execute(connection);
 
@@ -245,9 +239,7 @@ describe("connectToPersistentSubscription", () => {
         const subscription = await connectToPersistentSubscription(
           STREAM_NAME,
           GROUP_NAME
-        )
-          .authenticated("admin", "changeit")
-          .execute(connection);
+        ).execute(connection);
 
         for await (const { event } of subscription) {
           if (!event) continue;
@@ -277,7 +269,6 @@ describe("connectToPersistentSubscription", () => {
         const retryCount = 20;
 
         await createPersistentSubscription(STREAM_NAME, GROUP_NAME)
-          .authenticated("admin", "changeit")
           .fromStart()
           .execute(connection);
 
@@ -290,9 +281,7 @@ describe("connectToPersistentSubscription", () => {
         const subscription = await connectToPersistentSubscription(
           STREAM_NAME,
           GROUP_NAME
-        )
-          .authenticated("admin", "changeit")
-          .execute(connection);
+        ).execute(connection);
 
         for await (const { event } of subscription) {
           if (!event) continue;
@@ -335,16 +324,13 @@ describe("connectToPersistentSubscription", () => {
       const defer = new Defer();
 
       await createPersistentSubscription(STREAM_NAME, GROUP_NAME)
-        .authenticated("admin", "changeit")
         .fromStart()
         .execute(connection);
 
       const subscription = await connectToPersistentSubscription(
         STREAM_NAME,
         GROUP_NAME
-      )
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      ).execute(connection);
 
       const eventListenerOne = jest.fn();
       const eventListenerTwo = jest.fn();

--- a/src/__test__/persistentSubscription/createPersistentSubscription.test.ts
+++ b/src/__test__/persistentSubscription/createPersistentSubscription.test.ts
@@ -14,6 +14,7 @@ describe("createPersistentSubscription", () => {
     await node.up();
 
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });
@@ -28,7 +29,6 @@ describe("createPersistentSubscription", () => {
       const GROUP_NAME = "group_name_from_start";
       await expect(
         createPersistentSubscription(STREAM_NAME, GROUP_NAME)
-          .authenticated("admin", "changeit")
           .fromStart()
           .execute(connection)
       ).resolves.toBeUndefined();
@@ -39,7 +39,6 @@ describe("createPersistentSubscription", () => {
       const GROUP_NAME = "group_name_from_revision";
       await expect(
         createPersistentSubscription(STREAM_NAME, GROUP_NAME)
-          .authenticated("admin", "changeit")
           .fromRevision(BigInt(1))
           .execute(connection)
       ).resolves.toBeUndefined();

--- a/src/__test__/persistentSubscription/deletePersistentSubscription.test.ts
+++ b/src/__test__/persistentSubscription/deletePersistentSubscription.test.ts
@@ -15,6 +15,7 @@ describe("deletePersistentSubscription", () => {
     await node.up();
 
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });
@@ -28,14 +29,11 @@ describe("deletePersistentSubscription", () => {
     const GROUP_NAME = "test_group_name";
 
     await createPersistentSubscription(STREAM_NAME, GROUP_NAME)
-      .authenticated("admin", "changeit")
       .fromStart()
       .execute(connection);
 
     await expect(
-      deletePersistentSubscription(STREAM_NAME, GROUP_NAME)
-        .authenticated("admin", "changeit")
-        .execute(connection)
+      deletePersistentSubscription(STREAM_NAME, GROUP_NAME).execute(connection)
     ).resolves.toBeUndefined();
   });
 });

--- a/src/__test__/persistentSubscription/updatePersistentSubscription.test.ts
+++ b/src/__test__/persistentSubscription/updatePersistentSubscription.test.ts
@@ -16,6 +16,7 @@ describe("updatePersistentSubscription", () => {
     await node.up();
 
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });
@@ -29,13 +30,11 @@ describe("updatePersistentSubscription", () => {
     const GROUP_NAME = "from_start_test_group_name";
 
     await createPersistentSubscription(STREAM_NAME, GROUP_NAME)
-      .authenticated("admin", "changeit")
       .fromStart()
       .execute(connection);
 
     await expect(
       updatePersistentSubscription(STREAM_NAME, GROUP_NAME)
-        .authenticated("admin", "changeit")
         .consumerStrategy(PINNED)
         .execute(connection)
     ).resolves.toBeUndefined();

--- a/src/__test__/projections/createContinuousProjection.test.ts
+++ b/src/__test__/projections/createContinuousProjection.test.ts
@@ -13,6 +13,7 @@ describe("createContinuousProjection", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });
@@ -37,7 +38,6 @@ describe("createContinuousProjection", () => {
         `
       )
         .trackEmittedStreams()
-        .authenticated("admin", "changeit")
         .execute(connection)
     ).resolves.toBeUndefined();
   });
@@ -57,7 +57,6 @@ describe("createContinuousProjection", () => {
         `
       )
         .doNotTrackEmittedStreams()
-        .authenticated("admin", "changeit")
         .execute(connection)
     ).resolves.toBeUndefined();
   });

--- a/src/__test__/projections/createOneTimeProjection.test.ts
+++ b/src/__test__/projections/createOneTimeProjection.test.ts
@@ -13,6 +13,7 @@ describe("createOneTimeProjection", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });
@@ -30,9 +31,7 @@ describe("createOneTimeProjection", () => {
               return {};
             }
           });
-      `)
-        .authenticated("admin", "changeit")
-        .execute(connection)
+      `).execute(connection)
     ).resolves.toBeUndefined();
   });
 });

--- a/src/__test__/projections/createTransientProjection.test.ts
+++ b/src/__test__/projections/createTransientProjection.test.ts
@@ -13,6 +13,7 @@ describe("createOneTimeProjection", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });
@@ -35,9 +36,7 @@ describe("createOneTimeProjection", () => {
             }
           });
       `
-      )
-        .authenticated("admin", "changeit")
-        .execute(connection)
+      ).execute(connection)
     ).resolves.toBeUndefined();
   });
 });

--- a/src/__test__/projections/deleteProjection.test.ts
+++ b/src/__test__/projections/deleteProjection.test.ts
@@ -31,6 +31,7 @@ describe("deleteProjection", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });
@@ -42,36 +43,34 @@ describe("deleteProjection", () => {
   test("delete the projection", async () => {
     const PROJECTION_NAME = "projection_to_delete_everything";
 
-    await createContinuousProjection(PROJECTION_NAME, projection)
-      .authenticated("admin", "changeit")
-      .execute(connection);
+    await createContinuousProjection(PROJECTION_NAME, projection).execute(
+      connection
+    );
 
-    const beforeDetails = await getProjectionStatistics(PROJECTION_NAME)
-      .authenticated("admin", "changeit")
-      .execute(connection);
+    const beforeDetails = await getProjectionStatistics(
+      PROJECTION_NAME
+    ).execute(connection);
 
     expect(beforeDetails).toBeDefined();
     expect(beforeDetails.projectionStatus).toBe(RUNNING);
 
     await disableProjection(PROJECTION_NAME)
       .doNotWriteCheckpoint()
-      .authenticated("admin", "changeit")
+
       .execute(connection);
 
-    const disabledDetails = await getProjectionStatistics(PROJECTION_NAME)
-      .authenticated("admin", "changeit")
-      .execute(connection);
+    const disabledDetails = await getProjectionStatistics(
+      PROJECTION_NAME
+    ).execute(connection);
 
     expect(disabledDetails).toBeDefined();
     expect(disabledDetails.projectionStatus).toBe(STOPPED);
 
-    await deleteProjection(PROJECTION_NAME)
-      .authenticated("admin", "changeit")
-      .execute(connection);
+    await deleteProjection(PROJECTION_NAME).execute(connection);
 
-    const afterDetails = await getProjectionStatistics(PROJECTION_NAME)
-      .authenticated("admin", "changeit")
-      .execute(connection);
+    const afterDetails = await getProjectionStatistics(PROJECTION_NAME).execute(
+      connection
+    );
 
     expect(afterDetails).toBeDefined();
     expect(afterDetails.projectionStatus).toBe(DELETING);
@@ -82,9 +81,7 @@ describe("deleteProjection", () => {
       const PROJECTION_NAME = "doesnt exist";
 
       await expect(
-        deleteProjection(PROJECTION_NAME)
-          .authenticated("admin", "changeit")
-          .execute(connection)
+        deleteProjection(PROJECTION_NAME).execute(connection)
       ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
     });
   });

--- a/src/__test__/projections/disableProjection.test.ts
+++ b/src/__test__/projections/disableProjection.test.ts
@@ -30,6 +30,7 @@ describe("disableProjection", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });
@@ -42,25 +43,25 @@ describe("disableProjection", () => {
     test("write a checkpoint", async () => {
       const PROJECTION_NAME = "projection_to_disable_with_checkpoint";
 
-      await createContinuousProjection(PROJECTION_NAME, projection)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      await createContinuousProjection(PROJECTION_NAME, projection).execute(
+        connection
+      );
 
-      const beforeDetails = await getProjectionStatistics(PROJECTION_NAME)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      const beforeDetails = await getProjectionStatistics(
+        PROJECTION_NAME
+      ).execute(connection);
 
       expect(beforeDetails).toBeDefined();
       expect(beforeDetails.projectionStatus).toBe(RUNNING);
 
       await disableProjection(PROJECTION_NAME)
         .writeCheckpoint()
-        .authenticated("admin", "changeit")
+
         .execute(connection);
 
-      const afterDetails = await getProjectionStatistics(PROJECTION_NAME)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      const afterDetails = await getProjectionStatistics(
+        PROJECTION_NAME
+      ).execute(connection);
 
       expect(afterDetails).toBeDefined();
       expect(afterDetails.projectionStatus).toBe(ABORTED);
@@ -69,25 +70,25 @@ describe("disableProjection", () => {
     test("do not write a checkpoint", async () => {
       const PROJECTION_NAME = "projection_to_disable_without_checkpoint";
 
-      await createContinuousProjection(PROJECTION_NAME, projection)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      await createContinuousProjection(PROJECTION_NAME, projection).execute(
+        connection
+      );
 
-      const beforeDetails = await getProjectionStatistics(PROJECTION_NAME)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      const beforeDetails = await getProjectionStatistics(
+        PROJECTION_NAME
+      ).execute(connection);
 
       expect(beforeDetails).toBeDefined();
       expect(beforeDetails.projectionStatus).toBe(RUNNING);
 
       await disableProjection(PROJECTION_NAME)
         .doNotWriteCheckpoint()
-        .authenticated("admin", "changeit")
+
         .execute(connection);
 
-      const afterDetails = await getProjectionStatistics(PROJECTION_NAME)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      const afterDetails = await getProjectionStatistics(
+        PROJECTION_NAME
+      ).execute(connection);
 
       expect(afterDetails).toBeDefined();
       expect(afterDetails.projectionStatus).toBe(STOPPED);
@@ -99,9 +100,7 @@ describe("disableProjection", () => {
       const PROJECTION_NAME = "doesnt exist";
 
       await expect(
-        disableProjection(PROJECTION_NAME)
-          .authenticated("admin", "changeit")
-          .execute(connection)
+        disableProjection(PROJECTION_NAME).execute(connection)
       ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
     });
   });

--- a/src/__test__/projections/enableProjection.test.ts
+++ b/src/__test__/projections/enableProjection.test.ts
@@ -30,6 +30,7 @@ describe("enableProjection", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });
@@ -41,29 +42,27 @@ describe("enableProjection", () => {
   test("enables the projection", async () => {
     const PROJECTION_NAME = "projection_to_enable";
 
-    await createContinuousProjection(PROJECTION_NAME, projection)
-      .authenticated("admin", "changeit")
-      .execute(connection);
+    await createContinuousProjection(PROJECTION_NAME, projection).execute(
+      connection
+    );
 
     await disableProjection(PROJECTION_NAME)
       .writeCheckpoint()
-      .authenticated("admin", "changeit")
+
       .execute(connection);
 
-    const beforeDetails = await getProjectionStatistics(PROJECTION_NAME)
-      .authenticated("admin", "changeit")
-      .execute(connection);
+    const beforeDetails = await getProjectionStatistics(
+      PROJECTION_NAME
+    ).execute(connection);
 
     expect(beforeDetails).toBeDefined();
     expect(beforeDetails.projectionStatus).toBe(ABORTED);
 
-    await enableProjection(PROJECTION_NAME)
-      .authenticated("admin", "changeit")
-      .execute(connection);
+    await enableProjection(PROJECTION_NAME).execute(connection);
 
-    const afterDetails = await getProjectionStatistics(PROJECTION_NAME)
-      .authenticated("admin", "changeit")
-      .execute(connection);
+    const afterDetails = await getProjectionStatistics(PROJECTION_NAME).execute(
+      connection
+    );
 
     expect(afterDetails).toBeDefined();
     expect(afterDetails.projectionStatus).toBe(RUNNING);
@@ -73,9 +72,7 @@ describe("enableProjection", () => {
     const PROJECTION_NAME = "doesnt exist";
 
     await expect(
-      enableProjection(PROJECTION_NAME)
-        .authenticated("admin", "changeit")
-        .execute(connection)
+      enableProjection(PROJECTION_NAME).execute(connection)
     ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
   });
 });

--- a/src/__test__/projections/getProjectionState.test.ts
+++ b/src/__test__/projections/getProjectionState.test.ts
@@ -30,6 +30,7 @@ describe("getProjectionState", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });
@@ -42,17 +43,17 @@ describe("getProjectionState", () => {
     const PROJECTION_NAME = "count events";
     const count = 3;
 
-    await createContinuousProjection(PROJECTION_NAME, projection)
-      .authenticated("admin", "changeit")
-      .execute(connection);
+    await createContinuousProjection(PROJECTION_NAME, projection).execute(
+      connection
+    );
 
     await writeEventsToStream(STREAM_NAME)
       .send(...testEvents(count, EVENT_TYPE))
       .execute(connection);
 
-    const state = await getProjectionState<number>(PROJECTION_NAME)
-      .authenticated("admin", "changeit")
-      .execute(connection);
+    const state = await getProjectionState<number>(PROJECTION_NAME).execute(
+      connection
+    );
 
     expect(state).toBe(count);
   });
@@ -61,9 +62,7 @@ describe("getProjectionState", () => {
     const PROJECTION_NAME = "doesnt exist";
 
     await expect(
-      getProjectionState(PROJECTION_NAME)
-        .authenticated("admin", "changeit")
-        .execute(connection)
+      getProjectionState(PROJECTION_NAME).execute(connection)
     ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
   });
 });

--- a/src/__test__/projections/getProjectionStatistics.test.ts
+++ b/src/__test__/projections/getProjectionStatistics.test.ts
@@ -34,19 +34,20 @@ describe("getProjectionStatistics", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
 
     for (const name of continuousProjections) {
-      await createContinuousProjection(name, basicProjection)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      await createContinuousProjection(name, basicProjection).execute(
+        connection
+      );
     }
 
     for (const name of transientProjections) {
-      await createTransientProjection(name, basicProjection)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      await createTransientProjection(name, basicProjection).execute(
+        connection
+      );
     }
   });
 
@@ -58,9 +59,9 @@ describe("getProjectionStatistics", () => {
     test("continuous", async () => {
       const REQUESTED_NAME = continuousProjections[2];
 
-      const details = await getProjectionStatistics(REQUESTED_NAME)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      const details = await getProjectionStatistics(REQUESTED_NAME).execute(
+        connection
+      );
 
       expect(details).toBeDefined();
       expect(details.mode).toBe(CONTINUOUS);
@@ -69,9 +70,9 @@ describe("getProjectionStatistics", () => {
 
     test("transient", async () => {
       const REQUESTED_NAME = transientProjections[1];
-      const details = await getProjectionStatistics(REQUESTED_NAME)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      const details = await getProjectionStatistics(REQUESTED_NAME).execute(
+        connection
+      );
 
       expect(details).toBeDefined();
       expect(details.mode).toBe(TRANSIENT);
@@ -81,9 +82,7 @@ describe("getProjectionStatistics", () => {
     test("non-existant", async () => {
       const REQUESTED_NAME = "some-non-existant-projection";
       await expect(
-        getProjectionStatistics(REQUESTED_NAME)
-          .authenticated("admin", "changeit")
-          .execute(connection)
+        getProjectionStatistics(REQUESTED_NAME).execute(connection)
       ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
     });
   });

--- a/src/__test__/projections/listProjections.test.ts
+++ b/src/__test__/projections/listProjections.test.ts
@@ -38,25 +38,24 @@ describe("list projections", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
 
     for (const name of continuousProjections) {
-      await createContinuousProjection(name, basicProjection)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      await createContinuousProjection(name, basicProjection).execute(
+        connection
+      );
     }
 
     for (const _ of oneTimeProjections) {
-      await createOneTimeProjection(basicProjection)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      await createOneTimeProjection(basicProjection).execute(connection);
     }
 
     for (const name of transientProjections) {
-      await createTransientProjection(name, basicProjection)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      await createTransientProjection(name, basicProjection).execute(
+        connection
+      );
     }
   });
 
@@ -66,9 +65,7 @@ describe("list projections", () => {
 
   describe("lists projections", () => {
     test("listContinuousProjections", async () => {
-      const projections = await listContinuousProjections()
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      const projections = await listContinuousProjections().execute(connection);
 
       // includes system projections
       expect(projections.length).toBeGreaterThan(continuousProjections.length);
@@ -83,9 +80,7 @@ describe("list projections", () => {
     });
 
     test("listOneTimeProjections", async () => {
-      const projections = await listOneTimeProjections()
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      const projections = await listOneTimeProjections().execute(connection);
 
       expect(projections).toHaveLength(oneTimeProjections.length);
 
@@ -96,9 +91,7 @@ describe("list projections", () => {
     });
 
     test("listTransientProjections", async () => {
-      const projections = await listTransientProjections()
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      const projections = await listTransientProjections().execute(connection);
 
       expect(projections).toHaveLength(transientProjections.length);
 

--- a/src/__test__/projections/resetProjection.test.ts
+++ b/src/__test__/projections/resetProjection.test.ts
@@ -26,6 +26,7 @@ describe("resetProjection", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });
@@ -38,26 +39,26 @@ describe("resetProjection", () => {
     test("write a checkpoint", async () => {
       const PROJECTION_NAME = "projection_to_disable_with_checkpoint";
 
-      await createContinuousProjection(PROJECTION_NAME, projection)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      await createContinuousProjection(PROJECTION_NAME, projection).execute(
+        connection
+      );
 
       await resetProjection(PROJECTION_NAME)
         .writeCheckpoint()
-        .authenticated("admin", "changeit")
+
         .execute(connection);
     });
 
     test("do not write a checkpoint", async () => {
       const PROJECTION_NAME = "projection_to_disable_without_checkpoint";
 
-      await createContinuousProjection(PROJECTION_NAME, projection)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      await createContinuousProjection(PROJECTION_NAME, projection).execute(
+        connection
+      );
 
       await resetProjection(PROJECTION_NAME)
         .doNotWriteCheckpoint()
-        .authenticated("admin", "changeit")
+
         .execute(connection);
     });
   });
@@ -67,9 +68,7 @@ describe("resetProjection", () => {
       const PROJECTION_NAME = "doesnt exist";
 
       await expect(
-        resetProjection(PROJECTION_NAME)
-          .authenticated("admin", "changeit")
-          .execute(connection)
+        resetProjection(PROJECTION_NAME).execute(connection)
       ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
     });
   });

--- a/src/__test__/projections/restartSubsystem.test.ts
+++ b/src/__test__/projections/restartSubsystem.test.ts
@@ -9,6 +9,7 @@ describe("restartSubsystem", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });
@@ -19,7 +20,7 @@ describe("restartSubsystem", () => {
 
   test("Doesnt error", async () => {
     await expect(
-      restartSubsystem().authenticated("admin", "changeit").execute(connection)
+      restartSubsystem().execute(connection)
     ).resolves.toBeUndefined();
   });
 });

--- a/src/__test__/projections/updateProjection.test.ts
+++ b/src/__test__/projections/updateProjection.test.ts
@@ -5,8 +5,8 @@ import {
   EventStoreConnection,
   createContinuousProjection,
   UnknownError,
+  updateProjection,
 } from "../..";
-import { updateProjection } from "../../command";
 
 describe("resetProjection", () => {
   const node = createTestNode();
@@ -26,6 +26,7 @@ describe("resetProjection", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });
@@ -49,25 +50,23 @@ describe("resetProjection", () => {
           });
       `;
 
-      await createContinuousProjection(PROJECTION_NAME, projection)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      await createContinuousProjection(PROJECTION_NAME, projection).execute(
+        connection
+      );
 
-      await updateProjection(PROJECTION_NAME, after)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      await updateProjection(PROJECTION_NAME, after).execute(connection);
     });
 
     test("track Emitted Streams", async () => {
       const PROJECTION_NAME = "projection_to_update_tracking";
 
-      await createContinuousProjection(PROJECTION_NAME, projection)
-        .authenticated("admin", "changeit")
-        .execute(connection);
+      await createContinuousProjection(PROJECTION_NAME, projection).execute(
+        connection
+      );
 
       await updateProjection(PROJECTION_NAME, projection)
         .trackEmittedStreams()
-        .authenticated("admin", "changeit")
+
         .execute(connection);
     });
   });
@@ -77,9 +76,7 @@ describe("resetProjection", () => {
       const PROJECTION_NAME = "doesnt exist";
 
       await expect(
-        updateProjection(PROJECTION_NAME, projection)
-          .authenticated("admin", "changeit")
-          .execute(connection)
+        updateProjection(PROJECTION_NAME, projection).execute(connection)
       ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
     });
   });

--- a/src/__test__/streams/deleteStream.test.ts
+++ b/src/__test__/streams/deleteStream.test.ts
@@ -23,6 +23,7 @@ describe("deleteStream", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });

--- a/src/__test__/streams/readAllEvents.test.ts
+++ b/src/__test__/streams/readAllEvents.test.ts
@@ -16,6 +16,7 @@ describe("readAllEvents", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
 
@@ -35,7 +36,6 @@ describe("readAllEvents", () => {
   describe("should successfully read from $all", () => {
     test("from start", async () => {
       const events = await readAllEvents()
-        .authenticated("admin", "changeit")
         .fromStart()
         .count(Number.MAX_SAFE_INTEGER)
         .execute(connection);
@@ -52,7 +52,6 @@ describe("readAllEvents", () => {
 
     test("from position", async () => {
       const [, , eventToExtract] = await readAllEvents()
-        .authenticated("admin", "changeit")
         .fromStart()
         .count(3)
         .execute(connection);
@@ -60,7 +59,6 @@ describe("readAllEvents", () => {
       const { position } = eventToExtract.event!;
 
       const [extracted] = await readAllEvents()
-        .authenticated("admin", "changeit")
         .fromPosition(position)
         .count(1)
         .execute(connection);
@@ -70,7 +68,6 @@ describe("readAllEvents", () => {
 
     test("backward from end", async () => {
       const events = await readAllEvents()
-        .authenticated("admin", "changeit")
         .backward()
         .fromEnd()
         .count(Number.MAX_SAFE_INTEGER)
@@ -88,7 +85,6 @@ describe("readAllEvents", () => {
 
     test("count", async () => {
       const events = await readAllEvents()
-        .authenticated("admin", "changeit")
         .fromStart()
         .count(2)
         .execute(connection);

--- a/src/__test__/streams/readEventsFromStream.test.ts
+++ b/src/__test__/streams/readEventsFromStream.test.ts
@@ -17,6 +17,7 @@ describe("readEventsFromStream", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
 

--- a/src/__test__/streams/subscribeToAll.test.ts
+++ b/src/__test__/streams/subscribeToAll.test.ts
@@ -20,6 +20,7 @@ describe("subscribeToAll", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
 
@@ -66,7 +67,6 @@ describe("subscribeToAll", () => {
       );
 
       await subscribeToAll()
-        .authenticated("admin", "changeit")
         .fromStart()
         .on("error", onError)
         .on("event", onEvent)
@@ -125,7 +125,6 @@ describe("subscribeToAll", () => {
       );
 
       await subscribeToAll()
-        .authenticated("admin", "changeit")
         .fromEnd()
         .on("error", onError)
         .on("event", onEvent)
@@ -199,7 +198,6 @@ describe("subscribeToAll", () => {
       );
 
       await subscribeToAll()
-        .authenticated("admin", "changeit")
         .fromPosition(writeResult.position!)
         .on("error", onError)
         .on("event", onEvent)
@@ -241,10 +239,7 @@ describe("subscribeToAll", () => {
         message: "lets wrap this up",
       });
 
-      const subscription = await subscribeToAll()
-        .authenticated("admin", "changeit")
-        .fromEnd()
-        .execute(connection);
+      const subscription = await subscribeToAll().fromEnd().execute(connection);
 
       writeEventsToStream(STREAM_NAME)
         .send(...testEvents(8))
@@ -277,10 +272,7 @@ describe("subscribeToAll", () => {
         .send(...testEvents(8))
         .execute(connection);
 
-      const subscription = await subscribeToAll()
-        .authenticated("admin", "changeit")
-        .fromEnd()
-        .execute(connection);
+      const subscription = await subscribeToAll().fromEnd().execute(connection);
 
       const eventListenerOne = jest.fn();
       const eventListenerTwo = jest.fn();

--- a/src/__test__/streams/subscribeToStream.test.ts
+++ b/src/__test__/streams/subscribeToStream.test.ts
@@ -21,6 +21,7 @@ describe("subscribeToStream", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
 
@@ -55,7 +56,6 @@ describe("subscribeToStream", () => {
       });
 
       await subscribeToStream(STREAM_NAME)
-        .authenticated("admin", "changeit")
         .fromStart()
         .on("error", handleError)
         .on("event", handleEvent)
@@ -99,7 +99,6 @@ describe("subscribeToStream", () => {
       });
 
       await subscribeToStream(STREAM_NAME)
-        .authenticated("admin", "changeit")
         .fromEnd()
         .on("error", handleError)
         .on("event", handleEvent)
@@ -147,7 +146,6 @@ describe("subscribeToStream", () => {
       );
 
       await subscribeToStream(STREAM_NAME)
-        .authenticated("admin", "changeit")
         .fromRevision(BigInt(2))
         .on("close", handleClose)
         .on("error", handleError)
@@ -184,7 +182,6 @@ describe("subscribeToStream", () => {
         .execute(connection);
 
       const subscription = await subscribeToStream(STREAM_NAME)
-        .authenticated("admin", "changeit")
         .fromStart()
         .execute(connection);
 
@@ -209,7 +206,6 @@ describe("subscribeToStream", () => {
         .execute(connection);
 
       const subscription = await subscribeToStream(STREAM_NAME)
-        .authenticated("admin", "changeit")
         .fromEnd()
         .execute(connection);
 

--- a/src/__test__/streams/writeEventsToStream.test.ts
+++ b/src/__test__/streams/writeEventsToStream.test.ts
@@ -17,6 +17,7 @@ describe("writeEventsToStream", () => {
   beforeAll(async () => {
     await node.up();
     connection = EventStoreConnection.builder()
+      .defaultCredentials({ username: "admin", password: "changeit" })
       .sslRootCertificate(node.certPath)
       .singleNodeConnection(node.uri);
   });

--- a/src/command/Command.ts
+++ b/src/command/Command.ts
@@ -1,39 +1,18 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
 import { Metadata } from "@grpc/grpc-js";
-
-interface Credentials {
-  username: string;
-  password: string;
-}
+import { DEFAULT_CREDENTIALS } from "../symbols";
+import { Credentials, ESDBConnection } from "../types";
 
 export class Command {
   private _credentials?: Credentials;
   private _requiresLeader?: boolean = false;
 
-  get metadata(): Metadata {
-    const metadata = new Metadata();
-
-    if (this._credentials) {
-      const auth = Buffer.from(
-        `${this._credentials.username}:${this._credentials.password}`
-      ).toString("base64");
-      metadata.add("authorization", `Basic ${auth}`);
-    }
-
-    if (this._requiresLeader) {
-      metadata.add("requires-leader", "true");
-    }
-
-    return metadata;
-  }
-
   /**
    * Executes this command as an authenticated user.
-   * @param username
-   * @param password
+   * @param credentials
    */
-  authenticated(username: string, password: string) {
+  authenticated({ username, password }: Credentials) {
     this._credentials = { username, password };
     return this;
   }
@@ -46,4 +25,22 @@ export class Command {
     this._requiresLeader = requiresLeader;
     return this;
   }
+
+  protected metadata = (connection: ESDBConnection): Metadata => {
+    const metadata = new Metadata();
+    const credentials = this._credentials ?? connection[DEFAULT_CREDENTIALS]();
+
+    if (credentials) {
+      const auth = Buffer.from(
+        `${credentials.username}:${credentials.password}`
+      ).toString("base64");
+      metadata.add("authorization", `Basic ${auth}`);
+    }
+
+    if (this._requiresLeader) {
+      metadata.add("requires-leader", "true");
+    }
+
+    return metadata;
+  };
 }

--- a/src/command/persistentSubscription/ConnectToPersistentSubscription.ts
+++ b/src/command/persistentSubscription/ConnectToPersistentSubscription.ts
@@ -14,6 +14,7 @@ import {
 import { Command } from "../Command";
 import { TwoWaySubscription } from "../../utils/TwoWaySubscription";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class ConnectToPersistentSubscription extends Command {
   private _streamName: string;
@@ -92,11 +93,11 @@ export class ConnectToPersistentSubscription extends Command {
     debug.command("ConnectToPersistentSubscription: %c", this);
     debug.command_grpc("ConnectToPersistentSubscription: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       PersistentSubscriptionsClient,
       "ConnectToPersistentSubscription"
     );
-    const stream = client.read(this.metadata, {
+    const stream = client.read(this.metadata(connection), {
       deadline: Infinity,
     });
     stream.write(req);

--- a/src/command/persistentSubscription/CreatePersistentSubscription.ts
+++ b/src/command/persistentSubscription/CreatePersistentSubscription.ts
@@ -6,6 +6,7 @@ import { ConsumerStrategy, ESDBConnection } from "../../types";
 import { Command } from "../Command";
 import { convertToCommandError } from "../../utils/CommandError";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class CreatePersistentSubscription extends Command {
   private _stream: string;
@@ -256,13 +257,13 @@ export class CreatePersistentSubscription extends Command {
     debug.command("CreatePersistentSubscription: %c", this);
     debug.command_grpc("CreatePersistentSubscription: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       PersistentSubscriptionsClient,
       "CreatePersistentSubscription"
     );
 
     return new Promise<void>((resolve, reject) => {
-      client.create(req, this.metadata, (error) => {
+      client.create(req, this.metadata(connection), (error) => {
         if (error) return reject(convertToCommandError(error));
         return resolve();
       });

--- a/src/command/persistentSubscription/DeletePersistentSubscription.ts
+++ b/src/command/persistentSubscription/DeletePersistentSubscription.ts
@@ -6,6 +6,7 @@ import { ESDBConnection } from "../../types";
 import { Command } from "../Command";
 import { convertToCommandError } from "../../utils/CommandError";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class DeletePersistentSubscription extends Command {
   private _stream: string;
@@ -33,13 +34,13 @@ export class DeletePersistentSubscription extends Command {
     debug.command("DeletePersistentSubscription: %c", this);
     debug.command_grpc("DeletePersistentSubscription: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       PersistentSubscriptionsClient,
       "DeletePersistentSubscription"
     );
 
     return new Promise<void>((resolve, reject) => {
-      client.delete(req, this.metadata, (error) => {
+      client.delete(req, this.metadata(connection), (error) => {
         if (error) return reject(convertToCommandError(error));
         return resolve();
       });

--- a/src/command/persistentSubscription/UpdatePersistentSubscription.ts
+++ b/src/command/persistentSubscription/UpdatePersistentSubscription.ts
@@ -6,6 +6,7 @@ import { ConsumerStrategy, ESDBConnection } from "../../types";
 import { Command } from "../Command";
 import { convertToCommandError } from "../../utils/CommandError";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class UpdatePersistentSubscription extends Command {
   private _stream: string;
@@ -240,13 +241,13 @@ export class UpdatePersistentSubscription extends Command {
     debug.command("UpdatePersistentSubscription: %c", this);
     debug.command_grpc("UpdatePersistentSubscription: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       PersistentSubscriptionsClient,
       "UpdatePersistentSubscription"
     );
 
     return new Promise<void>((resolve, reject) => {
-      client.update(req, this.metadata, (error) => {
+      client.update(req, this.metadata(connection), (error) => {
         if (error) return reject(convertToCommandError(error));
         return resolve();
       });

--- a/src/command/projections/CreateContinuousProjection.ts
+++ b/src/command/projections/CreateContinuousProjection.ts
@@ -5,6 +5,7 @@ import { ESDBConnection } from "../../types";
 import { Command } from "../Command";
 import { convertToCommandError } from "../../utils/CommandError";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class CreateContinuousProjection extends Command {
   private _name: string;
@@ -53,13 +54,13 @@ export class CreateContinuousProjection extends Command {
     debug.command("CreateContinuousProjection: %c", this);
     debug.command_grpc("CreateContinuousProjection: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       ProjectionsClient,
       "CreateContinuousProjection"
     );
 
     return new Promise<void>((resolve, reject) => {
-      client.create(req, this.metadata, (error) => {
+      client.create(req, this.metadata(connection), (error) => {
         if (error) return reject(convertToCommandError(error));
         return resolve();
       });

--- a/src/command/projections/CreateOneTimeProjection.ts
+++ b/src/command/projections/CreateOneTimeProjection.ts
@@ -6,6 +6,7 @@ import { ESDBConnection } from "../../types";
 import { Command } from "../Command";
 import { convertToCommandError } from "../../utils/CommandError";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class CreateOneTimeProjection extends Command {
   private _query: string;
@@ -30,13 +31,13 @@ export class CreateOneTimeProjection extends Command {
     debug.command("CreateOneTimeProjection: %c", this);
     debug.command_grpc("CreateOneTimeProjection: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       ProjectionsClient,
       "CreateOneTimeProjection"
     );
 
     return new Promise<void>((resolve, reject) => {
-      client.create(req, this.metadata, (error) => {
+      client.create(req, this.metadata(connection), (error) => {
         if (error) return reject(convertToCommandError(error));
         return resolve();
       });

--- a/src/command/projections/CreateTransientProjection.ts
+++ b/src/command/projections/CreateTransientProjection.ts
@@ -5,6 +5,7 @@ import { ESDBConnection } from "../../types";
 import { Command } from "../Command";
 import { convertToCommandError } from "../../utils/CommandError";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class CreateTransientProjection extends Command {
   private _name: string;
@@ -34,13 +35,13 @@ export class CreateTransientProjection extends Command {
     debug.command("CreateTransientProjection: %c", this);
     debug.command_grpc("CreateTransientProjection: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       ProjectionsClient,
       "CreateTransientProjection"
     );
 
     return new Promise<void>((resolve, reject) => {
-      client.create(req, this.metadata, (error) => {
+      client.create(req, this.metadata(connection), (error) => {
         if (error) return reject(convertToCommandError(error));
         return resolve();
       });

--- a/src/command/projections/DeleteProjection.ts
+++ b/src/command/projections/DeleteProjection.ts
@@ -5,6 +5,7 @@ import { ESDBConnection } from "../../types";
 import { Command } from "../Command";
 import { convertToCommandError } from "../../utils/CommandError";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class DeleteProjection extends Command {
   private _name: string;
@@ -85,13 +86,13 @@ export class DeleteProjection extends Command {
     debug.command("DeleteProjection: %c", this);
     debug.command_grpc("DeleteProjection: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       ProjectionsClient,
       "DeleteProjection"
     );
 
     return new Promise<void>((resolve, reject) => {
-      client.delete(req, this.metadata, (error) => {
+      client.delete(req, this.metadata(connection), (error) => {
         if (error) return reject(convertToCommandError(error));
         return resolve();
       });

--- a/src/command/projections/DisableProjection.ts
+++ b/src/command/projections/DisableProjection.ts
@@ -5,6 +5,7 @@ import { ESDBConnection } from "../../types";
 import { Command } from "../Command";
 import { convertToCommandError } from "../../utils/CommandError";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class DisableProjection extends Command {
   private _name: string;
@@ -47,13 +48,13 @@ export class DisableProjection extends Command {
     debug.command("DisableProjection: %c", this);
     debug.command_grpc("DisableProjection: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       ProjectionsClient,
       "DisableProjection"
     );
 
     return new Promise<void>((resolve, reject) => {
-      client.disable(req, this.metadata, (error) => {
+      client.disable(req, this.metadata(connection), (error) => {
         if (error) return reject(convertToCommandError(error));
         return resolve();
       });

--- a/src/command/projections/EnableProjection.ts
+++ b/src/command/projections/EnableProjection.ts
@@ -5,6 +5,7 @@ import { ESDBConnection } from "../../types";
 import { Command } from "../Command";
 import { convertToCommandError } from "../../utils/CommandError";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class EnableProjection extends Command {
   private _name: string;
@@ -28,13 +29,13 @@ export class EnableProjection extends Command {
     debug.command("EnableProjection: %c", this);
     debug.command_grpc("EnableProjection: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       ProjectionsClient,
       "EnableProjection"
     );
 
     return new Promise<void>((resolve, reject) => {
-      client.enable(req, this.metadata, (error) => {
+      client.enable(req, this.metadata(connection), (error) => {
         if (error) return reject(convertToCommandError(error));
         return resolve();
       });

--- a/src/command/projections/GetProjectionResult.ts
+++ b/src/command/projections/GetProjectionResult.ts
@@ -5,6 +5,7 @@ import { ESDBConnection } from "../../types";
 import { Command } from "../Command";
 import { debug } from "../../utils/debug";
 import { convertToCommandError } from "../../utils/CommandError";
+import { CLIENT } from "../../symbols";
 
 export class GetProjectionResult<S = unknown> extends Command {
   private _name: string;
@@ -38,13 +39,13 @@ export class GetProjectionResult<S = unknown> extends Command {
     debug.command("GetProjectionResult: %c", this);
     debug.command_grpc("GetProjectionResult: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       ProjectionsClient,
       "GetProjectionResult"
     );
 
     return new Promise<S>((resolve, reject) => {
-      client.result(req, this.metadata, (error, response) => {
+      client.result(req, this.metadata(connection), (error, response) => {
         if (error) return reject(convertToCommandError(error));
         return resolve(response.getResult()?.toJavaScript() as S);
       });

--- a/src/command/projections/GetProjectionState.ts
+++ b/src/command/projections/GetProjectionState.ts
@@ -5,6 +5,7 @@ import { ESDBConnection } from "../../types";
 import { Command } from "../Command";
 import { debug } from "../../utils/debug";
 import { convertToCommandError } from "../../utils/CommandError";
+import { CLIENT } from "../../symbols";
 
 export class GetProjectionState<S = unknown> extends Command {
   private _name: string;
@@ -25,13 +26,13 @@ export class GetProjectionState<S = unknown> extends Command {
     debug.command("GetProjectionState: %c", this);
     debug.command_grpc("GetProjectionState: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       ProjectionsClient,
       "GetProjectionState"
     );
 
     return new Promise<S>((resolve, reject) => {
-      client.state(req, this.metadata, (error, response) => {
+      client.state(req, this.metadata(connection), (error, response) => {
         if (error) return reject(convertToCommandError(error));
         return resolve(response.getState()?.toJavaScript() as S);
       });

--- a/src/command/projections/GetProjectionStatistics.ts
+++ b/src/command/projections/GetProjectionStatistics.ts
@@ -10,6 +10,7 @@ import { Command } from "../Command";
 import { debug } from "../../utils/debug";
 import { convertToCommandError } from "../../utils/CommandError";
 import { convertGrpcProjectionDetails } from "../../utils/convertGrpcProjectionDetails";
+import { CLIENT } from "../../symbols";
 
 export class GetProjectionStatistics extends Command {
   private _name: string;
@@ -30,12 +31,12 @@ export class GetProjectionStatistics extends Command {
     debug.command("GetProjectionStatistics: %c", this);
     debug.command_grpc("GetProjectionStatistics: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       ProjectionsClient,
       "GetProjectionStatistics"
     );
 
-    const stream = client.statistics(req, this.metadata);
+    const stream = client.statistics(req, this.metadata(connection));
 
     return new Promise((resolve, reject) => {
       let projectionDetail: ProjectionDetails;

--- a/src/command/projections/ListProjections.ts
+++ b/src/command/projections/ListProjections.ts
@@ -1,4 +1,4 @@
-import { ServiceError } from "@grpc/grpc-js";
+import { Metadata, ServiceError } from "@grpc/grpc-js";
 import { Empty } from "../../../generated/shared_pb";
 import { ProjectionsClient } from "../../../generated/projections_grpc_pb";
 import {
@@ -11,11 +11,13 @@ import { Command } from "../Command";
 import { debug } from "../../utils/debug";
 import { convertToCommandError } from "../../utils/CommandError";
 import { convertGrpcProjectionDetails } from "../../utils/convertGrpcProjectionDetails";
+import { CLIENT } from "../../symbols";
 
 const fetchAndTransformProjectionList = async (
   connection: ESDBConnection,
   options: StatisticsReq.Options,
   command: Command,
+  metadata: Metadata,
   debugName: string
 ): Promise<ProjectionDetails[]> => {
   const req = new StatisticsReq();
@@ -24,9 +26,9 @@ const fetchAndTransformProjectionList = async (
   debug.command("%s: %c", debugName, command);
   debug.command_grpc("%s: %g", debugName, req);
 
-  const client = await connection._client(ProjectionsClient, debugName);
+  const client = await connection[CLIENT](ProjectionsClient, debugName);
 
-  const stream = client.statistics(req, command.metadata);
+  const stream = client.statistics(req, metadata);
 
   return new Promise((resolve, reject) => {
     const projectionDetails: ProjectionDetails[] = [];
@@ -58,6 +60,7 @@ export class ListContinuousProjections extends Command {
       connection,
       options,
       this,
+      this.metadata(connection),
       "ListContinuousProjections"
     );
   }
@@ -75,6 +78,7 @@ export class ListOneTimeProjections extends Command {
       connection,
       options,
       this,
+      this.metadata(connection),
       "ListOneTimeProjections"
     );
   }
@@ -92,6 +96,7 @@ export class ListTransientProjections extends Command {
       connection,
       options,
       this,
+      this.metadata(connection),
       "ListTransientProjections"
     );
   }

--- a/src/command/projections/ResetProjection.ts
+++ b/src/command/projections/ResetProjection.ts
@@ -5,6 +5,7 @@ import { ESDBConnection } from "../../types";
 import { Command } from "../Command";
 import { convertToCommandError } from "../../utils/CommandError";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class ResetProjection extends Command {
   private _name: string;
@@ -47,13 +48,13 @@ export class ResetProjection extends Command {
     debug.command("ResetProjection: %c", this);
     debug.command_grpc("ResetProjection: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       ProjectionsClient,
       "ResetProjection"
     );
 
     return new Promise<void>((resolve, reject) => {
-      client.reset(req, this.metadata, (error) => {
+      client.reset(req, this.metadata(connection), (error) => {
         if (error) return reject(convertToCommandError(error));
         return resolve();
       });

--- a/src/command/projections/RestartSubsystem.ts
+++ b/src/command/projections/RestartSubsystem.ts
@@ -1,10 +1,11 @@
 import { ProjectionsClient } from "../../../generated/projections_grpc_pb";
+import { Empty } from "../../../generated/shared_pb";
 
 import { ESDBConnection } from "../../types";
 import { Command } from "../Command";
 import { convertToCommandError } from "../../utils/CommandError";
 import { debug } from "../../utils/debug";
-import { Empty } from "../../../generated/shared_pb";
+import { CLIENT } from "../../symbols";
 
 export class RestartSubsystem extends Command {
   /**
@@ -16,13 +17,13 @@ export class RestartSubsystem extends Command {
     debug.command("RestartSubsystem: %c", this);
     debug.command_grpc("RestartSubsystem: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       ProjectionsClient,
       "RestartSubsystem"
     );
 
     return new Promise<void>((resolve, reject) => {
-      client.restartSubsystem(req, this.metadata, (error) => {
+      client.restartSubsystem(req, this.metadata(connection), (error) => {
         if (error) return reject(convertToCommandError(error));
         return resolve();
       });

--- a/src/command/projections/UpdateProjection.ts
+++ b/src/command/projections/UpdateProjection.ts
@@ -6,6 +6,7 @@ import { ESDBConnection } from "../../types";
 import { Command } from "../Command";
 import { convertToCommandError } from "../../utils/CommandError";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class UpdateProjection extends Command {
   private _name: string;
@@ -55,13 +56,13 @@ export class UpdateProjection extends Command {
     debug.command("UpdateProjection: %c", this);
     debug.command_grpc("UpdateProjection: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       ProjectionsClient,
       "UpdateProjection"
     );
 
     return new Promise<void>((resolve, reject) => {
-      client.update(req, this.metadata, (error) => {
+      client.update(req, this.metadata(connection), (error) => {
         if (error) return reject(convertToCommandError(error));
         return resolve();
       });

--- a/src/command/streams/DeleteStream.ts
+++ b/src/command/streams/DeleteStream.ts
@@ -5,6 +5,7 @@ import { DeleteResult, ESDBConnection, ExpectedRevision } from "../../types";
 import { Command } from "../Command";
 import { convertToCommandError } from "../../utils/CommandError";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class DeleteStream extends Command {
   private readonly _stream: string;
@@ -56,9 +57,9 @@ export class DeleteStream extends Command {
     debug.command("DeleteStream: %c", this);
     debug.command_grpc("DeleteStream: %g", req);
 
-    const client = await connection._client(StreamsClient, "DeleteStream");
+    const client = await connection[CLIENT](StreamsClient, "DeleteStream");
     return new Promise<DeleteResult>((resolve, reject) => {
-      client.delete(req, this.metadata, (error, resp) => {
+      client.delete(req, this.metadata(connection), (error, resp) => {
         if (error) {
           return reject(convertToCommandError(error));
         }

--- a/src/command/streams/ReadAllEvents.ts
+++ b/src/command/streams/ReadAllEvents.ts
@@ -14,6 +14,7 @@ import { Command } from "../Command";
 import { handleBatchRead } from "../../utils/handleBatchRead";
 import { convertAllStreamGrpcEvent } from "../../utils/convertGrpcEvent";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class ReadAllEvents extends Command {
   private _position: ReadPosition;
@@ -138,8 +139,8 @@ export class ReadAllEvents extends Command {
     debug.command("ReadAllEvents: %c", this);
     debug.command_grpc("ReadAllEvents: %g", req);
 
-    const client = await connection._client(StreamsClient, "ReadAllEvents");
-    const stream = client.read(req, this.metadata);
+    const client = await connection[CLIENT](StreamsClient, "ReadAllEvents");
+    const stream = client.read(req, this.metadata(connection));
     return handleBatchRead(stream, convertAllStreamGrpcEvent);
   }
 }

--- a/src/command/streams/ReadEventsFromStream.ts
+++ b/src/command/streams/ReadEventsFromStream.ts
@@ -12,6 +12,7 @@ import { Command } from "../Command";
 import { handleBatchRead } from "../../utils/handleBatchRead";
 import { convertGrpcEvent } from "../../utils/convertGrpcEvent";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class ReadEventsFromStream extends Command {
   private _stream: string;
@@ -156,11 +157,11 @@ export class ReadEventsFromStream extends Command {
     debug.command("ReadEventsFromStream: %c", this);
     debug.command_grpc("ReadEventsFromStream: %g", req);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       StreamsClient,
       "ReadEventsFromStream"
     );
-    const stream = client.read(req, this.metadata);
+    const stream = client.read(req, this.metadata(connection));
     return handleBatchRead(stream, convertGrpcEvent);
   }
 }

--- a/src/command/streams/SubscribeToAll.ts
+++ b/src/command/streams/SubscribeToAll.ts
@@ -20,6 +20,7 @@ import { Filter } from "../../utils/Filter";
 import { OneWaySubscription } from "../../utils/OneWaySubscription";
 import { convertAllStreamGrpcEvent } from "../../utils/convertGrpcEvent";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class SubscribeToAll extends Command {
   private _position: ReadPosition;
@@ -183,8 +184,8 @@ export class SubscribeToAll extends Command {
     debug.command("SubscribeToAll: %c", this);
     debug.command_grpc("SubscribeToAll: %g", req);
 
-    const client = await connection._client(StreamsClient, "SubscribeToAll");
-    const stream = client.read(req, this.metadata, callOptions);
+    const client = await connection[CLIENT](StreamsClient, "SubscribeToAll");
+    const stream = client.read(req, this.metadata(connection), callOptions);
 
     return new OneWaySubscription(
       stream,

--- a/src/command/streams/SubscribeToStream.ts
+++ b/src/command/streams/SubscribeToStream.ts
@@ -20,6 +20,7 @@ import { Command } from "../Command";
 import { OneWaySubscription } from "../../utils/OneWaySubscription";
 import { convertGrpcEvent } from "../../utils/convertGrpcEvent";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class SubscribeToStream extends Command {
   private _stream: string;
@@ -161,8 +162,8 @@ export class SubscribeToStream extends Command {
     debug.command("SubscribeToAll: %c", this);
     debug.command_grpc("SubscribeToAll: %g", req);
 
-    const client = await connection._client(StreamsClient, "SubscribeToAll");
-    const stream = client.read(req, this.metadata, callOptions);
+    const client = await connection[CLIENT](StreamsClient, "SubscribeToAll");
+    const stream = client.read(req, this.metadata(connection), callOptions);
 
     return new OneWaySubscription(stream, this._listeners, convertGrpcEvent);
   }

--- a/src/command/streams/TombstoneStream.ts
+++ b/src/command/streams/TombstoneStream.ts
@@ -5,6 +5,7 @@ import { DeleteResult, ESDBConnection, ExpectedRevision } from "../../types";
 import { convertToCommandError } from "../../utils/CommandError";
 import { Command } from "../Command";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class TombstoneStream extends Command {
   private readonly _stream: string;
@@ -60,10 +61,10 @@ export class TombstoneStream extends Command {
     debug.command("TombstoneStream: %c", this);
     debug.command_grpc("TombstoneStream: %g", req);
 
-    const client = await connection._client(StreamsClient, "TombstoneStream");
+    const client = await connection[CLIENT](StreamsClient, "TombstoneStream");
 
     return new Promise<DeleteResult>((resolve, reject) => {
-      client.tombstone(req, this.metadata, (error, resp) => {
+      client.tombstone(req, this.metadata(connection), (error, resp) => {
         if (error) {
           return reject(convertToCommandError(error));
         }

--- a/src/command/streams/WriteEventsToStream.ts
+++ b/src/command/streams/WriteEventsToStream.ts
@@ -14,6 +14,7 @@ import {
   WrongExpectedVersionError,
 } from "../../utils/CommandError";
 import { debug } from "../../utils/debug";
+import { CLIENT } from "../../symbols";
 
 export class WriteEventsToStream extends Command {
   private readonly _stream: string;
@@ -84,13 +85,13 @@ export class WriteEventsToStream extends Command {
     debug.command("WriteEventsToStream: %c", this);
     debug.command_grpc("WriteEventsToStream: %g", header);
 
-    const client = await connection._client(
+    const client = await connection[CLIENT](
       StreamsClient,
       "WriteEventsToStream"
     );
 
     return new Promise<WriteResult>((resolve, reject) => {
-      const sink = client.append(this.metadata, (error, resp) => {
+      const sink = client.append(this.metadata(connection), (error, resp) => {
         if (error != null) {
           return reject(convertToCommandError(error));
         }

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -6,17 +6,20 @@ import {
   ClientOptions,
   credentials as grpcCredentials,
 } from "@grpc/grpc-js";
-import { discoverEndpoint } from "./discovery";
+
 import {
   NodePreference,
   ESDBConnection,
   ClientConstructor,
   EndPoint,
+  Credentials,
+  VerifyOptions,
 } from "../types";
 import { debug } from "../utils/debug";
-import { parseConnectionString } from "./parseConnectionString";
+import { CLIENT, DEFAULT_CREDENTIALS } from "../symbols";
 
-export type VerifyOptions = Parameters<typeof grpcCredentials.createSsl>[3];
+import { discoverEndpoint } from "./discovery";
+import { parseConnectionString } from "./parseConnectionString";
 
 /**
  * Helps constructing an EventStoreDB connection.
@@ -27,6 +30,19 @@ export class EventStoreConnectionBuilder {
   private _privateKey?: Buffer;
   private _certChain?: Buffer;
   private _verifyOptions?: VerifyOptions;
+  private _defaultCredentials?: Credentials;
+
+  /**
+   * Sets default credentials to be used for each command.
+   * @param credentials
+   */
+  public defaultCredentials({
+    username,
+    password,
+  }: Credentials): EventStoreConnectionBuilder {
+    this._defaultCredentials = { username, password };
+    return this;
+  }
 
   /**
    * Use an insecure connection to the server. We do not advise using this mode while executing
@@ -119,7 +135,8 @@ export class EventStoreConnectionBuilder {
       {
         endpoint: uri,
       },
-      this.connectionCredentials()
+      this.channelCredentialSettings(),
+      this._defaultCredentials
     );
   }
 
@@ -136,7 +153,8 @@ export class EventStoreConnectionBuilder {
         endpoints,
         nodePreference,
       },
-      this.connectionCredentials()
+      this.channelCredentialSettings(),
+      this._defaultCredentials
     );
   }
 
@@ -153,11 +171,12 @@ export class EventStoreConnectionBuilder {
         domain,
         nodePreference,
       },
-      this.connectionCredentials()
+      this.channelCredentialSettings(),
+      this._defaultCredentials
     );
   }
 
-  private connectionCredentials = (): ConnectionCredentials =>
+  private channelCredentialSettings = (): ChannelCredentialsSettings =>
     this._insecure
       ? { insecure: this._insecure }
       : {
@@ -185,7 +204,7 @@ export type ConnectionSettings =
       endpoint: EndPoint | string;
     };
 
-export type ConnectionCredentials =
+export type ChannelCredentialsSettings =
   | {
       insecure: true;
     }
@@ -198,7 +217,7 @@ export type ConnectionCredentials =
     };
 
 const createGRPCCredentials = (
-  settings: ConnectionCredentials
+  settings: ChannelCredentialsSettings
 ): ChannelCredentials => {
   debug.connection("Using credentials %O", settings);
 
@@ -221,18 +240,23 @@ const createGRPCCredentials = (
  * connection.
  */
 export class EventStoreConnection implements ESDBConnection {
-  private _settings: ConnectionSettings;
-  private _credentials: ChannelCredentials;
+  private _connectionSettings: ConnectionSettings;
+  private _channelCredentials: ChannelCredentials;
+  private _defaultCredentials?: Credentials;
 
   private _channel?: Channel;
   private _clients: Map<ClientConstructor<Client>, Client>;
 
   constructor(
     settings: ConnectionSettings,
-    credentials: ConnectionCredentials
+    channelCredentialsSettings: ChannelCredentialsSettings,
+    defaultCredentials?: Credentials
   ) {
-    this._settings = settings;
-    this._credentials = createGRPCCredentials(credentials);
+    this._connectionSettings = settings;
+    this._channelCredentials = createGRPCCredentials(
+      channelCredentialsSettings
+    );
+    this._defaultCredentials = defaultCredentials;
     this._clients = new Map();
   }
 
@@ -302,9 +326,16 @@ export class EventStoreConnection implements ESDBConnection {
   };
 
   /**
+   * internal access to default credentials
+   */
+  [DEFAULT_CREDENTIALS] = (): Credentials | undefined => {
+    return this._defaultCredentials;
+  };
+
+  /**
    * internal access to grpc client.
    */
-  _client = async <T extends Client>(
+  [CLIENT] = async <T extends Client>(
     Client: ClientConstructor<T>,
     debugName: string
   ): Promise<T> => {
@@ -339,25 +370,27 @@ export class EventStoreConnection implements ESDBConnection {
     const uri = await this.resolveUri();
 
     debug.connection(
-      `Connecting to http${this._credentials._isSecure() ? "" : "s"}://%s`,
+      `Connecting to http${
+        this._channelCredentials._isSecure() ? "" : "s"
+      }://%s`,
       uri
     );
 
-    this._channel = new Channel(uri, this._credentials, {});
+    this._channel = new Channel(uri, this._channelCredentials, {});
 
     return this._channel;
   };
 
   private resolveUri = async (): Promise<string> => {
-    if ("endpoint" in this._settings) {
-      return typeof this._settings.endpoint === "string"
-        ? this._settings.endpoint
-        : `${this._settings.endpoint.address}:${this._settings.endpoint.port}`;
+    if ("endpoint" in this._connectionSettings) {
+      return typeof this._connectionSettings.endpoint === "string"
+        ? this._connectionSettings.endpoint
+        : `${this._connectionSettings.endpoint.address}:${this._connectionSettings.endpoint.port}`;
     }
 
     const { address, port } = await discoverEndpoint(
-      this._settings,
-      this._credentials
+      this._connectionSettings,
+      this._channelCredentials
     );
 
     return `${address}:${port}`;

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -293,6 +293,10 @@ export class EventStoreConnection implements ESDBConnection {
       builder.insecure();
     }
 
+    if (options.defaultCredentials) {
+      builder.defaultCredentials(options.defaultCredentials);
+    }
+
     if (options.dnsDiscover) {
       const { address } = options.hosts[0];
 

--- a/src/connection/parseConnectionString.ts
+++ b/src/connection/parseConnectionString.ts
@@ -1,4 +1,4 @@
-import { EndPoint, NodePreference } from "../types";
+import { Credentials, EndPoint, NodePreference } from "../types";
 import { debug } from "../utils/debug";
 
 const notCurrentlySupported = [
@@ -7,13 +7,7 @@ const notCurrentlySupported = [
   "gossipTimeout",
   "tlsVerifyCert",
   "throwOnAppendFailure",
-  "defaultCredentials",
 ];
-
-interface Credentials {
-  login: string;
-  password: string;
-}
 
 export interface ConnectionOptions {
   dnsDiscover: boolean;
@@ -100,19 +94,14 @@ const parseCredentials = (
 
   if (match.groups?.credentials) {
     nextPosition += match[0].length;
-    const [login, password] = match.groups.credentials.split(":");
-
-    debug.connection(
-      `default credentials are not currently supported by this client, and will have no effect.`
-    );
-
+    const [username, password] = match.groups.credentials.split(":");
     return parseHosts(
       connectionString,
       nextPosition,
       {
         ...options,
         defaultCredentials: {
-          login: decodeURIComponent(login),
+          username: decodeURIComponent(username),
           password: decodeURIComponent(password),
         },
       },

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,0 +1,2 @@
+export const CLIENT = Symbol("client");
+export const DEFAULT_CREDENTIALS = Symbol("default credentials");

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import { Client, ChannelCredentials, ClientOptions } from "@grpc/grpc-js";
 import { MemberInfo as GrpcMemberInfo } from "../generated/gossip_pb";
 import VNodeState = GrpcMemberInfo.VNodeState;
 import * as constants from "./constants";
+import { CLIENT, DEFAULT_CREDENTIALS } from "./symbols";
 export { VNodeState };
 
 /**
@@ -395,6 +396,8 @@ export type MemberInfo = {
   httpEndpoint?: EndPoint;
 };
 
+export type VerifyOptions = Parameters<typeof ChannelCredentials.createSsl>[3];
+
 export type ClientConstructor<T extends Client> = new (
   address: string,
   credentials: ChannelCredentials,
@@ -403,7 +406,8 @@ export type ClientConstructor<T extends Client> = new (
 
 export interface ESDBConnection {
   close(): Promise<void>;
-  _client<T extends Client>(
+  [DEFAULT_CREDENTIALS](): Credentials | undefined;
+  [CLIENT]<T extends Client>(
     c: ClientConstructor<T>,
     debugName: string
   ): Promise<T>;
@@ -422,6 +426,11 @@ export interface SubscriptionListeners<E, R> {
   [constants.CONFIRMATION_EVENT]: () => void;
   [constants.ERROR_EVENT]: (error: Error) => void;
   [constants.CLOSE_EVENT]: () => void;
+}
+
+export interface Credentials {
+  username: string;
+  password: string;
 }
 
 export type Listeners<E, R> = {

--- a/src/utils/CommandError.ts
+++ b/src/utils/CommandError.ts
@@ -349,6 +349,8 @@ export const convertToCommandError = (error: ServiceError): CommandError => {
       return new TimeoutError(error);
     case StatusCode.UNAVAILABLE:
       return new UnavailableError(error);
+    case StatusCode.UNAUTHENTICATED:
+      return new AccessDeniedError(error);
   }
 
   return new UnknownError(error);


### PR DESCRIPTION
- use symbols for access to internal client and credential functions
- propogate across commands
- move tests over to using default credentials
- Map auth error
- add defaultCredentials test

fixes: #62 