### PR TITLE
Include debug types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-alpha.9",
   "description": "NodeJS EventStoreDB version 20+ and uses gRPC as the communication protocol.",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "run-s generate build:*",
     "build:ts": "tsc",

--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.1.5",
+    "@types/debug": "^4.1.5",
     "debug": "^4.2.0",
     "google-protobuf": "^3.13.0",
     "uuid": "^8.2.0"
   },
   "devDependencies": {
-    "@types/debug": "^4.1.5",
     "@types/google-protobuf": "^3.7.3",
     "@types/jest": "^26.0.5",
     "@types/uuid": "^8.0.0",


### PR DESCRIPTION
Move debug types to be a dependancy
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#packaging-dependent-declarations
> If your type definitions depend on another package:
> - Don’t combine it with yours, keep each in their own file.
> - Don’t copy the declarations in your package either.
> - Do depend on the npm type declaration package if it doesn’t package its declaration files.

Add `types` field, as recommended by ts
These are currently picked up automatically, but looks like npm will only display that it includes typings if we have the field
https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package


fixes: #91 
