### PR TITLE
Extend Readable in a way that works with different node versions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -419,6 +419,10 @@ export interface ReadableSubscription<E> extends Readable {
   addListener(event: "readable", listener: () => void): this;
   addListener(event: "error", listener: (err: Error) => void): this;
   addListener(event: "confirmation", listener: () => void): this;
+  addListener(
+    event: string | symbol,
+    listener: (...args: unknown[]) => void
+  ): this;
 
   on(event: "close", listener: () => void): this;
   on(event: "data", listener: (event: E) => void): this;
@@ -426,6 +430,7 @@ export interface ReadableSubscription<E> extends Readable {
   on(event: "readable", listener: () => void): this;
   on(event: "error", listener: (err: Error) => void): this;
   on(event: "confirmation", listener: () => void): this;
+  on(event: string | symbol, listener: (...args: unknown[]) => void): this;
 
   once(event: "close", listener: () => void): this;
   once(event: "data", listener: (event: E) => void): this;
@@ -433,6 +438,7 @@ export interface ReadableSubscription<E> extends Readable {
   once(event: "readable", listener: () => void): this;
   once(event: "error", listener: (err: Error) => void): this;
   once(event: "confirmation", listener: () => void): this;
+  once(event: string | symbol, listener: (...args: unknown[]) => void): this;
 
   prependListener(event: "close", listener: () => void): this;
   prependListener(event: "data", listener: (event: E) => void): this;
@@ -440,6 +446,10 @@ export interface ReadableSubscription<E> extends Readable {
   prependListener(event: "readable", listener: () => void): this;
   prependListener(event: "error", listener: (err: Error) => void): this;
   prependListener(event: "confirmation", listener: () => void): this;
+  prependListener(
+    event: string | symbol,
+    listener: (...args: unknown[]) => void
+  ): this;
 
   prependOnceListener(event: "close", listener: () => void): this;
   prependOnceListener(event: "data", listener: (event: E) => void): this;
@@ -447,6 +457,10 @@ export interface ReadableSubscription<E> extends Readable {
   prependOnceListener(event: "readable", listener: () => void): this;
   prependOnceListener(event: "error", listener: (err: Error) => void): this;
   prependOnceListener(event: "confirmation", listener: () => void): this;
+  prependOnceListener(
+    event: string | symbol,
+    listener: (...args: unknown[]) => void
+  ): this;
 
   removeListener(event: "close", listener: () => void): this;
   removeListener(event: "data", listener: (event: E) => void): this;
@@ -454,6 +468,10 @@ export interface ReadableSubscription<E> extends Readable {
   removeListener(event: "readable", listener: () => void): this;
   removeListener(event: "error", listener: (err: Error) => void): this;
   removeListener(event: "confirmation", listener: () => void): this;
+  removeListener(
+    event: string | symbol,
+    listener: (...args: unknown[]) => void
+  ): this;
 
   [Symbol.asyncIterator](): AsyncIterableIterator<E>;
 }


### PR DESCRIPTION
Build fails when consuming package depends on `@types/node`: `13.x`, due to the addition of "pause" event in newer version of Readable.

 