### PR TITLE
Not leader example and expose subscription types

### DIFF
--- a/src/command/persistentSubscription/ConnectToPersistentSubscription.ts
+++ b/src/command/persistentSubscription/ConnectToPersistentSubscription.ts
@@ -10,6 +10,7 @@ import {
   SubscriptionEvent,
   SubscriptionListeners,
   PersistentReport,
+  PersistentSubscription,
 } from "../../types";
 import { Command } from "../Command";
 import { TwoWaySubscription } from "../../utils/TwoWaySubscription";
@@ -76,7 +77,7 @@ export class ConnectToPersistentSubscription extends Command {
   /**
    * Starts the subscription immediately.
    */
-  async execute(connection: ESDBConnection): Promise<TwoWaySubscription> {
+  async execute(connection: ESDBConnection): Promise<PersistentSubscription> {
     const req = new ReadReq();
     const options = new ReadReq.Options();
     const identifier = new StreamIdentifier();

--- a/src/command/streams/SubscribeToAll.ts
+++ b/src/command/streams/SubscribeToAll.ts
@@ -13,7 +13,7 @@ import {
   SubscriptionEvent,
   SubscriptionListeners,
   SubscriptionReport,
-  Subscription,
+  AllStreamSubscription,
 } from "../../types";
 import { Command } from "../Command";
 import { Filter } from "../../utils/Filter";
@@ -134,9 +134,7 @@ export class SubscribeToAll extends Command {
    * Starts the subscription immediately.
    * @param handler Set of callbacks used during the subscription lifecycle.
    */
-  async execute(
-    connection: ESDBConnection
-  ): Promise<Subscription<AllStreamResolvedEvent, SubscriptionReport>> {
+  async execute(connection: ESDBConnection): Promise<AllStreamSubscription> {
     const req = new ReadReq();
     const options = new ReadReq.Options();
     const uuidOption = new UUIDOption();

--- a/src/command/streams/SubscribeToStream.ts
+++ b/src/command/streams/SubscribeToStream.ts
@@ -11,10 +11,10 @@ import {
   ReadRevision,
   ResolvedEvent,
   SubscriptionReport,
-  Subscription,
   SubscriptionEvent,
   Listeners,
   SubscriptionListeners,
+  StreamSubscription,
 } from "../../types";
 import { Command } from "../Command";
 import { OneWaySubscription } from "../../utils/OneWaySubscription";
@@ -116,9 +116,7 @@ export class SubscribeToStream extends Command {
   /**
    * Starts the subscription immediately.
    */
-  async execute(
-    connection: ESDBConnection
-  ): Promise<Subscription<ResolvedEvent, SubscriptionReport>> {
+  async execute(connection: ESDBConnection): Promise<StreamSubscription> {
     const req = new ReadReq();
     const options = new ReadReq.Options();
     const identifier = new StreamIdentifier();

--- a/src/types.ts
+++ b/src/types.ts
@@ -461,3 +461,15 @@ export interface Subscription<E, R> {
 
   [Symbol.asyncIterator](): AsyncIterator<E>;
 }
+
+export interface PersistentSubscription
+  extends Subscription<ResolvedEvent, PersistentReport>,
+    PersistentReport {}
+
+export interface StreamSubscription
+  extends Subscription<ResolvedEvent, SubscriptionReport>,
+    SubscriptionReport {}
+
+export interface AllStreamSubscription
+  extends Subscription<AllStreamResolvedEvent, SubscriptionReport>,
+    SubscriptionReport {}


### PR DESCRIPTION
- Improve subscription types
  - Spell out the three subscription types in types.ts
  - Expose the subscription types as exports
  - Use new types as return types for commands
- add not-leader error handling example to tests