### PR TITLE
Dont assume that events with contentType `application/json` contain valid json

### DIFF
--- a/src/__test__/streams/readEventsFromStream.test.ts
+++ b/src/__test__/streams/readEventsFromStream.test.ts
@@ -85,7 +85,7 @@ describe("readEventsFromStream", () => {
         expect(event.isJson).toBe(false);
         expect(event.eventType).toBe("binary-test");
 
-        expect(Buffer.from(event.data).toString()).toBe("hello: 1");
+        expect(Buffer.from(event.data as string).toString()).toBe("hello: 1");
       });
     });
 

--- a/src/__test__/streams/subscribeToAll.test.ts
+++ b/src/__test__/streams/subscribeToAll.test.ts
@@ -1,4 +1,10 @@
-import { createTestNode, Defer, delay, testEvents } from "../utils";
+import {
+  createTestNode,
+  Defer,
+  delay,
+  TestEventData,
+  testEvents,
+} from "../utils";
 
 import {
   writeEventsToStream,
@@ -315,7 +321,7 @@ describe("subscribeToAll", () => {
           await delay(10);
 
           if (event.event.isJson) {
-            readEvents.add(event.event.data.index as number);
+            readEvents.add((event.event.data as TestEventData).index);
           }
         }
 

--- a/src/__test__/utils/Cluster.ts
+++ b/src/__test__/utils/Cluster.ts
@@ -75,6 +75,7 @@ const createNodes = (
           `EVENTSTORE_ADVERTISE_HOST_TO_CLIENT_AS=${domain}`,
           `EVENTSTORE_ADVERTISE_HTTP_PORT_TO_CLIENT_AS=${port}`,
           `EVENTSTORE_CLUSTER_SIZE=${internalIPs.length}`,
+          "EVENTSTORE_ENABLE_ATOM_PUB_OVER_HTTP=true",
           "EVENTSTORE_RUN_PROJECTIONS=All",
           "EVENTSTORE_DISCOVER_VIA_DNS=false",
           ...(insecure

--- a/src/__test__/utils/index.ts
+++ b/src/__test__/utils/index.ts
@@ -9,3 +9,4 @@ export const createInsecureTestCluster = (count = 3): Cluster =>
 export * from "./Defer";
 export * from "./delay";
 export * from "./testEvents";
+export * from "./postEventViaHttpApi";

--- a/src/__test__/utils/postEventViaHttpApi.ts
+++ b/src/__test__/utils/postEventViaHttpApi.ts
@@ -1,0 +1,83 @@
+import { request } from "https";
+import { readFileSync } from "fs";
+import { URL } from "url";
+import { Cluster } from "./Cluster";
+import { EndPoint } from "../../types";
+
+interface Options {
+  eventType: string;
+  contentType: string;
+  stream: string;
+  data: unknown;
+}
+
+const convertEndpoint = (endpoint: string | EndPoint, stream: string) => {
+  if (typeof endpoint === "string") {
+    const url = new URL(endpoint);
+
+    return {
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname,
+    };
+  }
+
+  return {
+    hostname: endpoint.address,
+    port: endpoint.port,
+    path: `/streams/${stream}`,
+  };
+};
+
+const post = (
+  endpoint: string | EndPoint,
+  cert: Buffer,
+  options: Options
+): Promise<string> => {
+  const { eventType, contentType, stream, data } = options;
+
+  return new Promise((resolve, reject) => {
+    const req = request(
+      {
+        ...convertEndpoint(endpoint, stream),
+        method: "POST",
+        headers: {
+          "Content-Type": contentType,
+          "ES-EventType": eventType,
+        },
+        ca: [cert],
+      },
+      (res) => {
+        if (res.statusCode === 307) {
+          return resolve(post(res.headers.location!, cert, options));
+        }
+
+        let response = "";
+
+        res.on("data", (d) => {
+          response += d;
+        });
+
+        res.on("end", () => {
+          return resolve(response);
+        });
+      }
+    );
+
+    req.on("error", (error) => {
+      reject(error);
+    });
+
+    req.write(data);
+    req.end();
+  });
+};
+
+export const postEventViaHttpApi = (
+  cluster: Cluster,
+  options: Options
+): Promise<string> => {
+  const [endpoint] = cluster.endpoints;
+  const cert = readFileSync(cluster.certPath);
+  return post(endpoint, cert, options);
+};

--- a/src/__test__/utils/testEvents.ts
+++ b/src/__test__/utils/testEvents.ts
@@ -1,5 +1,10 @@
 import { EventData } from "../..";
 
+export interface TestEventData {
+  message: "test";
+  index: number;
+}
+
 export const testEvents = (count = 4, eventType = "test"): EventData[] =>
   Array.from({ length: count }, (_, i) =>
     EventData.json(eventType, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,7 +112,7 @@ export interface JSONRecordedEvent extends RecordedEventBase {
   /**
    * Payload of this event.
    */
-  data: Record<string, unknown>;
+  data: unknown;
 
   /**
    * Representing the metadata associated with this event.

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -20,10 +20,11 @@ const base = createDebug("esdb");
 const command = base.extend("command");
 const command_grpc = command.extend("grpc");
 const connection = base.extend("connection");
+const events = base.extend("events");
 
 export const debug = {
-  base,
   command,
   command_grpc,
   connection,
+  events,
 };


### PR DESCRIPTION
- catch JSON parsing errors and return raw string
- write a debug message on parsing error

![image](https://user-images.githubusercontent.com/11861797/99420110-222acf80-28fd-11eb-8476-7bac053e2680.png)

fixes: #74 