### PR TITLE
Dont assume that metadata matches the event type

### DIFF
--- a/src/__test__/streams/appendToStream.test.ts
+++ b/src/__test__/streams/appendToStream.test.ts
@@ -43,55 +43,209 @@ describe("appendToStream", () => {
       expect(result.nextExpectedVersion).toBeGreaterThanOrEqual(0);
     });
 
-    test("with metadata for json events", async () => {
-      const STREAM_NAME = "json_metadata_stream_name";
-      const METADATA = { metaMessage: "How meta is this?" };
-      const event = jsonEvent({
-        type: "metadata-test-json",
-        data: {
-          message: "the json message",
-          kind: "json",
-        },
-        metadata: METADATA,
+    describe("metadata", () => {
+      describe("json", () => {
+        const METADATA = { metaMessage: "How meta is this?" };
+
+        test("json events", async () => {
+          const STREAM_NAME = "metadata_json_json";
+          const event = jsonEvent({
+            type: "metadata-test",
+            data: {
+              message: "the json message",
+              kind: "json",
+            },
+            metadata: METADATA,
+          });
+
+          const result = await client.appendToStream(STREAM_NAME, event);
+
+          expect(result).toBeDefined();
+          expect(result.nextExpectedVersion).toBeGreaterThanOrEqual(0);
+
+          const rxEvents = await client.readStream(STREAM_NAME, 1);
+
+          expect(rxEvents).toBeDefined();
+          expect(rxEvents.length).toEqual(1);
+          expect(rxEvents[0].event?.metadata).toBeDefined();
+          const metaJx = rxEvents[0].event!.metadata as Record<string, unknown>;
+          expect(metaJx.metaMessage).toMatch(METADATA.metaMessage);
+        });
+
+        test("binary events", async () => {
+          const STREAM_NAME = "metadata_json_binary";
+          const event = binaryEvent({
+            type: "metadata-test",
+            data: Buffer.from("the binary message"),
+            metadata: METADATA,
+          });
+
+          const result = await client.appendToStream(STREAM_NAME, event);
+
+          expect(result).toBeDefined();
+          expect(result.nextExpectedVersion).toBeGreaterThanOrEqual(0);
+
+          const rxEvents = await client.readStream(STREAM_NAME, 1);
+
+          expect(rxEvents).toBeDefined();
+          expect(rxEvents.length).toEqual(1);
+          expect(rxEvents[0].event?.metadata).toBeDefined();
+
+          const metaJx = rxEvents[0].event!.metadata as Record<string, unknown>;
+          expect(metaJx.metaMessage).toMatch(METADATA.metaMessage);
+        });
       });
 
-      const result = await client.appendToStream(STREAM_NAME, event);
+      describe("buffer", () => {
+        const MESSAGE = "How meta is this?";
+        const METADATA = Buffer.from(MESSAGE);
 
-      expect(result).toBeDefined();
-      expect(result.nextExpectedVersion).toBeGreaterThanOrEqual(0);
+        test("json events", async () => {
+          const STREAM_NAME = "metadata_buffer_json";
+          const event = jsonEvent({
+            type: "metadata-test",
+            data: {
+              message: "the json message",
+              kind: "json",
+            },
+            metadata: METADATA,
+          });
 
-      const rxEvents = await client.readStream(STREAM_NAME, 1);
+          const result = await client.appendToStream(STREAM_NAME, event);
 
-      expect(rxEvents).toBeDefined();
-      expect(rxEvents.length).toEqual(1);
-      expect(rxEvents[0].event?.metadata).toBeDefined();
-      const metaJx = rxEvents[0].event!.metadata as Record<string, unknown>;
-      expect(metaJx.metaMessage).toMatch(METADATA.metaMessage);
-    });
+          expect(result).toBeDefined();
+          expect(result.nextExpectedVersion).toBeGreaterThanOrEqual(0);
 
-    test("with metadata for binary events", async () => {
-      const STREAM_NAME = "binary_metadata_stream_name";
-      const METADATA = "How meta is this?";
+          const rxEvents = await client.readStream(STREAM_NAME, 1);
 
-      const event = binaryEvent({
-        type: "metadata-test-binary",
-        data: Buffer.from("the binary message"),
-        metadata: Buffer.from(METADATA),
+          expect(rxEvents).toBeDefined();
+          expect(rxEvents.length).toEqual(1);
+          expect(rxEvents[0].event?.metadata).toBeDefined();
+          const metaBx = rxEvents[0].event!.metadata as Uint8Array;
+          const metaBxData = Buffer.from(metaBx).toString("binary");
+          expect(metaBxData).toMatch(MESSAGE);
+        });
+
+        test("binary events", async () => {
+          const STREAM_NAME = "metadata_buffer_binary";
+          const event = binaryEvent({
+            type: "metadata-test",
+            data: Buffer.from("the binary message"),
+            metadata: METADATA,
+          });
+
+          const result = await client.appendToStream(STREAM_NAME, event);
+
+          expect(result).toBeDefined();
+          expect(result.nextExpectedVersion).toBeGreaterThanOrEqual(0);
+
+          const rxEvents = await client.readStream(STREAM_NAME, 1);
+
+          expect(rxEvents).toBeDefined();
+          expect(rxEvents.length).toEqual(1);
+          expect(rxEvents[0].event?.metadata).toBeDefined();
+          const metaBx = rxEvents[0].event!.metadata as Uint8Array;
+          const metaBxData = Buffer.from(metaBx).toString("binary");
+          expect(metaBxData).toMatch(MESSAGE);
+        });
       });
 
-      const result = await client.appendToStream(STREAM_NAME, event);
+      describe("Uint8Array", () => {
+        const MESSAGE = "How Uint8Array is this?";
+        const METADATA = Uint8Array.from(Buffer.from(MESSAGE));
 
-      expect(result).toBeDefined();
-      expect(result.nextExpectedVersion).toBeGreaterThanOrEqual(0);
+        test("json events", async () => {
+          const STREAM_NAME = "metadata_Uint8Array_json";
+          const event = jsonEvent({
+            type: "metadata-test",
+            data: {
+              message: "the json message",
+              kind: "json",
+            },
+            metadata: METADATA,
+          });
 
-      const rxEvents = await client.readStream(STREAM_NAME, 1);
+          const result = await client.appendToStream(STREAM_NAME, event);
 
-      expect(rxEvents).toBeDefined();
-      expect(rxEvents.length).toEqual(1);
-      expect(rxEvents[0].event?.metadata).toBeDefined();
-      const metaBx = rxEvents[0].event!.metadata as Uint8Array;
-      const metaBxData = Buffer.from(metaBx).toString("binary");
-      expect(metaBxData).toMatch(METADATA);
+          expect(result).toBeDefined();
+          expect(result.nextExpectedVersion).toBeGreaterThanOrEqual(0);
+
+          const rxEvents = await client.readStream(STREAM_NAME, 1);
+
+          expect(rxEvents).toBeDefined();
+          expect(rxEvents.length).toEqual(1);
+          expect(rxEvents[0].event?.metadata).toBeDefined();
+          const metaBx = rxEvents[0].event!.metadata as Uint8Array;
+          const metaBxData = Buffer.from(metaBx).toString("binary");
+          expect(metaBxData).toMatch(MESSAGE);
+        });
+
+        test("binary events", async () => {
+          const STREAM_NAME = "metadata_Uint8Array_binary";
+          const event = binaryEvent({
+            type: "metadata-test",
+            data: Buffer.from("the binary message"),
+            metadata: METADATA,
+          });
+
+          const result = await client.appendToStream(STREAM_NAME, event);
+
+          expect(result).toBeDefined();
+          expect(result.nextExpectedVersion).toBeGreaterThanOrEqual(0);
+
+          const rxEvents = await client.readStream(STREAM_NAME, 1);
+
+          expect(rxEvents).toBeDefined();
+          expect(rxEvents.length).toEqual(1);
+          expect(rxEvents[0].event?.metadata).toBeDefined();
+          const metaBx = rxEvents[0].event!.metadata as Uint8Array;
+          const metaBxData = Buffer.from(metaBx).toString("binary");
+          expect(metaBxData).toMatch(MESSAGE);
+        });
+      });
+
+      describe("undefined", () => {
+        test("json events", async () => {
+          const STREAM_NAME = "metadata_undefined_json";
+          const event = jsonEvent({
+            type: "metadata-test",
+            data: {
+              message: "the json message",
+              kind: "json",
+            },
+          });
+
+          const result = await client.appendToStream(STREAM_NAME, event);
+
+          expect(result).toBeDefined();
+          expect(result.nextExpectedVersion).toBeGreaterThanOrEqual(0);
+
+          const rxEvents = await client.readStream(STREAM_NAME, 1);
+
+          expect(rxEvents).toBeDefined();
+          expect(rxEvents.length).toEqual(1);
+          expect(rxEvents[0].event?.metadata).toBeUndefined();
+        });
+
+        test("binary events", async () => {
+          const STREAM_NAME = "metadata_undefined_binary";
+          const event = binaryEvent({
+            type: "metadata-test",
+            data: Buffer.from("the binary message"),
+          });
+
+          const result = await client.appendToStream(STREAM_NAME, event);
+
+          expect(result).toBeDefined();
+          expect(result.nextExpectedVersion).toBeGreaterThanOrEqual(0);
+
+          const rxEvents = await client.readStream(STREAM_NAME, 1);
+
+          expect(rxEvents).toBeDefined();
+          expect(rxEvents.length).toEqual(1);
+          expect(rxEvents[0].event?.metadata).toBeUndefined();
+        });
+      });
     });
 
     describe("expected revision", () => {

--- a/src/events/binaryEvent.ts
+++ b/src/events/binaryEvent.ts
@@ -1,14 +1,22 @@
 import { v4 as uuid } from "uuid";
+import { convertMetadata } from "./convertMetadata";
+import { MetadataType } from "./types";
 
-export interface BinaryEventData<Type extends string = string> {
+export interface BinaryEventData<
+  Type extends string = string,
+  Metadata extends MetadataType = MetadataType
+> {
   id: string;
   contentType: "application/octet-stream";
   type: Type;
   data: Uint8Array;
-  metadata?: Uint8Array;
+  metadata?: Metadata;
 }
 
-export interface BinaryEventOptions<Type extends string = string> {
+export interface BinaryEventOptions<
+  Type extends string = string,
+  Metadata extends MetadataType = MetadataType | Buffer
+> {
   /**
    * The id to this event. By default, the id will be generated.
    */
@@ -24,18 +32,21 @@ export interface BinaryEventOptions<Type extends string = string> {
   /**
    * The binary metadata of the event
    */
-  metadata?: Uint8Array | Buffer;
+  metadata?: Metadata;
 }
 
-export const binaryEvent = <Type extends string = string>({
+export const binaryEvent = <
+  Type extends string = string,
+  Metadata extends MetadataType = MetadataType
+>({
   type,
   data,
   metadata,
   id = uuid(),
-}: BinaryEventOptions<Type>): BinaryEventData<Type> => ({
+}: BinaryEventOptions<Type, Metadata>): BinaryEventData<Type, Metadata> => ({
   id,
   contentType: "application/octet-stream",
   type,
   data: Uint8Array.from(data),
-  metadata: metadata ? Uint8Array.from(metadata) : undefined,
+  metadata: convertMetadata<Metadata>(metadata),
 });

--- a/src/events/convertMetadata.ts
+++ b/src/events/convertMetadata.ts
@@ -1,0 +1,8 @@
+export const convertMetadata = <Metadata>(
+  metadata?: Metadata | Buffer
+): Metadata | undefined => {
+  if (Buffer.isBuffer(metadata)) {
+    return (Uint8Array.from(metadata) as unknown) as Metadata;
+  }
+  return metadata;
+};

--- a/src/events/jsonEvent.ts
+++ b/src/events/jsonEvent.ts
@@ -1,11 +1,11 @@
 import { v4 as uuid } from "uuid";
-
-export type JSONType = Record<string | number, unknown> | unknown[];
+import { convertMetadata } from "./convertMetadata";
+import { JSONType, MetadataType } from "./types";
 
 export interface JSONEventData<
   Type extends string = string,
   Data extends JSONType = JSONType,
-  Metadata extends JSONType = JSONType
+  Metadata extends MetadataType = MetadataType
 > {
   id: string;
   contentType: "application/json";
@@ -17,7 +17,7 @@ export interface JSONEventData<
 export interface JSONEventOptions<
   Type extends string = string,
   Data extends JSONType = JSONType,
-  Metadata extends JSONType = JSONType
+  Metadata extends MetadataType = MetadataType | Buffer
 > {
   /**
    * The id to this event. By default, the id will be generated.
@@ -40,7 +40,7 @@ export interface JSONEventOptions<
 export const jsonEvent = <
   Type extends string = string,
   Data extends JSONType = JSONType,
-  Metadata extends JSONType = JSONType
+  Metadata extends MetadataType = MetadataType
 >({
   type,
   data,
@@ -55,5 +55,5 @@ export const jsonEvent = <
   contentType: "application/json",
   type,
   data,
-  metadata,
+  metadata: convertMetadata<Metadata>(metadata),
 });

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -1,0 +1,2 @@
+export type JSONType = Record<string | number, unknown> | unknown[];
+export type MetadataType = JSONType | Uint8Array;

--- a/src/streams/appendToStream.ts
+++ b/src/streams/appendToStream.ts
@@ -161,18 +161,13 @@ Client.prototype.appendToStream = async function (
       }
 
       if (event.metadata) {
-        switch (event.contentType) {
-          case "application/json": {
-            const metadata = JSON.stringify(event.metadata);
-            message.setCustomMetadata(
-              Buffer.from(metadata, "binary").toString("base64")
-            );
-            break;
-          }
-          case "application/octet-stream": {
-            message.setCustomMetadata(event.metadata);
-            break;
-          }
+        if (event.metadata.constructor === Uint8Array) {
+          message.setCustomMetadata(event.metadata);
+        } else {
+          const metadata = JSON.stringify(event.metadata);
+          message.setCustomMetadata(
+            Buffer.from(metadata, "binary").toString("base64")
+          );
         }
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,7 +91,7 @@ export interface AppendResult {
 /**
  * Represents a previously written event.
  */
-export interface RecordedEventBase<Type extends string = string> {
+interface RecordedEventBase<Type extends string, Metadata> {
   /**
    * The event stream that events belongs to.
    */
@@ -116,13 +116,18 @@ export interface RecordedEventBase<Type extends string = string> {
    * Representing when this event was created in the database system.
    */
   created: number;
+
+  /**
+   * Representing the metadata associated with this event.
+   */
+  metadata: Metadata;
 }
 
 export interface JSONRecordedEvent<
   Type extends string = string,
   Data = unknown,
-  Metadata extends Record<string, unknown> = Record<string, unknown>
-> extends RecordedEventBase<Type> {
+  Metadata = unknown
+> extends RecordedEventBase<Type, Metadata> {
   /**
    * Indicates whether the content is internally marked as JSON.
    */
@@ -132,15 +137,12 @@ export interface JSONRecordedEvent<
    * Data of this event.
    */
   data: Data;
-
-  /**
-   * Representing the metadata associated with this event.
-   */
-  metadata: Metadata;
 }
 
-export interface BinaryRecordedEvent<Type extends string = string>
-  extends RecordedEventBase<Type> {
+export interface BinaryRecordedEvent<
+  Type extends string = string,
+  Metadata = unknown
+> extends RecordedEventBase<Type, Metadata> {
   /**
    * Indicates whether the content is internally marked as JSON.
    */
@@ -150,17 +152,12 @@ export interface BinaryRecordedEvent<Type extends string = string>
    * Data of this event.
    */
   data: Uint8Array;
-
-  /**
-   * Representing the metadata associated with this event.
-   */
-  metadata: Uint8Array;
 }
 
 export interface AllStreamJSONRecordedEvent<
   Type extends string = string,
   Data = unknown,
-  Metadata extends Record<string, unknown> = Record<string, unknown>
+  Metadata = unknown
 > extends JSONRecordedEvent<Type, Data, Metadata> {
   /**
    * Position of this event in the transaction log.
@@ -168,8 +165,10 @@ export interface AllStreamJSONRecordedEvent<
   position: Position;
 }
 
-export interface AllStreamBinaryRecordedEvent<Type extends string = string>
-  extends BinaryRecordedEvent<Type> {
+export interface AllStreamBinaryRecordedEvent<
+  Type extends string = string,
+  Metadata = unknown
+> extends BinaryRecordedEvent<Type, Metadata> {
   /**
    * Position of this event in the transaction log.
    */


### PR DESCRIPTION
- Allow writing events with binarty or json metadata, regardless of type
- [ts] Allow typing of binary metadata, and extend json metadata typing requirement to include Uint8Array
- Don't parse metadata based off of event type when reading events

fixes: #99 