### PR TITLE
Case insensitive keys in connection string

### DIFF
--- a/src/Client/parseConnectionString.ts
+++ b/src/Client/parseConnectionString.ts
@@ -9,6 +9,17 @@ const notCurrentlySupported = [
   "throwOnAppendFailure",
 ];
 
+const lowerToKey: Record<string, keyof ConnectionOptions> = {
+  dnsdiscover: "dnsDiscover",
+  maxdiscoverattempts: "maxDiscoverAttempts",
+  discoveryinterval: "discoveryInterval",
+  gossiptimeout: "gossipTimeout",
+  nodepreference: "nodePreference",
+  tls: "tls",
+  tlsverifycert: "tlsVerifyCert",
+  throwonappendfailure: "throwOnAppendFailure",
+};
+
 export interface ConnectionOptions {
   dnsDiscover: boolean;
   maxDiscoverAttempts: number;
@@ -218,11 +229,12 @@ interface KeyValuePair {
 }
 
 const verifyKeyValuePair = (
-  { key, value }: RawKeyPair,
+  { key: rawKey, value }: RawKeyPair,
   connectionString: string,
   [from, to]: ParsingLocation
 ): KeyValuePair | null => {
-  const keyFrom = from + `&${key}=`.length;
+  const keyFrom = from + `&${rawKey}=`.length;
+  const key = lowerToKey[rawKey.toLowerCase()] ?? rawKey;
 
   if (notCurrentlySupported.includes(key)) {
     debug.connection(

--- a/src/__test__/connection/connectionStringMockups.ts
+++ b/src/__test__/connection/connectionStringMockups.ts
@@ -433,6 +433,25 @@ export const valid: Array<
       ],
     },
   ],
+  [
+    "esdb://host?MaxDiscoverAttempts=200&discoveryinterval=1000&GOSSIPTIMEOUT=1&nOdEpReFeReNcE=leader&TLS=false&TlsVerifyCert=false&THROWOnAppendFailure=false",
+    {
+      dnsDiscover: false,
+      maxDiscoverAttempts: 200,
+      discoveryInterval: 1000,
+      gossipTimeout: 1,
+      nodePreference: "leader",
+      tls: false,
+      tlsVerifyCert: false,
+      throwOnAppendFailure: false,
+      hosts: [
+        {
+          address: "host",
+          port: 2113,
+        },
+      ],
+    },
+  ],
 ];
 
 export const invalid: string[] = [


### PR DESCRIPTION
- Convert keys to lowercase and pull camelCase from a dictionary.
- Add test case

fixes: #108 