### PR TITLE
[e] (Github actions) Only connect to tailscale on main repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,15 @@ jobs:
     strategy:
       matrix:
         version: [ci]
+    env:
+      # Github only passes secrets to the main repo, so we need to skip some things if they are unavailable
+      SECRETS_AVAILABLE: ${{ secrets.EVENTSTORE_CLOUD_ID != null }}
     needs: build
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - name: Connect to tailscale
+        if: ${{ env.SECRETS_AVAILABLE == 'true' }}
         run: |
           curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/eoan.gpg | sudo apt-key add -
           curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/eoan.list | sudo tee /etc/apt/sources.list.d/tailscale.list
@@ -58,6 +62,7 @@ jobs:
         env:
           EVENTSTORE_CLOUD_ID: ${{ secrets.EVENTSTORE_CLOUD_ID }}
       - name: Disconnect from tailscale
+        if: ${{ env.SECRETS_AVAILABLE == 'true' }}
         run: sudo tailscale down
 
   linting:

--- a/src/__test__/connection/dns.test.ts
+++ b/src/__test__/connection/dns.test.ts
@@ -7,73 +7,70 @@ import {
   NotLeaderError,
 } from "../..";
 
-optionalDescribe(process.env.EVENTSTORE_CLOUD_ID != null)(
-  "dns discover",
-  () => {
-    const STREAM_NAME = "test_stream_name";
-    const { EVENTSTORE_CLOUD_ID } = process.env;
-    const event = jsonEvent({
-      eventType: "test",
-      payload: { message: "test" },
+optionalDescribe(!!process.env.EVENTSTORE_CLOUD_ID)("dns discover", () => {
+  const STREAM_NAME = "test_stream_name";
+  const { EVENTSTORE_CLOUD_ID } = process.env;
+  const event = jsonEvent({
+    eventType: "test",
+    payload: { message: "test" },
+  });
+
+  describe.each([
+    [
+      "connectionString",
+      (nodePreference?: NodePreference) =>
+        EventStoreDBClient.connectionString`esdb+discover://${EVENTSTORE_CLOUD_ID!}.mesdb.eventstore.cloud${
+          nodePreference ? `?nodePreference=${nodePreference}` : ""
+        }`,
+    ],
+    [
+      "new client",
+      (nodePreference?: NodePreference) =>
+        new EventStoreDBClient({
+          discover: {
+            address: `${EVENTSTORE_CLOUD_ID!}.mesdb.eventstore.cloud`,
+            port: 2113,
+          },
+          nodePreference,
+        }),
+    ],
+  ])("%s", (clientType, createClient) => {
+    test("should successfully connect", async () => {
+      const client = createClient();
+
+      const appendResult = await client.appendToStream(STREAM_NAME, event);
+      const readResult = await client.readStream(STREAM_NAME, 10);
+
+      expect(appendResult).toBeDefined();
+      expect(readResult).toBeDefined();
     });
 
-    describe.each([
-      [
-        "connectionString",
-        (nodePreference?: NodePreference) =>
-          EventStoreDBClient.connectionString`esdb+discover://${EVENTSTORE_CLOUD_ID!}.mesdb.eventstore.cloud${
-            nodePreference ? `?nodePreference=${nodePreference}` : ""
-          }`,
-      ],
-      [
-        "new client",
-        (nodePreference?: NodePreference) =>
-          new EventStoreDBClient({
-            discover: {
-              address: `${EVENTSTORE_CLOUD_ID!}.mesdb.eventstore.cloud`,
-              port: 2113,
-            },
-            nodePreference,
-          }),
-      ],
-    ])("%s", (clientType, createClient) => {
-      test("should successfully connect", async () => {
-        const client = createClient();
-
-        const appendResult = await client.appendToStream(STREAM_NAME, event);
-        const readResult = await client.readStream(STREAM_NAME, 10);
+    describe("should connect to specified preference", () => {
+      test("leader", async () => {
+        const client = createClient("leader");
+        const appendResult = await client.appendToStream(
+          `${clientType}-leader-test`,
+          jsonTestEvents(),
+          { requiresLeader: true }
+        );
 
         expect(appendResult).toBeDefined();
-        expect(readResult).toBeDefined();
       });
 
-      describe("should connect to specified preference", () => {
-        test("leader", async () => {
-          const client = createClient("leader");
+      test("follower", async () => {
+        const client = createClient("follower");
+
+        try {
           const appendResult = await client.appendToStream(
             `${clientType}-leader-test`,
             jsonTestEvents(),
             { requiresLeader: true }
           );
-
-          expect(appendResult).toBeDefined();
-        });
-
-        test("follower", async () => {
-          const client = createClient("follower");
-
-          try {
-            const appendResult = await client.appendToStream(
-              `${clientType}-leader-test`,
-              jsonTestEvents(),
-              { requiresLeader: true }
-            );
-            expect(appendResult).toBe("unreachable");
-          } catch (error) {
-            expect(error).toBeInstanceOf(NotLeaderError);
-          }
-        });
+          expect(appendResult).toBe("unreachable");
+        } catch (error) {
+          expect(error).toBeInstanceOf(NotLeaderError);
+        }
       });
     });
-  }
-);
+  });
+});


### PR DESCRIPTION
Secrets are unavailable to PRs from forks so we need to skip connecting to tailscale in this case.

I chose to test for the presence of secrets rather than checking repo names, as forks might want to set their own secrets or the repo could be renamed, and as it is pass / fail, the skipping might be missed.

See #106 for same PR from branch.

## From fork:
- Tailscale step is skipped
- DNS test is skipped
![image](https://user-images.githubusercontent.com/11861797/103281941-8d73c100-49d4-11eb-9102-0c94468a4f46.png)

## From branch:
- Connected to Tailscale
- All tests are run
![image](https://user-images.githubusercontent.com/11861797/103282001-b09e7080-49d4-11eb-9e93-bb02397015b8.png)
