### PR TITLE
Add generics to event types

### DIFF
--- a/src/__test__/connection/connectionStringMockups.ts
+++ b/src/__test__/connection/connectionStringMockups.ts
@@ -1,9 +1,8 @@
 import { ConnectionOptions } from "../../Client/parseConnectionString";
 
-export const valid: Array<[
-  connectionString: string,
-  expected: ConnectionOptions
-]> = [
+export const valid: Array<
+  [connectionString: string, expected: ConnectionOptions]
+> = [
   [
     "esdb://localhost",
     {
@@ -451,10 +450,9 @@ export const invalid: string[] = [
   "esdb://localhost?throwOnAppendFailure=sometimes",
 ];
 
-export const warning: Array<[
-  connectionString: string,
-  expected: ConnectionOptions
-]> = [
+export const warning: Array<
+  [connectionString: string, expected: ConnectionOptions]
+> = [
   [
     "esdb://localhost?catchOnAppendFailure=true&tlsVerifyCert=false",
     {

--- a/src/__test__/connection/connectionStringMockups.ts
+++ b/src/__test__/connection/connectionStringMockups.ts
@@ -1,8 +1,9 @@
 import { ConnectionOptions } from "../../Client/parseConnectionString";
 
-export const valid: Array<
-  [connectionString: string, expected: ConnectionOptions]
-> = [
+export const valid: Array<[
+  connectionString: string,
+  expected: ConnectionOptions
+]> = [
   [
     "esdb://localhost",
     {
@@ -450,9 +451,10 @@ export const invalid: string[] = [
   "esdb://localhost?throwOnAppendFailure=sometimes",
 ];
 
-export const warning: Array<
-  [connectionString: string, expected: ConnectionOptions]
-> = [
+export const warning: Array<[
+  connectionString: string,
+  expected: ConnectionOptions
+]> = [
   [
     "esdb://localhost?catchOnAppendFailure=true&tlsVerifyCert=false",
     {

--- a/src/events/binaryEvent.ts
+++ b/src/events/binaryEvent.ts
@@ -1,14 +1,14 @@
 import { v4 as uuid } from "uuid";
 
-export interface BinaryEventData<T extends string = string> {
+export interface BinaryEventData<EventType extends string = string> {
   id: string;
   contentType: "application/octet-stream";
-  eventType: string;
+  eventType: EventType;
   payload: Uint8Array;
   metadata?: Uint8Array;
 }
 
-export interface BinaryEventOptions<T extends string = string> {
+export interface BinaryEventOptions<EventType extends string = string> {
   /**
    * The id to this event. By default, the id will be generated.
    */
@@ -16,7 +16,7 @@ export interface BinaryEventOptions<T extends string = string> {
   /**
    * The event type
    */
-  eventType: T;
+  eventType: EventType;
   /**
    * The binary payload of the event
    */
@@ -27,12 +27,12 @@ export interface BinaryEventOptions<T extends string = string> {
   metadata?: Uint8Array | Buffer;
 }
 
-export const binaryEvent = <T extends string = string>({
+export const binaryEvent = <EventType extends string = string>({
   eventType,
   payload,
   metadata,
   id = uuid(),
-}: BinaryEventOptions<T>): BinaryEventData<T> => ({
+}: BinaryEventOptions<EventType>): BinaryEventData<EventType> => ({
   id,
   contentType: "application/octet-stream",
   eventType,

--- a/src/events/binaryEvent.ts
+++ b/src/events/binaryEvent.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from "uuid";
 
-export interface BinaryEventData {
+export interface BinaryEventData<T extends string = string> {
   id: string;
   contentType: "application/octet-stream";
   eventType: string;
@@ -8,7 +8,7 @@ export interface BinaryEventData {
   metadata?: Uint8Array;
 }
 
-export interface BinaryEventOptions {
+export interface BinaryEventOptions<T extends string = string> {
   /**
    * The id to this event. By default, the id will be generated.
    */
@@ -16,7 +16,7 @@ export interface BinaryEventOptions {
   /**
    * The event type
    */
-  eventType: string;
+  eventType: T;
   /**
    * The binary payload of the event
    */
@@ -27,12 +27,12 @@ export interface BinaryEventOptions {
   metadata?: Uint8Array | Buffer;
 }
 
-export const binaryEvent = ({
+export const binaryEvent = <T extends string = string>({
   eventType,
   payload,
   metadata,
   id = uuid(),
-}: BinaryEventOptions): BinaryEventData => ({
+}: BinaryEventOptions<T>): BinaryEventData<T> => ({
   id,
   contentType: "application/octet-stream",
   eventType,

--- a/src/events/jsonEvent.ts
+++ b/src/events/jsonEvent.ts
@@ -2,15 +2,15 @@ import { v4 as uuid } from "uuid";
 
 export type JSONType = Record<string | number, unknown> | unknown[];
 
-export interface JSONEventData {
+export interface JSONEventData<T extends string = string, D extends JSONType = JSONType, M extends JSONType = JSONType> {
   id: string;
   contentType: "application/json";
-  eventType: string;
-  payload: JSONType;
-  metadata?: JSONType;
+  eventType: T;
+  payload: D;
+  metadata?: M;
 }
 
-export interface JSONEventOptions {
+export interface JSONEventOptions<T extends string = string, D extends JSONType = JSONType, M extends JSONType = JSONType> {
   /**
    * The id to this event. By default, the id will be generated.
    */
@@ -18,23 +18,23 @@ export interface JSONEventOptions {
   /**
    * The event type
    */
-  eventType: string;
+  eventType: T;
   /**
    * The payload of the event
    */
-  payload: JSONType;
+  payload: D;
   /**
    * The payload of the event
    */
-  metadata?: JSONType;
+  metadata?: M;
 }
 
-export const jsonEvent = ({
+export const jsonEvent = <T extends string = string, D extends JSONType = JSONType, M extends JSONType = JSONType>({
   eventType,
   payload,
   metadata,
   id = uuid(),
-}: JSONEventOptions): JSONEventData => ({
+}: JSONEventOptions<T, D, M>): JSONEventData<T, D, M> => ({
   id,
   contentType: "application/json",
   eventType,

--- a/src/events/jsonEvent.ts
+++ b/src/events/jsonEvent.ts
@@ -2,7 +2,11 @@ import { v4 as uuid } from "uuid";
 
 export type JSONType = Record<string | number, unknown> | unknown[];
 
-export interface JSONEventData<EventType extends string = string, Data extends JSONType = JSONType, Metadata extends JSONType = JSONType> {
+export interface JSONEventData<
+  EventType extends string = string,
+  Data extends JSONType = JSONType,
+  Metadata extends JSONType = JSONType
+> {
   id: string;
   contentType: "application/json";
   eventType: EventType;
@@ -10,7 +14,11 @@ export interface JSONEventData<EventType extends string = string, Data extends J
   metadata?: Metadata;
 }
 
-export interface JSONEventOptions<EventType extends string = string, Data extends JSONType = JSONType, Metadata extends JSONType = JSONType> {
+export interface JSONEventOptions<
+  EventType extends string = string,
+  Data extends JSONType = JSONType,
+  Metadata extends JSONType = JSONType
+> {
   /**
    * The id to this event. By default, the id will be generated.
    */
@@ -29,12 +37,20 @@ export interface JSONEventOptions<EventType extends string = string, Data extend
   metadata?: Metadata;
 }
 
-export const jsonEvent = <EventType extends string = string, Data extends JSONType = JSONType, Metadata extends JSONType = JSONType>({
+export const jsonEvent = <
+  EventType extends string = string,
+  Data extends JSONType = JSONType,
+  Metadata extends JSONType = JSONType
+>({
   eventType,
   payload,
   metadata,
   id = uuid(),
-}: JSONEventOptions<EventType, Data, Metadata>): JSONEventData<EventType, Data, Metadata> => ({
+}: JSONEventOptions<EventType, Data, Metadata>): JSONEventData<
+  EventType,
+  Data,
+  Metadata
+> => ({
   id,
   contentType: "application/json",
   eventType,

--- a/src/events/jsonEvent.ts
+++ b/src/events/jsonEvent.ts
@@ -2,15 +2,15 @@ import { v4 as uuid } from "uuid";
 
 export type JSONType = Record<string | number, unknown> | unknown[];
 
-export interface JSONEventData<T extends string = string, D extends JSONType = JSONType, M extends JSONType = JSONType> {
+export interface JSONEventData<EventType extends string = string, Data extends JSONType = JSONType, Metadata extends JSONType = JSONType> {
   id: string;
   contentType: "application/json";
-  eventType: T;
-  payload: D;
-  metadata?: M;
+  eventType: EventType;
+  payload: Data;
+  metadata?: Metadata;
 }
 
-export interface JSONEventOptions<T extends string = string, D extends JSONType = JSONType, M extends JSONType = JSONType> {
+export interface JSONEventOptions<EventType extends string = string, Data extends JSONType = JSONType, Metadata extends JSONType = JSONType> {
   /**
    * The id to this event. By default, the id will be generated.
    */
@@ -18,23 +18,23 @@ export interface JSONEventOptions<T extends string = string, D extends JSONType 
   /**
    * The event type
    */
-  eventType: T;
+  eventType: EventType;
   /**
    * The payload of the event
    */
-  payload: D;
+  payload: Data;
   /**
    * The payload of the event
    */
-  metadata?: M;
+  metadata?: Metadata;
 }
 
-export const jsonEvent = <T extends string = string, D extends JSONType = JSONType, M extends JSONType = JSONType>({
+export const jsonEvent = <EventType extends string = string, Data extends JSONType = JSONType, Metadata extends JSONType = JSONType>({
   eventType,
   payload,
   metadata,
   id = uuid(),
-}: JSONEventOptions<T, D, M>): JSONEventData<T, D, M> => ({
+}: JSONEventOptions<EventType, Data, Metadata>): JSONEventData<EventType, Data, Metadata> => ({
   id,
   contentType: "application/json",
   eventType,

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,8 +178,8 @@ export interface AllStreamBinaryRecordedEvent<EventType extends string = string>
 
 export type RecordedEvent = JSONRecordedEvent | BinaryRecordedEvent;
 export type AllStreamRecordedEvent =
-  | AllStreamJSONRecordedEvent<string>
-  | AllStreamBinaryRecordedEvent<string>;
+  | AllStreamJSONRecordedEvent
+  | AllStreamBinaryRecordedEvent;
 
 /**
  * A structure representing a single event or an resolved link event.

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,18 +135,6 @@ export interface JSONRecordedEvent<T extends string = string, D = unknown, M ext
   metadata: M;
 }
 
-
-
-type EventX = JSONRecordedEvent<'RepoStarred', { userId: string, repoName: string }>
-type EventY = JSONRecordedEvent<'RepoUnstarred', { userId: string, repoName: string, reason: string }>
-
-const fun = (ev: EventX | EventY) => {
-  if (ev.eventType === '') {
-    
-  }
-}
-
-
 export interface BinaryRecordedEvent<T extends string = string> extends RecordedEventBase<T> {
   /**
    * Indicates whether the content is internally marked as JSON.

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,12 +176,12 @@ export interface AllStreamBinaryRecordedEvent<EventType extends string = string>
   position: Position;
 }
 
-export type RecordedEvent<EventType extends string = string> =
-  | JSONRecordedEvent<EventType>
-  | BinaryRecordedEvent<EventType>;
-export type AllStreamRecordedEvent<EventType extends string = string> =
-  | AllStreamJSONRecordedEvent<EventType>
-  | AllStreamBinaryRecordedEvent<EventType>;
+export type RecordedEvent =
+  | JSONRecordedEvent<string>
+  | BinaryRecordedEvent<string>;
+export type AllStreamRecordedEvent =
+  | AllStreamJSONRecordedEvent<string>
+  | AllStreamBinaryRecordedEvent<string>;
 
 /**
  * A structure representing a single event or an resolved link event.

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,7 +91,7 @@ export interface AppendResult {
 /**
  * Represents a previously written event.
  */
-export interface RecordedEventBase<T extends string = string> {
+export interface RecordedEventBase<EventType extends string = string> {
   /**
    * The event stream that events belongs to.
    */
@@ -110,7 +110,7 @@ export interface RecordedEventBase<T extends string = string> {
   /**
    * Type of this event.
    */
-  eventType: T;
+  eventType: EventType;
 
   /**
    * Representing when this event was created in the database system.
@@ -118,7 +118,7 @@ export interface RecordedEventBase<T extends string = string> {
   created: number;
 }
 
-export interface JSONRecordedEvent<T extends string = string, D = unknown, M extends Record<string, unknown>  = Record<string, unknown>> extends RecordedEventBase<T> {
+export interface JSONRecordedEvent<EventType extends string = string, Data = unknown, Metadata extends Record<string, unknown>  = Record<string, unknown>> extends RecordedEventBase<EventType> {
   /**
    * Indicates whether the content is internally marked as JSON.
    */
@@ -127,15 +127,15 @@ export interface JSONRecordedEvent<T extends string = string, D = unknown, M ext
   /**
    * Payload of this event.
    */
-  data: D;
+  data: Data;
 
   /**
    * Representing the metadata associated with this event.
    */
-  metadata: M;
+  metadata: Metadata;
 }
 
-export interface BinaryRecordedEvent<T extends string = string> extends RecordedEventBase<T> {
+export interface BinaryRecordedEvent<EventType extends string = string> extends RecordedEventBase<EventType> {
   /**
    * Indicates whether the content is internally marked as JSON.
    */
@@ -152,24 +152,24 @@ export interface BinaryRecordedEvent<T extends string = string> extends Recorded
   metadata: Uint8Array;
 }
 
-export interface AllStreamJSONRecordedEvent<T extends string = string, D = unknown, M extends Record<string, unknown>  = Record<string, unknown>> extends JSONRecordedEvent<T, D, M> {
+export interface AllStreamJSONRecordedEvent<EventType extends string = string, Data = unknown, Metadata extends Record<string, unknown>  = Record<string, unknown>> extends JSONRecordedEvent<EventType, Data, Metadata> {
   /**
    * Position of this event in the transaction log.
    */
   position: Position;
 }
 
-export interface AllStreamBinaryRecordedEvent<T extends string = string> extends BinaryRecordedEvent<T> {
+export interface AllStreamBinaryRecordedEvent<EventType extends string = string> extends BinaryRecordedEvent<EventType> {
   /**
    * Position of this event in the transaction log.
    */
   position: Position;
 }
 
-export type RecordedEvent<T extends string = string> = JSONRecordedEvent<T> | BinaryRecordedEvent<T>;
-export type AllStreamRecordedEvent<T extends string = string> =
-  | AllStreamJSONRecordedEvent<T>
-  | AllStreamBinaryRecordedEvent<T>;
+export type RecordedEvent<EventType extends string = string> = JSONRecordedEvent<EventType> | BinaryRecordedEvent<EventType>;
+export type AllStreamRecordedEvent<EventType extends string = string> =
+  | AllStreamJSONRecordedEvent<EventType>
+  | AllStreamBinaryRecordedEvent<EventType>;
 
 /**
  * A structure representing a single event or an resolved link event.

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,9 +176,7 @@ export interface AllStreamBinaryRecordedEvent<EventType extends string = string>
   position: Position;
 }
 
-export type RecordedEvent =
-  | JSONRecordedEvent<string>
-  | BinaryRecordedEvent<string>;
+export type RecordedEvent = JSONRecordedEvent | BinaryRecordedEvent;
 export type AllStreamRecordedEvent =
   | AllStreamJSONRecordedEvent<string>
   | AllStreamBinaryRecordedEvent<string>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,7 +118,11 @@ export interface RecordedEventBase<EventType extends string = string> {
   created: number;
 }
 
-export interface JSONRecordedEvent<EventType extends string = string, Data = unknown, Metadata extends Record<string, unknown>  = Record<string, unknown>> extends RecordedEventBase<EventType> {
+export interface JSONRecordedEvent<
+  EventType extends string = string,
+  Data = unknown,
+  Metadata extends Record<string, unknown> = Record<string, unknown>
+> extends RecordedEventBase<EventType> {
   /**
    * Indicates whether the content is internally marked as JSON.
    */
@@ -135,7 +139,8 @@ export interface JSONRecordedEvent<EventType extends string = string, Data = unk
   metadata: Metadata;
 }
 
-export interface BinaryRecordedEvent<EventType extends string = string> extends RecordedEventBase<EventType> {
+export interface BinaryRecordedEvent<EventType extends string = string>
+  extends RecordedEventBase<EventType> {
   /**
    * Indicates whether the content is internally marked as JSON.
    */
@@ -152,21 +157,28 @@ export interface BinaryRecordedEvent<EventType extends string = string> extends 
   metadata: Uint8Array;
 }
 
-export interface AllStreamJSONRecordedEvent<EventType extends string = string, Data = unknown, Metadata extends Record<string, unknown>  = Record<string, unknown>> extends JSONRecordedEvent<EventType, Data, Metadata> {
+export interface AllStreamJSONRecordedEvent<
+  EventType extends string = string,
+  Data = unknown,
+  Metadata extends Record<string, unknown> = Record<string, unknown>
+> extends JSONRecordedEvent<EventType, Data, Metadata> {
   /**
    * Position of this event in the transaction log.
    */
   position: Position;
 }
 
-export interface AllStreamBinaryRecordedEvent<EventType extends string = string> extends BinaryRecordedEvent<EventType> {
+export interface AllStreamBinaryRecordedEvent<EventType extends string = string>
+  extends BinaryRecordedEvent<EventType> {
   /**
    * Position of this event in the transaction log.
    */
   position: Position;
 }
 
-export type RecordedEvent<EventType extends string = string> = JSONRecordedEvent<EventType> | BinaryRecordedEvent<EventType>;
+export type RecordedEvent<EventType extends string = string> =
+  | JSONRecordedEvent<EventType>
+  | BinaryRecordedEvent<EventType>;
 export type AllStreamRecordedEvent<EventType extends string = string> =
   | AllStreamJSONRecordedEvent<EventType>
   | AllStreamBinaryRecordedEvent<EventType>;
@@ -485,4 +497,6 @@ export interface PersistentSubscription
 }
 
 export type StreamSubscription = ReadableSubscription<ResolvedEvent>;
-export type AllStreamSubscription = ReadableSubscription<AllStreamResolvedEvent>;
+export type AllStreamSubscription = ReadableSubscription<
+  AllStreamResolvedEvent
+>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -497,6 +497,4 @@ export interface PersistentSubscription
 }
 
 export type StreamSubscription = ReadableSubscription<ResolvedEvent>;
-export type AllStreamSubscription = ReadableSubscription<
-  AllStreamResolvedEvent
->;
+export type AllStreamSubscription = ReadableSubscription<AllStreamResolvedEvent>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,7 +91,7 @@ export interface AppendResult {
 /**
  * Represents a previously written event.
  */
-export interface RecordedEventBase {
+export interface RecordedEventBase<T extends string = string> {
   /**
    * The event stream that events belongs to.
    */
@@ -110,7 +110,7 @@ export interface RecordedEventBase {
   /**
    * Type of this event.
    */
-  eventType: string;
+  eventType: T;
 
   /**
    * Representing when this event was created in the database system.
@@ -118,24 +118,36 @@ export interface RecordedEventBase {
   created: number;
 }
 
-export interface JSONRecordedEvent extends RecordedEventBase {
+export interface JSONRecordedEvent<T extends string = string, D = unknown, M extends Record<string, unknown>  = Record<string, unknown>> extends RecordedEventBase<T> {
   /**
-   * Indicates wheter the content is internally marked as JSON.
+   * Indicates whether the content is internally marked as JSON.
    */
   isJson: true;
 
   /**
    * Payload of this event.
    */
-  data: unknown;
+  data: D;
 
   /**
    * Representing the metadata associated with this event.
    */
-  metadata: Record<string, unknown>;
+  metadata: M;
 }
 
-export interface BinaryRecordedEvent extends RecordedEventBase {
+
+
+type EventX = JSONRecordedEvent<'RepoStarred', { userId: string, repoName: string }>
+type EventY = JSONRecordedEvent<'RepoUnstarred', { userId: string, repoName: string, reason: string }>
+
+const fun = (ev: EventX | EventY) => {
+  if (ev.eventType === '') {
+    
+  }
+}
+
+
+export interface BinaryRecordedEvent<T extends string = string> extends RecordedEventBase<T> {
   /**
    * Indicates whether the content is internally marked as JSON.
    */
@@ -152,24 +164,24 @@ export interface BinaryRecordedEvent extends RecordedEventBase {
   metadata: Uint8Array;
 }
 
-export interface AllStreamJSONRecordedEvent extends JSONRecordedEvent {
+export interface AllStreamJSONRecordedEvent<T extends string = string, D = unknown, M extends Record<string, unknown>  = Record<string, unknown>> extends JSONRecordedEvent<T, D, M> {
   /**
    * Position of this event in the transaction log.
    */
   position: Position;
 }
 
-export interface AllStreamBinaryRecordedEvent extends BinaryRecordedEvent {
+export interface AllStreamBinaryRecordedEvent<T extends string = string> extends BinaryRecordedEvent<T> {
   /**
    * Position of this event in the transaction log.
    */
   position: Position;
 }
 
-export type RecordedEvent = JSONRecordedEvent | BinaryRecordedEvent;
-export type AllStreamRecordedEvent =
-  | AllStreamJSONRecordedEvent
-  | AllStreamBinaryRecordedEvent;
+export type RecordedEvent<T extends string = string> = JSONRecordedEvent<T> | BinaryRecordedEvent<T>;
+export type AllStreamRecordedEvent<T extends string = string> =
+  | AllStreamJSONRecordedEvent<T>
+  | AllStreamBinaryRecordedEvent<T>;
 
 /**
  * A structure representing a single event or an resolved link event.
@@ -181,8 +193,7 @@ export interface ResolvedEvent {
   event?: RecordedEvent;
 
   /**
-   *
-   The link event if this ResolvedEvent is a link event.
+   * The link event if this ResolvedEvent is a link event.
    */
   link?: RecordedEvent;
 
@@ -202,8 +213,7 @@ export interface AllStreamResolvedEvent {
   event?: AllStreamRecordedEvent;
 
   /**
-   *
-   The link event if this ResolvedEvent is a link event.
+   * The link event if this ResolvedEvent is a link event.
    */
   link?: AllStreamRecordedEvent;
 


### PR DESCRIPTION
#103

Discrimation of events based on event type:

![image](https://user-images.githubusercontent.com/3396772/103167707-ca518380-482d-11eb-8ca0-3626ed74ddcc.png)

Strongly typed events:

![image](https://user-images.githubusercontent.com/3396772/103167738-01c03000-482e-11eb-8e15-8725a7614d6c.png)


As mentioned in #103, this is backwards compatible since the generic parameters all have defaults. 