### PR TITLE
Reproduction of awaiting an async function in an async iterator

### DIFF
--- a/src/__test__/streams/subscribeToAll.test.ts
+++ b/src/__test__/streams/subscribeToAll.test.ts
@@ -309,7 +309,6 @@ describe("subscribeToAll", () => {
         }
 
         if (event.event?.eventType === 'test') {
-          console.log(event)
           // example of awaiting an async function when iterating over the async iterator
           await delay(10)
         }


### PR DESCRIPTION
Hi,

I'm having trouble awaiting an async function when using an async iterator. After awaiting the function for the first time, the async iterator does not continue and the tests time out.
﻿
Context: writing a projector, so I need to do some async work for every event received.

Adding a reproduction in this PR.
