### PR TITLE
Renamed "payload" to "data", "eventType" to "type" to align with the .NET Client naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,21 @@ $ yarn build
 ## Run tests
 
 Tests are written using [Jest] and require [Docker] and [Docker Compose] to be installed.
-To access the github packages docker images, you need to [authenticate docker with a gitub personal access token].
+To access the github packages docker images, you need to authenticate docker with a gitub personal access token. It should be [generated](https://github.com/settings/tokens/new). Select at least following scopes:
+- `repo`
+- `read:packages`
+- `write:packages`
+
+Then login to github docker registry with:
+```shell script
+$ docker login https://docker.pkg.github.com -u YOUR_GITHUB_USERNAME
+```
+
+and providing your personal access token as a password. 
+
+Check full instructions in the ["Authenticating to GitHub packages"](https://docs.github.com/en/free-pro-team@latest/packages/guides/configuring-docker-for-use-with-github-packages#authenticating-to-github-packages) guide.
+
+Then run test with:
 
 ```shell script
 $ yarn test

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ async function simpleTest() {
   const streamName = "es_supported_clients";
 
   const event = jsonEvent({
-    eventType: "grpc-client",
-    payload: {
+    type: "grpc-client",
+    data: {
       languages: ["typescript", "javascript"],
       runtime: "NodeJS",
     },
@@ -84,8 +84,8 @@ async function simpleTest(): Promise<void> {
   const streamName = "es_supported_clients";
 
   const event = jsonEvent({
-    eventType: "grpc-client",
-    payload: {
+    type: "grpc-client",
+    data: {
       languages: ["typescript", "javascript"],
       runtime: "NodeJS",
     },

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The following snippet showcases a simple example where we form a connection, the
 const {
   EventStoreDBClient,
   jsonEvent,
-  FORWARD,
+  FORWARDS,
   START,
 } = require("@eventstore/db-client");
 
@@ -59,7 +59,7 @@ async function simpleTest() {
 
   const events = await client.readStream(streamName, 10, {
     fromRevision: START,
-    direction: FORWARD,
+    direction: FORWARDS,
   });
 
   events.forEach(doSomethingProductive);
@@ -72,7 +72,7 @@ async function simpleTest() {
 import {
   EventStoreDBClient,
   jsonEvent,
-  FORWARD,
+  FORWARDS,
   START,
 } from "@eventstore/db-client";
 
@@ -95,7 +95,7 @@ async function simpleTest(): Promise<void> {
 
   const events = await client.readStream(streamName, 10, {
     fromRevision: START,
-    direction: FORWARD,
+    direction: FORWARDS,
   });
 
   events.forEach(doSomethingProductive);

--- a/src/__test__/connection/cluster.test.ts
+++ b/src/__test__/connection/cluster.test.ts
@@ -5,7 +5,7 @@ import { jsonEvent, EventStoreDBClient } from "../..";
 describe("cluster", () => {
   const cluster = createTestCluster();
   const STREAM_NAME = "test_stream_name";
-  const event = jsonEvent({ eventType: "test", payload: { message: "test" } });
+  const event = jsonEvent({ type: "test", data: { message: "test" } });
 
   beforeAll(async () => {
     await cluster.up();

--- a/src/__test__/connection/connectionString.test.ts
+++ b/src/__test__/connection/connectionString.test.ts
@@ -7,7 +7,7 @@ describe("connectionString", () => {
   const cluster = createInsecureTestCluster();
 
   const testEvent = () =>
-    jsonEvent({ eventType: "test", payload: { message: "test" } });
+    jsonEvent({ type: "test", data: { message: "test" } });
 
   beforeAll(async () => {
     await node.up();

--- a/src/__test__/connection/connectionStringMockups.ts
+++ b/src/__test__/connection/connectionStringMockups.ts
@@ -1,9 +1,8 @@
 import { ConnectionOptions } from "../../Client/parseConnectionString";
 
-export const valid: Array<[
-  connectionString: string,
-  expected: ConnectionOptions
-]> = [
+export const valid: Array<
+  [connectionString: string, expected: ConnectionOptions]
+> = [
   [
     "esdb://localhost",
     {
@@ -451,10 +450,9 @@ export const invalid: string[] = [
   "esdb://localhost?throwOnAppendFailure=sometimes",
 ];
 
-export const warning: Array<[
-  connectionString: string,
-  expected: ConnectionOptions
-]> = [
+export const warning: Array<
+  [connectionString: string, expected: ConnectionOptions]
+> = [
   [
     "esdb://localhost?catchOnAppendFailure=true&tlsVerifyCert=false",
     {

--- a/src/__test__/connection/connectionStringMockups.ts
+++ b/src/__test__/connection/connectionStringMockups.ts
@@ -1,8 +1,9 @@
 import { ConnectionOptions } from "../../Client/parseConnectionString";
 
-export const valid: Array<
-  [connectionString: string, expected: ConnectionOptions]
-> = [
+export const valid: Array<[
+  connectionString: string,
+  expected: ConnectionOptions
+]> = [
   [
     "esdb://localhost",
     {
@@ -450,9 +451,10 @@ export const invalid: string[] = [
   "esdb://localhost?throwOnAppendFailure=sometimes",
 ];
 
-export const warning: Array<
-  [connectionString: string, expected: ConnectionOptions]
-> = [
+export const warning: Array<[
+  connectionString: string,
+  expected: ConnectionOptions
+]> = [
   [
     "esdb://localhost?catchOnAppendFailure=true&tlsVerifyCert=false",
     {

--- a/src/__test__/connection/dns.test.ts
+++ b/src/__test__/connection/dns.test.ts
@@ -11,8 +11,8 @@ optionalDescribe(!!process.env.EVENTSTORE_CLOUD_ID)("dns discover", () => {
   const STREAM_NAME = "test_stream_name";
   const { EVENTSTORE_CLOUD_ID } = process.env;
   const event = jsonEvent({
-    eventType: "test",
-    payload: { message: "test" },
+    type: "test",
+    data: { message: "test" },
   });
 
   describe.each([

--- a/src/__test__/connection/insecure.test.ts
+++ b/src/__test__/connection/insecure.test.ts
@@ -5,7 +5,7 @@ import { EventStoreDBClient, jsonEvent } from "../..";
 describe("insecure", () => {
   const node = createInsecureTestNode();
   const STREAM_NAME = "test_stream_name";
-  const event = jsonEvent({ eventType: "test", payload: { message: "test" } });
+  const event = jsonEvent({ type: "test", data: { message: "test" } });
 
   beforeAll(async () => {
     await node.up();

--- a/src/__test__/connection/not-leader.test.ts
+++ b/src/__test__/connection/not-leader.test.ts
@@ -12,7 +12,7 @@ import { BACKWARD, END } from "../../constants";
 describe("not-leader", () => {
   const cluster = createTestCluster();
   const STREAM_NAME = "test_stream_name";
-  const event = jsonEvent({ eventType: "test", payload: { message: "test" } });
+  const event = jsonEvent({ type: "test", data: { message: "test" } });
 
   beforeAll(async () => {
     await cluster.up();

--- a/src/__test__/connection/not-leader.test.ts
+++ b/src/__test__/connection/not-leader.test.ts
@@ -7,7 +7,7 @@ import {
   NotLeaderError,
   EventStoreDBClient,
 } from "../..";
-import { BACKWARD, END } from "../../constants";
+import { BACKWARDS, END } from "../../constants";
 
 describe("not-leader", () => {
   const cluster = createTestCluster();
@@ -40,7 +40,7 @@ describe("not-leader", () => {
 
     const readFromTestStream = (client: EventStoreDBClient) => {
       return client.readStream(STREAM_NAME, 10, {
-        direction: BACKWARD,
+        direction: BACKWARDS,
         fromRevision: END,
         requiresLeader: true,
       });

--- a/src/__test__/connection/singleNode.test.ts
+++ b/src/__test__/connection/singleNode.test.ts
@@ -5,7 +5,7 @@ import { EventStoreDBClient, jsonEvent } from "../..";
 describe("singleNodeConnection", () => {
   const node = createTestNode();
   const STREAM_NAME = "test_stream_name";
-  const event = jsonEvent({ eventType: "test", payload: { message: "test" } });
+  const event = jsonEvent({ type: "test", data: { message: "test" } });
 
   beforeAll(async () => {
     await node.up();

--- a/src/__test__/persistentSubscription/connectToPersistentSubscription.test.ts
+++ b/src/__test__/persistentSubscription/connectToPersistentSubscription.test.ts
@@ -26,8 +26,8 @@ describe("connectToPersistentSubscription", () => {
 
   const finishEvent = () =>
     jsonEvent({
-      eventType: "finish-test",
-      payload: {
+      type: "finish-test",
+      data: {
         message: "lets wrap this up",
       },
     });
@@ -73,7 +73,7 @@ describe("connectToPersistentSubscription", () => {
           await subscription.ack(event.event.id);
         }
 
-        if (event.event?.eventType === "finish-test") {
+        if (event.event?.type === "finish-test") {
           defer.resolve();
         }
       });
@@ -126,7 +126,7 @@ describe("connectToPersistentSubscription", () => {
           await subscription.ack(event.event.id);
         }
 
-        if (event.event?.eventType === "finish-test") {
+        if (event.event?.type === "finish-test") {
           defer.resolve();
         }
       });
@@ -189,7 +189,7 @@ describe("connectToPersistentSubscription", () => {
       const onEvent = jest.fn(async (event: ResolvedEvent) => {
         if (!event.event) return;
 
-        if (event.event.eventType === "finish-test") {
+        if (event.event.type === "finish-test") {
           await subscription.ack(event.event.id);
           defer.resolve();
           return;
@@ -198,7 +198,7 @@ describe("connectToPersistentSubscription", () => {
         if (!nacked.includes(event.event.id)) {
           nacked.push(event.event.id);
           await subscription.nack(
-            event.event.eventType === "skip-event" ? "skip" : "retry",
+            event.event.type === "skip-event" ? "skip" : "retry",
             "To test it",
             event.event.id
           );
@@ -262,7 +262,7 @@ describe("connectToPersistentSubscription", () => {
           doSomething(event);
           await subscription.ack(event.id);
 
-          if (event?.eventType === "finish-test") {
+          if (event?.type === "finish-test") {
             break;
           }
         }
@@ -305,7 +305,7 @@ describe("connectToPersistentSubscription", () => {
 
           doSomething(event);
 
-          if (event.eventType === "finish-test") {
+          if (event.type === "finish-test") {
             await subscription.ack(event.id);
             break;
           }
@@ -313,7 +313,7 @@ describe("connectToPersistentSubscription", () => {
           if (!nacked.includes(event.id)) {
             nacked.push(event.id);
             await subscription.nack(
-              event.eventType === "skip-event" ? "skip" : "retry",
+              event.type === "skip-event" ? "skip" : "retry",
               "To test it",
               event.id
             );
@@ -357,7 +357,7 @@ describe("connectToPersistentSubscription", () => {
         for await (const { event } of subscription) {
           if (!event) continue;
 
-          if (event?.eventType === "test") {
+          if (event?.type === "test") {
             // example of awaiting an async function when iterating over the async iterator
             await delay(10);
           }
@@ -366,7 +366,7 @@ describe("connectToPersistentSubscription", () => {
 
           await subscription.ack(event.id);
 
-          if (event?.eventType === "finish-test") {
+          if (event?.type === "finish-test") {
             break;
           }
         }
@@ -406,7 +406,7 @@ describe("connectToPersistentSubscription", () => {
           eventListenerTwo(event);
           await subscription.ack(event.id);
 
-          if (event.eventType === "finish-test") {
+          if (event.type === "finish-test") {
             subscription.unsubscribe();
           }
         })
@@ -438,8 +438,8 @@ describe("connectToPersistentSubscription", () => {
       await client.appendToStream(STREAM_NAME, [
         ...jsonTestEvents(8),
         jsonEvent({
-          eventType: FINISH_TEST,
-          payload: {
+          type: FINISH_TEST,
+          data: {
             message: "lets wrap this up",
           },
         }),
@@ -466,7 +466,7 @@ describe("connectToPersistentSubscription", () => {
         public ids: string[] = [];
         _write({ event }: ResolvedEvent, _encoding: string, done: () => void) {
           this.ids.push(event!.id);
-          if (event?.eventType === FINISH_TEST) {
+          if (event?.type === FINISH_TEST) {
             subscription.unsubscribe().then(done);
           } else {
             done();
@@ -497,7 +497,7 @@ describe("connectToPersistentSubscription", () => {
 
     await postEventViaHttpApi(cluster, {
       contentType: "application/json",
-      eventType: "malformed-event",
+      type: "malformed-event",
       stream: STREAM_NAME,
       data: malformedData,
     });
@@ -518,11 +518,11 @@ describe("connectToPersistentSubscription", () => {
       doSomething(event);
       await subscription.ack(event.id);
 
-      if (event.eventType === "malformed-event") {
+      if (event.type === "malformed-event") {
         expect(event.data).toBe(malformedData);
       }
 
-      if (event.eventType === "finish-test") {
+      if (event.type === "finish-test") {
         break;
       }
     }
@@ -595,7 +595,7 @@ describe("connectToPersistentSubscription", () => {
       doSomething(event);
       await subscription.ack(event.id);
 
-      if (event?.eventType === "finish-test") {
+      if (event?.type === "finish-test") {
         break;
       }
     }

--- a/src/__test__/projections/getProjectionResult.test.ts
+++ b/src/__test__/projections/getProjectionResult.test.ts
@@ -95,10 +95,10 @@ describe("getProjectionResult", () => {
           });
       `;
 
-      const createCatEvent = (catName: string, eventType: string) => {
+      const createCatEvent = (catName: string, type: string) => {
         return jsonEvent({
-          eventType,
-          payload: {
+          type,
+          data: {
             catName,
           },
         });

--- a/src/__test__/streams/appendToStream.test.ts
+++ b/src/__test__/streams/appendToStream.test.ts
@@ -47,8 +47,8 @@ describe("appendToStream", () => {
       const STREAM_NAME = "json_metadata_stream_name";
       const METADATA = { metaMessage: "How meta is this?" };
       const event = jsonEvent({
-        eventType: "metadata-test-json",
-        payload: {
+        type: "metadata-test-json",
+        data: {
           message: "the json message",
           kind: "json",
         },
@@ -74,8 +74,8 @@ describe("appendToStream", () => {
       const METADATA = "How meta is this?";
 
       const event = binaryEvent({
-        eventType: "metadata-test-binary",
-        payload: Buffer.from("the binary message"),
+        type: "metadata-test-binary",
+        data: Buffer.from("the binary message"),
         metadata: Buffer.from(METADATA),
       });
 

--- a/src/__test__/streams/deleteStream.test.ts
+++ b/src/__test__/streams/deleteStream.test.ts
@@ -6,6 +6,7 @@ import {
   NO_STREAM,
   StreamNotFoundError,
 } from "../..";
+import { BACKWARDS } from "../../constants";
 
 describe("deleteStream", () => {
   const node = createTestNode();
@@ -68,7 +69,7 @@ describe("deleteStream", () => {
 
         it("succeeds", async () => {
           const events = await client.readStream(STREAM, 1, {
-            direction: "backward",
+            direction: BACKWARDS,
             fromRevision: "end",
           });
 

--- a/src/__test__/streams/readAll.test.ts
+++ b/src/__test__/streams/readAll.test.ts
@@ -1,6 +1,6 @@
 import { createTestNode, jsonTestEvents } from "../utils";
 
-import { EventStoreDBClient, BACKWARD, END, START } from "../..";
+import { EventStoreDBClient, BACKWARDS, END, START } from "../..";
 
 describe("readAll", () => {
   const node = createTestNode();
@@ -52,9 +52,9 @@ describe("readAll", () => {
       expect(extracted).toEqual(eventToExtract);
     });
 
-    test("backward from end", async () => {
+    test("backwards from end", async () => {
       const events = await client.readAll(Number.MAX_SAFE_INTEGER, {
-        direction: BACKWARD,
+        direction: BACKWARDS,
         fromPosition: END,
       });
 

--- a/src/__test__/streams/readStream.test.ts
+++ b/src/__test__/streams/readStream.test.ts
@@ -1,6 +1,6 @@
 import { binaryTestEvents, createTestNode, jsonTestEvents } from "../utils";
 
-import { EventStoreDBClient, BACKWARD, END } from "../..";
+import { EventStoreDBClient, BACKWARDS, END } from "../..";
 
 describe("readStream", () => {
   const node = createTestNode();
@@ -84,12 +84,12 @@ describe("readStream", () => {
         expect(events.length).toBe(7);
       });
 
-      test("backward from end", async () => {
+      test("backwards from end", async () => {
         const events = await client.readStream(
           STREAM_NAME,
           Number.MAX_SAFE_INTEGER,
           {
-            direction: BACKWARD,
+            direction: BACKWARDS,
             fromRevision: END,
           }
         );
@@ -97,12 +97,12 @@ describe("readStream", () => {
         expect(events.length).toBe(8);
       });
 
-      test("backward from revision", async () => {
+      test("backwards from revision", async () => {
         const events = await client.readStream(
           STREAM_NAME,
           Number.MAX_SAFE_INTEGER,
           {
-            direction: BACKWARD,
+            direction: BACKWARDS,
             fromRevision: BigInt(1),
           }
         );

--- a/src/__test__/streams/readStream.test.ts
+++ b/src/__test__/streams/readStream.test.ts
@@ -41,7 +41,7 @@ describe("readStream", () => {
         const event = resolvedEvent.event!;
 
         expect(event.isJson).toBe(true);
-        expect(event.eventType).toBe("json-test");
+        expect(event.type).toBe("json-test");
         expect(event.data).toMatchObject({
           index: 1,
           message: "test",
@@ -56,7 +56,7 @@ describe("readStream", () => {
         const event = resolvedEvent.event!;
 
         expect(event.isJson).toBe(false);
-        expect(event.eventType).toBe("binary-test");
+        expect(event.type).toBe("binary-test");
 
         expect(Buffer.from(event.data as string).toString()).toBe("hello: 1");
       });

--- a/src/__test__/streams/subscribeToAll.test.ts
+++ b/src/__test__/streams/subscribeToAll.test.ts
@@ -52,11 +52,11 @@ describe("subscribeToAll", () => {
       const onEvent = jest.fn(async (event: ResolvedEvent) => {
         events.push(event);
 
-        if (!event.event?.eventType.startsWith("$")) {
+        if (!event.event?.type.startsWith("$")) {
           filteredEvents.push(event);
         }
 
-        if (event.event?.eventType === FINISH_TEST) {
+        if (event.event?.type === FINISH_TEST) {
           subscription.unsubscribe();
         }
       });
@@ -70,8 +70,8 @@ describe("subscribeToAll", () => {
         .on("end", onEnd);
 
       const finishEvent = jsonEvent({
-        eventType: FINISH_TEST,
-        payload: {
+        type: FINISH_TEST,
+        data: {
           message: "lets wrap this up",
         },
       });
@@ -109,11 +109,11 @@ describe("subscribeToAll", () => {
       const onEvent = jest.fn((event: ResolvedEvent) => {
         events.push(event);
 
-        if (!event.event?.eventType.startsWith("$")) {
+        if (!event.event?.type.startsWith("$")) {
           filteredEvents.push(event);
         }
 
-        if (event.event?.eventType === FINISH_TEST) {
+        if (event.event?.type === FINISH_TEST) {
           subscription.unsubscribe();
         }
       });
@@ -127,8 +127,8 @@ describe("subscribeToAll", () => {
         .on("end", onEnd);
 
       const finishEvent = jsonEvent({
-        eventType: FINISH_TEST,
-        payload: {
+        type: FINISH_TEST,
+        data: {
           message: "lets wrap this up",
         },
       });
@@ -160,8 +160,8 @@ describe("subscribeToAll", () => {
       const appendResult = await client.appendToStream(
         STREAM_NAME_B,
         jsonEvent({
-          eventType: MARKER_EVENT,
-          payload: { message: "mark my words" },
+          type: MARKER_EVENT,
+          data: { message: "mark my words" },
         })
       );
 
@@ -179,11 +179,11 @@ describe("subscribeToAll", () => {
       const onEvent = jest.fn((event: ResolvedEvent) => {
         events.push(event);
 
-        if (!event.event?.eventType.startsWith("$")) {
+        if (!event.event?.type.startsWith("$")) {
           filteredEvents.push(event);
         }
 
-        if (event.event?.eventType === FINISH_TEST) {
+        if (event.event?.type === FINISH_TEST) {
           subscription.unsubscribe();
         }
       });
@@ -199,8 +199,8 @@ describe("subscribeToAll", () => {
         .on("end", onEnd);
 
       const finishEvent = jsonEvent({
-        eventType: FINISH_TEST,
-        payload: {
+        type: FINISH_TEST,
+        data: {
           message: "lets wrap this up",
         },
       });
@@ -232,15 +232,15 @@ describe("subscribeToAll", () => {
       const doSomethingElse = jest.fn();
 
       const markerEvent = jsonEvent({
-        eventType: MARKER_EVENT,
-        payload: {
+        type: MARKER_EVENT,
+        data: {
           message: "mark",
         },
       });
 
       const finishEvent = jsonEvent({
-        eventType: FINISH_TEST,
-        payload: {
+        type: FINISH_TEST,
+        data: {
           message: "lets wrap this up",
         },
       });
@@ -259,11 +259,11 @@ describe("subscribeToAll", () => {
       for await (const event of subscription) {
         doSomething(event);
 
-        if (!event.event?.eventType.startsWith("$")) {
+        if (!event.event?.type.startsWith("$")) {
           doSomethingElse(event);
         }
 
-        if (event.event?.eventType === FINISH_TEST) {
+        if (event.event?.type === FINISH_TEST) {
           break;
         }
       }
@@ -280,15 +280,15 @@ describe("subscribeToAll", () => {
       const doSomethingElse = jest.fn();
 
       const markerEvent = jsonEvent({
-        eventType: MARKER_EVENT,
-        payload: {
+        type: MARKER_EVENT,
+        data: {
           message: "mark",
         },
       });
 
       const finishEvent = jsonEvent({
-        eventType: FINISH_TEST,
-        payload: {
+        type: FINISH_TEST,
+        data: {
           message: "lets wrap this up",
         },
       });
@@ -309,11 +309,11 @@ describe("subscribeToAll", () => {
       for await (const event of subscription) {
         doSomething(event);
 
-        if (!event.event?.eventType.startsWith("$")) {
+        if (!event.event?.type.startsWith("$")) {
           doSomethingElse(event);
         }
 
-        if (event.event?.eventType === "test") {
+        if (event.event?.type === "test") {
           // example of awaiting an async function when iterating over the async iterator
           await delay(10);
 
@@ -322,7 +322,7 @@ describe("subscribeToAll", () => {
           }
         }
 
-        if (event.event?.eventType === FINISH_TEST) {
+        if (event.event?.type === FINISH_TEST) {
           break;
         }
       }
@@ -339,15 +339,15 @@ describe("subscribeToAll", () => {
       const MARKER_EVENT = "after_the_fact_marker";
 
       const markerEvent = jsonEvent({
-        eventType: MARKER_EVENT,
-        payload: {
+        type: MARKER_EVENT,
+        data: {
           message: "mark",
         },
       });
 
       const finishEvent = jsonEvent({
-        eventType: FINISH_TEST,
-        payload: {
+        type: FINISH_TEST,
+        data: {
           message: "lets wrap this up",
         },
       });
@@ -375,7 +375,7 @@ describe("subscribeToAll", () => {
         .on("data", (event) => {
           eventListenerTwo(event);
 
-          if (event.event?.eventType === FINISH_TEST) {
+          if (event.event?.type === FINISH_TEST) {
             subscription.unsubscribe();
           }
         })
@@ -405,8 +405,8 @@ describe("subscribeToAll", () => {
       await client.appendToStream(STREAM_NAME, [
         ...jsonTestEvents(8),
         jsonEvent({
-          eventType: FINISH_TEST,
-          payload: {
+          type: FINISH_TEST,
+          data: {
             message: "lets wrap this up",
           },
         }),
@@ -418,7 +418,7 @@ describe("subscribeToAll", () => {
         public ids: string[] = [];
         _write({ event }: ResolvedEvent, _encoding: string, done: () => void) {
           this.ids.push(event!.id);
-          if (event?.eventType === FINISH_TEST) {
+          if (event?.type === FINISH_TEST) {
             subscription.unsubscribe().then(done);
           } else {
             done();

--- a/src/__test__/streams/subscribeToStream.test.ts
+++ b/src/__test__/streams/subscribeToStream.test.ts
@@ -12,8 +12,8 @@ describe("subscribeToStream", () => {
 
   const finishEvent = () =>
     jsonEvent({
-      eventType: "finish-test",
-      payload: {
+      type: "finish-test",
+      data: {
         message: "lets wrap this up",
       },
     });
@@ -46,7 +46,7 @@ describe("subscribeToStream", () => {
       const handleConfirmation = jest.fn();
       const handleEnd = jest.fn(defer.resolve);
       const handleEvent = jest.fn((event: ResolvedEvent) => {
-        if (event.event?.eventType === "finish-test") {
+        if (event.event?.type === "finish-test") {
           subscription.unsubscribe();
         }
       });
@@ -86,7 +86,7 @@ describe("subscribeToStream", () => {
       const handleConfirmation = jest.fn();
       const handleEnd = jest.fn(defer.resolve);
       const handleEvent = jest.fn((event: ResolvedEvent) => {
-        if (event.event?.eventType === "finish-test") {
+        if (event.event?.type === "finish-test") {
           subscription.unsubscribe();
         }
       });
@@ -129,7 +129,7 @@ describe("subscribeToStream", () => {
       const handleConfirmation = jest.fn();
       const handleEnd = jest.fn(defer.resolve);
       const handleEvent = jest.fn((event: ResolvedEvent) => {
-        if (event.event?.eventType === "finish-test") {
+        if (event.event?.type === "finish-test") {
           subscription.unsubscribe();
         }
       });
@@ -174,7 +174,7 @@ describe("subscribeToStream", () => {
       for await (const event of client.subscribeToStream(STREAM_NAME)) {
         doSomething(event);
 
-        if (event.event?.eventType === "finish-test") {
+        if (event.event?.type === "finish-test") {
           break;
         }
       }
@@ -196,7 +196,7 @@ describe("subscribeToStream", () => {
         public ids: string[] = [];
         _write({ event }: ResolvedEvent, _encoding: string, done: () => void) {
           this.ids.push(event!.id);
-          if (event?.eventType === "finish-test") {
+          if (event?.type === "finish-test") {
             subscription.unsubscribe().then(done);
           } else {
             done();

--- a/src/__test__/streams/tombstoneStream.test.ts
+++ b/src/__test__/streams/tombstoneStream.test.ts
@@ -6,7 +6,7 @@ import {
   NO_STREAM,
   EventStoreDBClient,
 } from "../..";
-import { BACKWARD, END } from "../../constants";
+import { BACKWARDS, END } from "../../constants";
 
 describe("tombstoneStream", () => {
   describe("should successfully tombstone a stream", () => {
@@ -76,7 +76,7 @@ describe("tombstoneStream", () => {
 
         it("succeeds", async () => {
           const [resolvedEvent] = await client.readStream(STREAM, 1, {
-            direction: BACKWARD,
+            direction: BACKWARDS,
             fromRevision: END,
           });
 

--- a/src/__test__/utils/postEventViaHttpApi.ts
+++ b/src/__test__/utils/postEventViaHttpApi.ts
@@ -5,7 +5,7 @@ import { Cluster } from "./Cluster";
 import { EndPoint } from "../../types";
 
 interface Options {
-  eventType: string;
+  type: string;
   contentType: string;
   stream: string;
   data: unknown;
@@ -34,7 +34,7 @@ const post = (
   cert: Buffer,
   options: Options
 ): Promise<string> => {
-  const { eventType, contentType, stream, data } = options;
+  const { type, contentType, stream, data } = options;
 
   return new Promise((resolve, reject) => {
     const req = request(
@@ -43,7 +43,7 @@ const post = (
         method: "POST",
         headers: {
           "Content-Type": contentType,
-          "ES-EventType": eventType,
+          "ES-EventType": type,
         },
         ca: [cert],
       },

--- a/src/__test__/utils/postEventViaHttpApi.ts
+++ b/src/__test__/utils/postEventViaHttpApi.ts
@@ -43,7 +43,7 @@ const post = (
         method: "POST",
         headers: {
           "Content-Type": contentType,
-          "ES-EventType": type,
+          "ES-Type": type,
         },
         ca: [cert],
       },

--- a/src/__test__/utils/postEventViaHttpApi.ts
+++ b/src/__test__/utils/postEventViaHttpApi.ts
@@ -43,7 +43,7 @@ const post = (
         method: "POST",
         headers: {
           "Content-Type": contentType,
-          "ES-Type": type,
+          "ES-EventType": type,
         },
         ca: [cert],
       },

--- a/src/__test__/utils/testEvents.ts
+++ b/src/__test__/utils/testEvents.ts
@@ -5,21 +5,21 @@ export interface TestEventData {
   index: number;
 }
 
-export const jsonTestEvents = (count = 4, eventType = "test"): EventData[] =>
+export const jsonTestEvents = (count = 4, type = "test"): EventData[] =>
   Array.from({ length: count }, (_, i) =>
     jsonEvent({
-      eventType,
-      payload: {
+      type,
+      data: {
         message: "test",
         index: i,
       },
     })
   );
 
-export const binaryTestEvents = (count = 4, eventType = "test"): EventData[] =>
+export const binaryTestEvents = (count = 4, type = "test"): EventData[] =>
   Array.from({ length: count }, (_, i) =>
     binaryEvent({
-      eventType,
-      payload: Buffer.from(`hello: ${i}`),
+      type,
+      data: Buffer.from(`hello: ${i}`),
     })
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,8 +8,8 @@ export const START = "start";
 export const END = "end";
 
 // directions
-export const FORWARD = "forward";
-export const BACKWARD = "backward";
+export const FORWARDS = "forwards";
+export const BACKWARDS = "backwards";
 
 // node Preference
 export const RANDOM = "random";

--- a/src/events/binaryEvent.ts
+++ b/src/events/binaryEvent.ts
@@ -1,14 +1,14 @@
 import { v4 as uuid } from "uuid";
 
-export interface BinaryEventData<EventType extends string = string> {
+export interface BinaryEventData<Type extends string = string> {
   id: string;
   contentType: "application/octet-stream";
-  type: EventType;
+  type: Type;
   data: Uint8Array;
   metadata?: Uint8Array;
 }
 
-export interface BinaryEventOptions<EventType extends string = string> {
+export interface BinaryEventOptions<Type extends string = string> {
   /**
    * The id to this event. By default, the id will be generated.
    */
@@ -16,7 +16,7 @@ export interface BinaryEventOptions<EventType extends string = string> {
   /**
    * The event type
    */
-  type: EventType;
+  type: Type;
   /**
    * The binary data of the event
    */
@@ -27,12 +27,12 @@ export interface BinaryEventOptions<EventType extends string = string> {
   metadata?: Uint8Array | Buffer;
 }
 
-export const binaryEvent = <EventType extends string = string>({
+export const binaryEvent = <Type extends string = string>({
   type,
   data,
   metadata,
   id = uuid(),
-}: BinaryEventOptions<EventType>): BinaryEventData<EventType> => ({
+}: BinaryEventOptions<Type>): BinaryEventData<Type> => ({
   id,
   contentType: "application/octet-stream",
   type,

--- a/src/events/binaryEvent.ts
+++ b/src/events/binaryEvent.ts
@@ -3,8 +3,8 @@ import { v4 as uuid } from "uuid";
 export interface BinaryEventData<EventType extends string = string> {
   id: string;
   contentType: "application/octet-stream";
-  eventType: EventType;
-  payload: Uint8Array;
+  type: EventType;
+  data: Uint8Array;
   metadata?: Uint8Array;
 }
 
@@ -16,11 +16,11 @@ export interface BinaryEventOptions<EventType extends string = string> {
   /**
    * The event type
    */
-  eventType: EventType;
+  type: EventType;
   /**
-   * The binary payload of the event
+   * The binary data of the event
    */
-  payload: Uint8Array | Buffer;
+  data: Uint8Array | Buffer;
   /**
    * The binary metadata of the event
    */
@@ -28,14 +28,14 @@ export interface BinaryEventOptions<EventType extends string = string> {
 }
 
 export const binaryEvent = <EventType extends string = string>({
-  eventType,
-  payload,
+  type,
+  data,
   metadata,
   id = uuid(),
 }: BinaryEventOptions<EventType>): BinaryEventData<EventType> => ({
   id,
   contentType: "application/octet-stream",
-  eventType,
-  payload: Uint8Array.from(payload),
+  type,
+  data: Uint8Array.from(data),
   metadata: metadata ? Uint8Array.from(metadata) : undefined,
 });

--- a/src/events/jsonEvent.ts
+++ b/src/events/jsonEvent.ts
@@ -3,19 +3,19 @@ import { v4 as uuid } from "uuid";
 export type JSONType = Record<string | number, unknown> | unknown[];
 
 export interface JSONEventData<
-  EventType extends string = string,
+  Type extends string = string,
   Data extends JSONType = JSONType,
   Metadata extends JSONType = JSONType
 > {
   id: string;
   contentType: "application/json";
-  type: EventType;
+  type: Type;
   data: Data;
   metadata?: Metadata;
 }
 
 export interface JSONEventOptions<
-  EventType extends string = string,
+  Type extends string = string,
   Data extends JSONType = JSONType,
   Metadata extends JSONType = JSONType
 > {
@@ -26,7 +26,7 @@ export interface JSONEventOptions<
   /**
    * The event type
    */
-  type: EventType;
+  type: Type;
   /**
    * The data of the event
    */
@@ -38,7 +38,7 @@ export interface JSONEventOptions<
 }
 
 export const jsonEvent = <
-  EventType extends string = string,
+  Type extends string = string,
   Data extends JSONType = JSONType,
   Metadata extends JSONType = JSONType
 >({
@@ -46,8 +46,8 @@ export const jsonEvent = <
   data,
   metadata,
   id = uuid(),
-}: JSONEventOptions<EventType, Data, Metadata>): JSONEventData<
-  EventType,
+}: JSONEventOptions<Type, Data, Metadata>): JSONEventData<
+  Type,
   Data,
   Metadata
 > => ({

--- a/src/events/jsonEvent.ts
+++ b/src/events/jsonEvent.ts
@@ -9,8 +9,8 @@ export interface JSONEventData<
 > {
   id: string;
   contentType: "application/json";
-  eventType: EventType;
-  payload: Data;
+  type: EventType;
+  data: Data;
   metadata?: Metadata;
 }
 
@@ -26,13 +26,13 @@ export interface JSONEventOptions<
   /**
    * The event type
    */
-  eventType: EventType;
+  type: EventType;
   /**
-   * The payload of the event
+   * The data of the event
    */
-  payload: Data;
+  data: Data;
   /**
-   * The payload of the event
+   * The meta data of the event
    */
   metadata?: Metadata;
 }
@@ -42,8 +42,8 @@ export const jsonEvent = <
   Data extends JSONType = JSONType,
   Metadata extends JSONType = JSONType
 >({
-  eventType,
-  payload,
+  type,
+  data,
   metadata,
   id = uuid(),
 }: JSONEventOptions<EventType, Data, Metadata>): JSONEventData<
@@ -53,7 +53,7 @@ export const jsonEvent = <
 > => ({
   id,
   contentType: "application/json",
-  eventType,
-  payload,
+  type,
+  data,
   metadata,
 });

--- a/src/persistentSubscription/createPersistentSubscription.ts
+++ b/src/persistentSubscription/createPersistentSubscription.ts
@@ -50,7 +50,7 @@ Client.prototype.createPersistentSubscription = async function (
   const identifier = new StreamIdentifier();
   const reqSettings = new CreateReq.Settings();
 
-  reqSettings.setResolveLinks(settings.resolveLinks);
+  reqSettings.setResolveLinks(settings.resolveLinkTos);
   switch (settings.fromRevision) {
     case START: {
       reqSettings.setRevision(BigInt(0).toString(10));

--- a/src/persistentSubscription/updatePersistentSubscription.ts
+++ b/src/persistentSubscription/updatePersistentSubscription.ts
@@ -48,7 +48,7 @@ Client.prototype.updatePersistentSubscription = async function (
   const identifier = new StreamIdentifier();
   const reqSettings = new UpdateReq.Settings();
 
-  reqSettings.setResolveLinks(settings.resolveLinks);
+  reqSettings.setResolveLinks(settings.resolveLinkTos);
   switch (settings.fromRevision) {
     case START: {
       reqSettings.setRevision(BigInt(0).toString(10));

--- a/src/streams/appendToStream.ts
+++ b/src/streams/appendToStream.ts
@@ -145,17 +145,17 @@ Client.prototype.appendToStream = async function (
       const id = new UUID();
       id.setString(event.id);
       message.setId(id);
-      message.getMetadataMap().set("type", event.eventType);
+      message.getMetadataMap().set("type", event.type);
       message.getMetadataMap().set("content-type", event.contentType);
 
       switch (event.contentType) {
         case "application/json": {
-          const data = JSON.stringify(event.payload);
+          const data = JSON.stringify(event.data);
           message.setData(Buffer.from(data, "binary").toString("base64"));
           break;
         }
         case "application/octet-stream": {
-          message.setData(event.payload);
+          message.setData(event.data);
           break;
         }
       }

--- a/src/streams/readAll.ts
+++ b/src/streams/readAll.ts
@@ -10,7 +10,7 @@ import {
   AllStreamResolvedEvent,
 } from "../types";
 import { debug, convertAllStreamGrpcEvent, handleBatchRead } from "../utils";
-import { BACKWARD, FORWARD, START } from "../constants";
+import { BACKWARDS, FORWARDS, START } from "../constants";
 import { Client } from "../Client";
 
 export interface ReadAllOptions extends BaseOptions {
@@ -29,7 +29,7 @@ export interface ReadAllOptions extends BaseOptions {
 declare module "../Client" {
   interface Client {
     /**
-     * Reads events from the $all. You can read forward or backward.
+     * Reads events from the $all. You can read forwards or backwards.
      * You might need to be authenticated to execute the command successfully.
      * @param count The number of events to read
      * @param options Reading options
@@ -46,7 +46,7 @@ Client.prototype.readAll = async function (
   count: number | BigInt,
   {
     fromPosition = START,
-    direction = FORWARD,
+    direction = FORWARDS,
     ...baseOptions
   }: ReadAllOptions = {}
 ): Promise<AllStreamResolvedEvent[]> {
@@ -83,11 +83,11 @@ Client.prototype.readAll = async function (
   options.setNoFilter(new Empty());
 
   switch (direction) {
-    case FORWARD: {
+    case FORWARDS: {
       options.setReadDirection(0);
       break;
     }
-    case BACKWARD: {
+    case BACKWARDS: {
       options.setReadDirection(1);
       break;
     }

--- a/src/streams/readStream.ts
+++ b/src/streams/readStream.ts
@@ -4,7 +4,7 @@ import { ReadReq } from "../../generated/streams_pb";
 import UUIDOption = ReadReq.Options.UUIDOption;
 
 import { Client } from "../Client";
-import { BACKWARD, END, FORWARD, START } from "../constants";
+import { BACKWARDS, END, FORWARDS, START } from "../constants";
 import { BaseOptions, Direction, ReadRevision, ResolvedEvent } from "../types";
 import { debug, handleBatchRead, convertGrpcEvent } from "../utils";
 
@@ -20,7 +20,7 @@ export interface ReadStreamOptions extends BaseOptions {
    * resolution feature, the server will also return the event targeted by the link.
    * @defaultValue false
    */
-  resolveLinks?: boolean;
+  resolveLinkTos?: boolean;
   /**
    *  Sets the read direction of the stream
    * @defaultValue FORWARDS
@@ -50,8 +50,8 @@ Client.prototype.readStream = async function (
   count: number | BigInt,
   {
     fromRevision = START,
-    resolveLinks = false,
-    direction = FORWARD,
+    resolveLinkTos = false,
+    direction = FORWARDS,
     ...baseOptions
   }: ReadStreamOptions = {}
 ): Promise<ResolvedEvent[]> {
@@ -82,17 +82,17 @@ Client.prototype.readStream = async function (
   }
 
   options.setStream(streamOptions);
-  options.setResolveLinks(resolveLinks);
+  options.setResolveLinks(resolveLinkTos);
   options.setCount(count.toString(10));
   options.setUuidOption(uuidOption);
   options.setNoFilter(new Empty());
 
   switch (direction) {
-    case FORWARD: {
+    case FORWARDS: {
       options.setReadDirection(0);
       break;
     }
-    case BACKWARD: {
+    case BACKWARDS: {
       options.setReadDirection(1);
       break;
     }
@@ -105,7 +105,7 @@ Client.prototype.readStream = async function (
     count,
     options: {
       fromRevision,
-      resolveLinks,
+      resolveLinkTos,
       direction,
       ...baseOptions,
     },

--- a/src/streams/subscribeToAll.ts
+++ b/src/streams/subscribeToAll.ts
@@ -32,7 +32,7 @@ export interface SubscribeToAllOptions extends BaseOptions {
    * resolution feature, the server will also return the event targeted by the link.
    * @defaultValue false
    */
-  resolveLinks?: boolean;
+  resolveLinkTos?: boolean;
   /**
    * Filters events or streams based upon a predicate.
    */
@@ -54,7 +54,7 @@ Client.prototype.subscribeToAll = function (
   this: Client,
   {
     fromPosition = START,
-    resolveLinks = false,
+    resolveLinkTos = false,
     filter,
     ...baseOptions
   }: SubscribeToAllOptions = {},
@@ -88,7 +88,7 @@ Client.prototype.subscribeToAll = function (
   }
 
   options.setAll(allOptions);
-  options.setResolveLinks(resolveLinks);
+  options.setResolveLinks(resolveLinkTos);
   options.setSubscription(new SubscriptionOptions());
   options.setUuidOption(uuidOption);
 
@@ -139,7 +139,7 @@ Client.prototype.subscribeToAll = function (
   debug.command("subscribeToAll: %O", {
     options: {
       fromPosition,
-      resolveLinks,
+      resolveLinkTos,
       filter,
       ...baseOptions,
     },

--- a/src/streams/subscribeToStream.ts
+++ b/src/streams/subscribeToStream.ts
@@ -24,7 +24,7 @@ export interface SubscribeToStreamOptions extends BaseOptions {
    * resolution feature, the server will also return the event targeted by the link.
    * @defaultValue false
    */
-  resolveLinks?: boolean;
+  resolveLinkTos?: boolean;
 }
 
 declare module "../Client" {
@@ -47,7 +47,7 @@ Client.prototype.subscribeToStream = function (
   streamName: string,
   {
     fromRevision = START,
-    resolveLinks = false,
+    resolveLinkTos = false,
     ...baseOptions
   }: SubscribeToStreamOptions = {},
   readableOptions: ReadableOptions = {}
@@ -81,7 +81,7 @@ Client.prototype.subscribeToStream = function (
   }
 
   options.setStream(streamOptions);
-  options.setResolveLinks(resolveLinks);
+  options.setResolveLinks(resolveLinkTos);
   options.setSubscription(new SubscriptionOptions());
   options.setUuidOption(uuidOption);
   options.setNoFilter(new Empty());
@@ -96,7 +96,7 @@ Client.prototype.subscribeToStream = function (
     streamName,
     options: {
       fromRevision,
-      resolveLinks,
+      resolveLinkTos,
       ...baseOptions,
     },
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -495,6 +495,4 @@ export interface PersistentSubscription
 }
 
 export type StreamSubscription = ReadableSubscription<ResolvedEvent>;
-export type AllStreamSubscription = ReadableSubscription<
-  AllStreamResolvedEvent
->;
+export type AllStreamSubscription = ReadableSubscription<AllStreamResolvedEvent>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,7 +110,7 @@ export interface RecordedEventBase<EventType extends string = string> {
   /**
    * Type of this event.
    */
-  eventType: EventType;
+  type: EventType;
 
   /**
    * Representing when this event was created in the database system.
@@ -129,7 +129,7 @@ export interface JSONRecordedEvent<
   isJson: true;
 
   /**
-   * Payload of this event.
+   * Data of this event.
    */
   data: Data;
 
@@ -147,7 +147,7 @@ export interface BinaryRecordedEvent<EventType extends string = string>
   isJson: false;
 
   /**
-   * Payload of this event.
+   * Data of this event.
    */
   data: Uint8Array;
 
@@ -495,4 +495,6 @@ export interface PersistentSubscription
 }
 
 export type StreamSubscription = ReadableSubscription<ResolvedEvent>;
-export type AllStreamSubscription = ReadableSubscription<AllStreamResolvedEvent>;
+export type AllStreamSubscription = ReadableSubscription<
+  AllStreamResolvedEvent
+>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,7 +81,7 @@ export type CurrentRevision =
 /**
  * Represents the direction of read operation (both from '$all' and a regular stream).
  */
-export type Direction = typeof constants.FORWARD | typeof constants.BACKWARD;
+export type Direction = typeof constants.FORWARDS | typeof constants.BACKWARDS;
 
 export interface AppendResult {
   nextExpectedVersion: bigint;

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,7 +91,7 @@ export interface AppendResult {
 /**
  * Represents a previously written event.
  */
-export interface RecordedEventBase<EventType extends string = string> {
+export interface RecordedEventBase<Type extends string = string> {
   /**
    * The event stream that events belongs to.
    */
@@ -110,7 +110,7 @@ export interface RecordedEventBase<EventType extends string = string> {
   /**
    * Type of this event.
    */
-  type: EventType;
+  type: Type;
 
   /**
    * Representing when this event was created in the database system.
@@ -119,10 +119,10 @@ export interface RecordedEventBase<EventType extends string = string> {
 }
 
 export interface JSONRecordedEvent<
-  EventType extends string = string,
+  Type extends string = string,
   Data = unknown,
   Metadata extends Record<string, unknown> = Record<string, unknown>
-> extends RecordedEventBase<EventType> {
+> extends RecordedEventBase<Type> {
   /**
    * Indicates whether the content is internally marked as JSON.
    */
@@ -139,8 +139,8 @@ export interface JSONRecordedEvent<
   metadata: Metadata;
 }
 
-export interface BinaryRecordedEvent<EventType extends string = string>
-  extends RecordedEventBase<EventType> {
+export interface BinaryRecordedEvent<Type extends string = string>
+  extends RecordedEventBase<Type> {
   /**
    * Indicates whether the content is internally marked as JSON.
    */
@@ -158,18 +158,18 @@ export interface BinaryRecordedEvent<EventType extends string = string>
 }
 
 export interface AllStreamJSONRecordedEvent<
-  EventType extends string = string,
+  Type extends string = string,
   Data = unknown,
   Metadata extends Record<string, unknown> = Record<string, unknown>
-> extends JSONRecordedEvent<EventType, Data, Metadata> {
+> extends JSONRecordedEvent<Type, Data, Metadata> {
   /**
    * Position of this event in the transaction log.
    */
   position: Position;
 }
 
-export interface AllStreamBinaryRecordedEvent<EventType extends string = string>
-  extends BinaryRecordedEvent<EventType> {
+export interface AllStreamBinaryRecordedEvent<Type extends string = string>
+  extends BinaryRecordedEvent<Type> {
   /**
    * Position of this event in the transaction log.
    */

--- a/src/utils/convertGrpcEvent.ts
+++ b/src/utils/convertGrpcEvent.ts
@@ -91,7 +91,7 @@ export const convertGrpcRecord = (
 ): RecordedEvent => {
   const metadataMap = grpcRecord.getMetadataMap();
 
-  const eventType = metadataMap.get("type") ?? "<no-event-type-provided>";
+  const type = metadataMap.get("type") ?? "<no-event-type-provided>";
   const contentType =
     metadataMap.get("content-type") ?? "application/octet-stream";
   const created = parseInt(metadataMap.get("created") ?? "0", 10);
@@ -136,7 +136,7 @@ export const convertGrpcRecord = (
       streamId,
       id,
       revision,
-      eventType,
+      type,
       data,
       metadata,
       isJson,
@@ -151,7 +151,7 @@ export const convertGrpcRecord = (
     streamId,
     id,
     revision,
-    eventType,
+    type,
     data,
     metadata,
     isJson,

--- a/src/utils/persistentSubscriptionSettings.ts
+++ b/src/utils/persistentSubscriptionSettings.ts
@@ -8,7 +8,7 @@ export interface PersistentSubscriptionSettings {
    * resolution feature, the server will also return the event targeted by the link.
    * @defaultValue false
    */
-  resolveLinks: boolean;
+  resolveLinkTos: boolean;
 
   /**
    * Starts the read at the given event revision.
@@ -87,7 +87,7 @@ export interface PersistentSubscriptionSettings {
 export const persistentSubscriptionSettingsFromDefaults = (
   changes: Partial<PersistentSubscriptionSettings> = {}
 ): PersistentSubscriptionSettings => ({
-  resolveLinks: false,
+  resolveLinkTos: false,
   extraStats: false,
   fromRevision: START,
   messageTimeout: 30_000,


### PR DESCRIPTION
Aligned naming with .NET Client:
- renamed `payload` to `data`, `eventType` to `type` to align with the .NET Client naming
- renamed Directions from FORWARD to FORWARDS and BACKWARD to BACKWARDS
- renamed resolveLinks into resolveLinkTos