### PR TITLE
Renamed count to maxCount in read methods and make it optional

### DIFF
--- a/src/__test__/connection/Channel.test.ts
+++ b/src/__test__/connection/Channel.test.ts
@@ -30,7 +30,11 @@ describe("Channel", () => {
 
     const promises: Promise<unknown>[] = [
       client.appendToStream("stream_1", jsonTestEvents()),
-      client.readAll(1, { fromPosition: "start", direction: "forwards" }),
+      client.readAll({
+        maxCount: 1,
+        fromPosition: "start",
+        direction: "forwards",
+      }),
       client.appendToStream("stream_2", jsonTestEvents()),
     ];
 

--- a/src/__test__/connection/cluster.test.ts
+++ b/src/__test__/connection/cluster.test.ts
@@ -22,7 +22,7 @@ describe("cluster", () => {
     );
 
     const appendResult = await client.appendToStream(STREAM_NAME, event);
-    const readResult = await client.readStream(STREAM_NAME, 10);
+    const readResult = await client.readStream(STREAM_NAME, { maxCount: 10 });
 
     expect(appendResult).toBeDefined();
     expect(readResult).toBeDefined();

--- a/src/__test__/connection/connectionString.test.ts
+++ b/src/__test__/connection/connectionString.test.ts
@@ -29,7 +29,9 @@ describe("connectionString", () => {
           STREAM_NAME,
           testEvent()
         );
-        const readResult = await client.readStream(STREAM_NAME, 10);
+        const readResult = await client.readStream(STREAM_NAME, {
+          maxCount: 10,
+        });
 
         expect(appendResult).toBeDefined();
         expect(readResult).toBeDefined();
@@ -46,7 +48,9 @@ describe("connectionString", () => {
           STREAM_NAME,
           testEvent()
         );
-        const readResult = await client.readStream(STREAM_NAME, 10);
+        const readResult = await client.readStream(STREAM_NAME, {
+          maxCount: 10,
+        });
 
         expect(appendResult).toBeDefined();
         expect(readResult).toBeDefined();
@@ -54,7 +58,7 @@ describe("connectionString", () => {
 
       test("default credentials", async () => {
         const client = EventStoreDBClient.connectionString`esdb://admin:changeit@${node.uri}?tls=false`;
-        await expect(client.readAll(10)).resolves.toBeDefined();
+        await expect(client.readAll({ maxCount: 10 })).resolves.toBeDefined();
       });
     });
 
@@ -72,7 +76,9 @@ describe("connectionString", () => {
           testEvent()
         );
 
-        const readResult = await client.readStream(STREAM_NAME, 10);
+        const readResult = await client.readStream(STREAM_NAME, {
+          maxCount: 10,
+        });
 
         expect(appendResult).toBeDefined();
         expect(readResult).toBeDefined();
@@ -91,7 +97,9 @@ describe("connectionString", () => {
           STREAM_NAME,
           testEvent()
         );
-        const readResult = await client.readStream(STREAM_NAME, 10);
+        const readResult = await client.readStream(STREAM_NAME, {
+          maxCount: 10,
+        });
 
         expect(appendResult).toBeDefined();
         expect(readResult).toBeDefined();
@@ -104,7 +112,7 @@ describe("connectionString", () => {
 
         const client = EventStoreDBClient.connectionString`esdb://admin:changeit@${gossipEndpoints}?tls=false&nodePreference=leader`;
 
-        await expect(client.readAll(10)).resolves.toBeDefined();
+        await expect(client.readAll({ maxCount: 10 })).resolves.toBeDefined();
       });
     });
   });

--- a/src/__test__/connection/defaultCredentials.test.ts
+++ b/src/__test__/connection/defaultCredentials.test.ts
@@ -20,9 +20,10 @@ describe("defaultCredentials", () => {
         { rootCertificate: node.rootCertificate },
         { username: "admin", password: "changeit" }
       );
-      await expect(client.readAll(10)).resolves.toBeDefined();
+      await expect(client.readAll({ maxCount: 10 })).resolves.toBeDefined();
       await expect(
-        client.readAll(10, {
+        client.readAll({
+          maxCount: 10,
           credentials: { username: "AzureDiamond", password: "hunter2" },
         })
       ).rejects.toThrowError(AccessDeniedError);
@@ -34,9 +35,12 @@ describe("defaultCredentials", () => {
         { rootCertificate: node.rootCertificate },
         { username: "AzureDiamond", password: "hunter2" }
       );
-      await expect(client.readAll(10)).rejects.toThrowError(AccessDeniedError);
+      await expect(client.readAll({ maxCount: 10 })).rejects.toThrowError(
+        AccessDeniedError
+      );
       await expect(
-        client.readAll(10, {
+        client.readAll({
+          maxCount: 10,
           credentials: { username: "admin", password: "changeit" },
         })
       ).resolves.toBeDefined();

--- a/src/__test__/connection/dns.test.ts
+++ b/src/__test__/connection/dns.test.ts
@@ -39,7 +39,7 @@ optionalDescribe(!!process.env.EVENTSTORE_CLOUD_ID)("dns discover", () => {
       const client = createClient();
 
       const appendResult = await client.appendToStream(STREAM_NAME, event);
-      const readResult = await client.readStream(STREAM_NAME, 10);
+      const readResult = await client.readStream(STREAM_NAME, { maxCount: 10 });
 
       expect(appendResult).toBeDefined();
       expect(readResult).toBeDefined();

--- a/src/__test__/connection/insecure.test.ts
+++ b/src/__test__/connection/insecure.test.ts
@@ -22,7 +22,7 @@ describe("insecure", () => {
     );
 
     const appendResult = await client.appendToStream(STREAM_NAME, event);
-    const readResult = await client.readStream(STREAM_NAME, 10);
+    const readResult = await client.readStream(STREAM_NAME, { maxCount: 10 });
 
     expect(appendResult).toBeDefined();
     expect(readResult).toBeDefined();

--- a/src/__test__/connection/not-leader.test.ts
+++ b/src/__test__/connection/not-leader.test.ts
@@ -39,7 +39,8 @@ describe("not-leader", () => {
     expect(appendResult).toBeDefined();
 
     const readFromTestStream = (client: EventStoreDBClient) => {
-      return client.readStream(STREAM_NAME, 10, {
+      return client.readStream(STREAM_NAME, {
+        maxCount: 10,
         direction: BACKWARDS,
         fromRevision: END,
         requiresLeader: true,

--- a/src/__test__/connection/singleNode.test.ts
+++ b/src/__test__/connection/singleNode.test.ts
@@ -22,7 +22,7 @@ describe("singleNodeConnection", () => {
     );
 
     const appendResult = await client.appendToStream(STREAM_NAME, event);
-    const readResult = await client.readStream(STREAM_NAME, 10);
+    const readResult = await client.readStream(STREAM_NAME, { maxCount: 10 });
 
     expect(appendResult).toBeDefined();
     expect(readResult).toBeDefined();

--- a/src/__test__/streams/appendToStream.test.ts
+++ b/src/__test__/streams/appendToStream.test.ts
@@ -63,7 +63,9 @@ describe("appendToStream", () => {
           expect(result).toBeDefined();
           expect(result.nextExpectedRevision).toBeGreaterThanOrEqual(0);
 
-          const rxEvents = await client.readStream(STREAM_NAME, 1);
+          const rxEvents = await client.readStream(STREAM_NAME, {
+            maxCount: 1,
+          });
 
           expect(rxEvents).toBeDefined();
           expect(rxEvents.length).toEqual(1);
@@ -85,7 +87,9 @@ describe("appendToStream", () => {
           expect(result).toBeDefined();
           expect(result.nextExpectedRevision).toBeGreaterThanOrEqual(0);
 
-          const rxEvents = await client.readStream(STREAM_NAME, 1);
+          const rxEvents = await client.readStream(STREAM_NAME, {
+            maxCount: 1,
+          });
 
           expect(rxEvents).toBeDefined();
           expect(rxEvents.length).toEqual(1);
@@ -116,7 +120,9 @@ describe("appendToStream", () => {
           expect(result).toBeDefined();
           expect(result.nextExpectedRevision).toBeGreaterThanOrEqual(0);
 
-          const rxEvents = await client.readStream(STREAM_NAME, 1);
+          const rxEvents = await client.readStream(STREAM_NAME, {
+            maxCount: 1,
+          });
 
           expect(rxEvents).toBeDefined();
           expect(rxEvents.length).toEqual(1);
@@ -139,7 +145,9 @@ describe("appendToStream", () => {
           expect(result).toBeDefined();
           expect(result.nextExpectedRevision).toBeGreaterThanOrEqual(0);
 
-          const rxEvents = await client.readStream(STREAM_NAME, 1);
+          const rxEvents = await client.readStream(STREAM_NAME, {
+            maxCount: 1,
+          });
 
           expect(rxEvents).toBeDefined();
           expect(rxEvents.length).toEqual(1);
@@ -170,7 +178,9 @@ describe("appendToStream", () => {
           expect(result).toBeDefined();
           expect(result.nextExpectedRevision).toBeGreaterThanOrEqual(0);
 
-          const rxEvents = await client.readStream(STREAM_NAME, 1);
+          const rxEvents = await client.readStream(STREAM_NAME, {
+            maxCount: 1,
+          });
 
           expect(rxEvents).toBeDefined();
           expect(rxEvents.length).toEqual(1);
@@ -193,7 +203,9 @@ describe("appendToStream", () => {
           expect(result).toBeDefined();
           expect(result.nextExpectedRevision).toBeGreaterThanOrEqual(0);
 
-          const rxEvents = await client.readStream(STREAM_NAME, 1);
+          const rxEvents = await client.readStream(STREAM_NAME, {
+            maxCount: 1,
+          });
 
           expect(rxEvents).toBeDefined();
           expect(rxEvents.length).toEqual(1);
@@ -220,7 +232,9 @@ describe("appendToStream", () => {
           expect(result).toBeDefined();
           expect(result.nextExpectedRevision).toBeGreaterThanOrEqual(0);
 
-          const rxEvents = await client.readStream(STREAM_NAME, 1);
+          const rxEvents = await client.readStream(STREAM_NAME, {
+            maxCount: 1,
+          });
 
           expect(rxEvents).toBeDefined();
           expect(rxEvents.length).toEqual(1);
@@ -239,7 +253,9 @@ describe("appendToStream", () => {
           expect(result).toBeDefined();
           expect(result.nextExpectedRevision).toBeGreaterThanOrEqual(0);
 
-          const rxEvents = await client.readStream(STREAM_NAME, 1);
+          const rxEvents = await client.readStream(STREAM_NAME, {
+            maxCount: 1,
+          });
 
           expect(rxEvents).toBeDefined();
           expect(rxEvents.length).toEqual(1);

--- a/src/__test__/streams/deleteStream.test.ts
+++ b/src/__test__/streams/deleteStream.test.ts
@@ -38,7 +38,7 @@ describe("deleteStream", () => {
         expect(result).toBeDefined();
 
         await expect(
-          client.readStream(ANY_REVISION_STREAM, 10)
+          client.readStream(ANY_REVISION_STREAM, { maxCount: 10 })
         ).rejects.toThrowError(StreamNotFoundError);
       });
     });
@@ -68,7 +68,8 @@ describe("deleteStream", () => {
         });
 
         it("succeeds", async () => {
-          const events = await client.readStream(STREAM, 1, {
+          const events = await client.readStream(STREAM, {
+            maxCount: 1,
             direction: BACKWARDS,
             fromRevision: "end",
           });
@@ -81,9 +82,9 @@ describe("deleteStream", () => {
 
           expect(result).toBeDefined();
 
-          await expect(client.readStream(STREAM, 1)).rejects.toThrowError(
-            StreamNotFoundError
-          );
+          await expect(
+            client.readStream(STREAM, { maxCount: 1 })
+          ).rejects.toThrowError(StreamNotFoundError);
         });
       });
 

--- a/src/__test__/streams/readAll.test.ts
+++ b/src/__test__/streams/readAll.test.ts
@@ -26,9 +26,7 @@ describe("readAll", () => {
 
   describe("should successfully read from $all", () => {
     test("from start", async () => {
-      const events = await client.readAll(Number.MAX_SAFE_INTEGER, {
-        fromPosition: START,
-      });
+      const events = await client.readAll();
 
       expect(events).toBeDefined();
       expect(events.length).toBeGreaterThan(8);

--- a/src/__test__/streams/readAll.test.ts
+++ b/src/__test__/streams/readAll.test.ts
@@ -1,6 +1,6 @@
 import { createTestNode, jsonTestEvents } from "../utils";
 
-import { EventStoreDBClient, BACKWARDS, END, START } from "../..";
+import { EventStoreDBClient, BACKWARDS, END } from "../..";
 
 describe("readAll", () => {
   const node = createTestNode();
@@ -39,11 +39,12 @@ describe("readAll", () => {
     });
 
     test("from position", async () => {
-      const [, , eventToExtract] = await client.readAll(3);
+      const [, , eventToExtract] = await client.readAll({ maxCount: 3 });
 
       const { position } = eventToExtract.event!;
 
-      const [extracted] = await client.readAll(1, {
+      const [extracted] = await client.readAll({
+        maxCount: 1,
         fromPosition: position,
       });
 
@@ -51,7 +52,7 @@ describe("readAll", () => {
     });
 
     test("backwards from end", async () => {
-      const events = await client.readAll(Number.MAX_SAFE_INTEGER, {
+      const events = await client.readAll({
         direction: BACKWARDS,
         fromPosition: END,
       });
@@ -67,7 +68,7 @@ describe("readAll", () => {
     });
 
     test("count", async () => {
-      const events = await client.readAll(2);
+      const events = await client.readAll({ maxCount: 2 });
       expect(events.length).toBe(2);
     });
   });

--- a/src/__test__/streams/readStream.test.ts
+++ b/src/__test__/streams/readStream.test.ts
@@ -65,8 +65,7 @@ describe("readStream", () => {
     describe("options", () => {
       test("from start", async () => {
         const events = await client.readStream(
-          STREAM_NAME,
-          Number.MAX_SAFE_INTEGER
+          STREAM_NAME
         );
 
         expect(events.length).toBe(8);

--- a/src/__test__/streams/readStream.test.ts
+++ b/src/__test__/streams/readStream.test.ts
@@ -34,7 +34,8 @@ describe("readStream", () => {
   describe("should successfully read from stream", () => {
     describe("Event types", () => {
       test("json event", async () => {
-        const [resolvedEvent] = await client.readStream(STREAM_NAME, 1, {
+        const [resolvedEvent] = await client.readStream(STREAM_NAME, {
+          maxCount: 1,
           fromRevision: BigInt(1),
         });
 
@@ -49,7 +50,8 @@ describe("readStream", () => {
       });
 
       test("binary event", async () => {
-        const [resolvedEvent] = await client.readStream(STREAM_NAME, 1, {
+        const [resolvedEvent] = await client.readStream(STREAM_NAME, {
+          maxCount: 1,
           fromRevision: BigInt(5),
         });
 
@@ -64,53 +66,39 @@ describe("readStream", () => {
 
     describe("options", () => {
       test("from start", async () => {
-        const events = await client.readStream(
-          STREAM_NAME
-        );
+        const events = await client.readStream(STREAM_NAME);
 
         expect(events.length).toBe(8);
       });
 
       test("from revision", async () => {
-        const events = await client.readStream(
-          STREAM_NAME,
-          Number.MAX_SAFE_INTEGER,
-          {
-            fromRevision: BigInt(1),
-          }
-        );
+        const events = await client.readStream(STREAM_NAME, {
+          fromRevision: BigInt(1),
+        });
 
         expect(events.length).toBe(7);
       });
 
       test("backwards from end", async () => {
-        const events = await client.readStream(
-          STREAM_NAME,
-          Number.MAX_SAFE_INTEGER,
-          {
-            direction: BACKWARDS,
-            fromRevision: END,
-          }
-        );
+        const events = await client.readStream(STREAM_NAME, {
+          direction: BACKWARDS,
+          fromRevision: END,
+        });
 
         expect(events.length).toBe(8);
       });
 
       test("backwards from revision", async () => {
-        const events = await client.readStream(
-          STREAM_NAME,
-          Number.MAX_SAFE_INTEGER,
-          {
-            direction: BACKWARDS,
-            fromRevision: BigInt(1),
-          }
-        );
+        const events = await client.readStream(STREAM_NAME, {
+          direction: BACKWARDS,
+          fromRevision: BigInt(1),
+        });
 
         expect(events.length).toBe(2);
       });
 
       test("count", async () => {
-        const events = await client.readStream(STREAM_NAME, 2);
+        const events = await client.readStream(STREAM_NAME, { maxCount: 2 });
 
         expect(events.length).toBe(2);
       });

--- a/src/__test__/streams/tombstoneStream.test.ts
+++ b/src/__test__/streams/tombstoneStream.test.ts
@@ -37,7 +37,9 @@ describe("tombstoneStream", () => {
         expect(result).toBeDefined();
 
         try {
-          const result = await client.readStream(ANY_REVISION_STREAM, 10);
+          const result = await client.readStream(ANY_REVISION_STREAM, {
+            maxCount: 10,
+          });
 
           expect(result).toBe("Unreachable");
         } catch (error) {
@@ -75,7 +77,8 @@ describe("tombstoneStream", () => {
         });
 
         it("succeeds", async () => {
-          const [resolvedEvent] = await client.readStream(STREAM, 1, {
+          const [resolvedEvent] = await client.readStream(STREAM, {
+            maxCount: 1,
             direction: BACKWARDS,
             fromRevision: END,
           });
@@ -89,7 +92,7 @@ describe("tombstoneStream", () => {
           expect(result).toBeDefined();
 
           await expect(() =>
-            client.readStream(STREAM, 10)
+            client.readStream(STREAM, { maxCount: 10 })
           ).rejects.toThrowError(StreamDeletedError);
         });
       });
@@ -125,7 +128,7 @@ describe("tombstoneStream", () => {
           expect(result).toBeDefined();
 
           await expect(() =>
-            client.readStream(NOT_A_STREAM, 10)
+            client.readStream(NOT_A_STREAM, { maxCount: 10 })
           ).rejects.toThrowError(StreamDeletedError);
         });
       });

--- a/src/streams/readAll.ts
+++ b/src/streams/readAll.ts
@@ -15,6 +15,11 @@ import { Client } from "../Client";
 
 export interface ReadAllOptions extends BaseOptions {
   /**
+   * The number of events to read.
+   * @defaultValue Number.MAX_SAFE_INTEGER
+   */
+  maxCount?: number | BigInt;
+  /**
    * Starts the read at the given position.
    * @defaultValue START
    */
@@ -31,20 +36,16 @@ declare module "../Client" {
     /**
      * Reads events from the $all. You can read forwards or backwards.
      * You might need to be authenticated to execute the command successfully.
-     * @param maxCount The number of events to read
      * @param options Reading options
      */
-    readAll(
-      maxCount?: number | BigInt,
-      options?: ReadAllOptions
-    ): Promise<AllStreamResolvedEvent[]>;
+    readAll(options?: ReadAllOptions): Promise<AllStreamResolvedEvent[]>;
   }
 }
 
 Client.prototype.readAll = async function (
   this: Client,
-  maxCount?: number | BigInt,
   {
+    maxCount = Number.MAX_SAFE_INTEGER,
     fromPosition = START,
     direction = FORWARDS,
     ...baseOptions
@@ -77,7 +78,7 @@ Client.prototype.readAll = async function (
       break;
     }
   }
-  options.setCount((maxCount ?? Number.MAX_SAFE_INTEGER).toString(10));
+  options.setCount(maxCount.toString(10));
   options.setAll(allOptions);
   options.setUuidOption(uuidOption);
   options.setNoFilter(new Empty());
@@ -96,7 +97,7 @@ Client.prototype.readAll = async function (
   req.setOptions(options);
 
   debug.command("readAll: %O", {
-    maxCount: maxCount,
+    maxCount,
     options: {
       fromPosition,
       direction,

--- a/src/streams/readAll.ts
+++ b/src/streams/readAll.ts
@@ -31,11 +31,11 @@ declare module "../Client" {
     /**
      * Reads events from the $all. You can read forwards or backwards.
      * You might need to be authenticated to execute the command successfully.
-     * @param count The number of events to read
+     * @param maxCount The number of events to read
      * @param options Reading options
      */
     readAll(
-      count: number | BigInt,
+      maxCount?: number | BigInt,
       options?: ReadAllOptions
     ): Promise<AllStreamResolvedEvent[]>;
   }
@@ -43,7 +43,7 @@ declare module "../Client" {
 
 Client.prototype.readAll = async function (
   this: Client,
-  count: number | BigInt,
+  maxCount?: number | BigInt,
   {
     fromPosition = START,
     direction = FORWARDS,
@@ -77,7 +77,7 @@ Client.prototype.readAll = async function (
       break;
     }
   }
-  options.setCount(count.toString(10));
+  options.setCount((maxCount ?? Number.MAX_SAFE_INTEGER).toString(10));
   options.setAll(allOptions);
   options.setUuidOption(uuidOption);
   options.setNoFilter(new Empty());
@@ -96,7 +96,7 @@ Client.prototype.readAll = async function (
   req.setOptions(options);
 
   debug.command("readAll: %O", {
-    count,
+    maxCount: maxCount,
     options: {
       fromPosition,
       direction,

--- a/src/streams/readStream.ts
+++ b/src/streams/readStream.ts
@@ -10,6 +10,11 @@ import { debug, handleBatchRead, convertGrpcEvent } from "../utils";
 
 export interface ReadStreamOptions extends BaseOptions {
   /**
+   * The number of events to read.
+   * @defaultValue Number.MAX_SAFE_INTEGER
+   */
+  maxCount?: number | BigInt;
+  /**
    * Starts the read at the given event revision.
    * @defaultValue START
    */
@@ -33,12 +38,10 @@ declare module "../Client" {
     /**
      * Sends events to a given stream.
      * @param streamName A stream name.
-     * @param maxCount Amount to read
      * @param options Reading options
      */
     readStream(
       streamName: string,
-      maxCount?: number | BigInt,
       options?: ReadStreamOptions
     ): Promise<ResolvedEvent[]>;
   }
@@ -47,8 +50,8 @@ declare module "../Client" {
 Client.prototype.readStream = async function (
   this: Client,
   streamName: string,
-  maxCount?: number | BigInt,
   {
+    maxCount = Number.MAX_SAFE_INTEGER,
     fromRevision = START,
     resolveLinkTos = false,
     direction = FORWARDS,
@@ -83,7 +86,7 @@ Client.prototype.readStream = async function (
 
   options.setStream(streamOptions);
   options.setResolveLinks(resolveLinkTos);
-  options.setCount((maxCount ?? Number.MAX_SAFE_INTEGER).toString(10));
+  options.setCount(maxCount.toString(10));
   options.setUuidOption(uuidOption);
   options.setNoFilter(new Empty());
 
@@ -102,7 +105,7 @@ Client.prototype.readStream = async function (
 
   debug.command("readStream: %O", {
     streamName,
-    maxCount: maxCount,
+    maxCount,
     options: {
       fromRevision,
       resolveLinkTos,

--- a/src/streams/readStream.ts
+++ b/src/streams/readStream.ts
@@ -33,12 +33,12 @@ declare module "../Client" {
     /**
      * Sends events to a given stream.
      * @param streamName A stream name.
-     * @param count Amount to read
+     * @param maxCount Amount to read
      * @param options Reading options
      */
     readStream(
       streamName: string,
-      count: number | BigInt,
+      maxCount?: number | BigInt,
       options?: ReadStreamOptions
     ): Promise<ResolvedEvent[]>;
   }
@@ -47,7 +47,7 @@ declare module "../Client" {
 Client.prototype.readStream = async function (
   this: Client,
   streamName: string,
-  count: number | BigInt,
+  maxCount?: number | BigInt,
   {
     fromRevision = START,
     resolveLinkTos = false,
@@ -83,7 +83,7 @@ Client.prototype.readStream = async function (
 
   options.setStream(streamOptions);
   options.setResolveLinks(resolveLinkTos);
-  options.setCount(count.toString(10));
+  options.setCount((maxCount ?? Number.MAX_SAFE_INTEGER).toString(10));
   options.setUuidOption(uuidOption);
   options.setNoFilter(new Empty());
 
@@ -102,7 +102,7 @@ Client.prototype.readStream = async function (
 
   debug.command("readStream: %O", {
     streamName,
-    count,
+    maxCount: maxCount,
     options: {
       fromRevision,
       resolveLinkTos,


### PR DESCRIPTION
Other clients (.NET, Java) are using `count` as parameter name instead of `maxCount`. They also make it optional.
- renamed `count` to `maxCount`,
- moved `maxCount` from method parameter to `ReadOptions` an `ReadAllOptions` to align with the JS/TS convention (there is no method overload),
- make it optional - used `Number.MAX_SAFE_INTEGER` as a fallback.