### PR TITLE
Prevent possible Channel race condition

### DIFF
--- a/src/Client/index.ts
+++ b/src/Client/index.ts
@@ -67,7 +67,7 @@ export class Client {
   #channelCredentials: ChannelCredentials;
   #defaultCredentials?: Credentials;
 
-  #channel?: Channel;
+  #channel?: Promise<Channel>;
   #grpcClients: Map<GRPCClientConstructor<GRPCClient>, GRPCClient> = new Map();
 
   /**
@@ -207,12 +207,18 @@ export class Client {
     return client;
   };
 
-  private getChannel = async () => {
+  private getChannel = async (): Promise<Channel> => {
     if (this.#channel) {
       debug.connection("Using existing connection");
       return this.#channel;
     }
 
+    this.#channel = this.createChannel();
+
+    return this.#channel;
+  };
+
+  private createChannel = async (): Promise<Channel> => {
     const uri = await this.resolveUri();
 
     debug.connection(
@@ -222,9 +228,7 @@ export class Client {
       uri
     );
 
-    this.#channel = new Channel(uri, this.#channelCredentials, {});
-
-    return this.#channel;
+    return new Channel(uri, this.#channelCredentials, {});
   };
 
   private resolveUri = async (): Promise<string> => {


### PR DESCRIPTION
Its possible to accidentaly connect to two nodes via the following:

``` ts
const client = EventStoreDBClient.connectionString`esdb+discover://eventstore.dev&nodePreference=random`;
client.connectToPersistentSubscription // no channel yet, begin discovery
await client.appendToStream // still no channel yet, and `connectToPS` doesnt return a promise, so we immediately begin discovery 
```

If nodePreference is random, discovery could resolve to different nodes. The second chosen node is used for subsiquent requests, but the first chosen node is used by its requesting command.
