### PR TITLE
Move credentials header to CallCredentials

### DIFF
--- a/src/Client/index.ts
+++ b/src/Client/index.ts
@@ -72,6 +72,7 @@ export class Client {
   #throwOnAppendFailure: boolean;
   #connectionSettings: ConnectionTypeOptions;
   #channelCredentials: ChannelCredentials;
+  #insecure: boolean;
   #defaultCredentials?: Credentials;
 
   #channel?: Promise<Channel>;
@@ -173,9 +174,10 @@ export class Client {
   ) {
     this.#throwOnAppendFailure = throwOnAppendFailure;
     this.#connectionSettings = connectionSettings;
+    this.#insecure = !!channelCredentials.insecure;
     this.#defaultCredentials = defaultUserCredentials;
 
-    if (channelCredentials.insecure) {
+    if (this.#insecure) {
       debug.connection("Using insecure channel");
       this.#channelCredentials = grpcCredentials.createInsecure();
     } else {
@@ -272,8 +274,16 @@ export class Client {
     typeof grpcCredentials.createFromMetadataGenerator
   >[0] => (_, cb) => {
     const metadata = new Metadata();
-    const auth = Buffer.from(`${username}:${password}`).toString("base64");
-    metadata.add("authorization", `Basic ${auth}`);
+
+    if (this.#insecure) {
+      debug.connection(
+        "Credentials are unsupported in insecure mode, and will be ignored."
+      );
+    } else {
+      const auth = Buffer.from(`${username}:${password}`).toString("base64");
+      metadata.add("authorization", `Basic ${auth}`);
+    }
+
     return cb(null, metadata);
   };
 

--- a/src/persistentSubscription/connectToPersistentSubscription.ts
+++ b/src/persistentSubscription/connectToPersistentSubscription.ts
@@ -72,9 +72,11 @@ Client.prototype.connectToPersistentSubscription = function (
       PersistentSubscriptionsClient,
       "connectToPersistentSubscription"
     );
-    const stream = client.read(this.metadata(baseOptions), {
-      deadline: Infinity,
-    });
+    const stream = client.read(
+      ...this.callArguments(baseOptions, {
+        deadline: Infinity,
+      })
+    );
     stream.write(req);
     return stream;
   }, duplexOptions);

--- a/src/persistentSubscription/createPersistentSubscription.ts
+++ b/src/persistentSubscription/createPersistentSubscription.ts
@@ -119,7 +119,7 @@ Client.prototype.createPersistentSubscription = async function (
   );
 
   return new Promise<void>((resolve, reject) => {
-    client.create(req, this.metadata(baseOptions), (error) => {
+    client.create(req, ...this.callArguments(baseOptions), (error) => {
       if (error) return reject(convertToCommandError(error));
       return resolve();
     });

--- a/src/persistentSubscription/deletePersistentSubscription.ts
+++ b/src/persistentSubscription/deletePersistentSubscription.ts
@@ -52,7 +52,7 @@ Client.prototype.deletePersistentSubscription = async function (
   );
 
   return new Promise<void>((resolve, reject) => {
-    client.delete(req, this.metadata(baseOptions), (error) => {
+    client.delete(req, ...this.callArguments(baseOptions), (error) => {
       if (error) return reject(convertToCommandError(error));
       return resolve();
     });

--- a/src/persistentSubscription/updatePersistentSubscription.ts
+++ b/src/persistentSubscription/updatePersistentSubscription.ts
@@ -117,7 +117,7 @@ Client.prototype.updatePersistentSubscription = async function (
   );
 
   return new Promise<void>((resolve, reject) => {
-    client.update(req, this.metadata(baseOptions), (error) => {
+    client.update(req, ...this.callArguments(baseOptions), (error) => {
       if (error) return reject(convertToCommandError(error));
       return resolve();
     });

--- a/src/projections/createContinuousProjection.ts
+++ b/src/projections/createContinuousProjection.ts
@@ -66,7 +66,7 @@ Client.prototype.createContinuousProjection = async function (
   );
 
   return new Promise<void>((resolve, reject) => {
-    client.create(req, this.metadata(baseOptions), (error) => {
+    client.create(req, ...this.callArguments(baseOptions), (error) => {
       if (error) return reject(convertToCommandError(error));
       return resolve();
     });

--- a/src/projections/createOneTimeProjection.ts
+++ b/src/projections/createOneTimeProjection.ts
@@ -62,7 +62,7 @@ Client.prototype.createOneTimeProjection = async function (
   return new Promise<void>((resolve, reject) => {
     client.create(
       req,
-      this.metadata(typeof baseOptions === "string" ? {} : baseOptions),
+      ...this.callArguments(typeof baseOptions === "string" ? {} : baseOptions),
       (error) => {
         if (error) return reject(convertToCommandError(error));
         return resolve();

--- a/src/projections/createTransientProjection.ts
+++ b/src/projections/createTransientProjection.ts
@@ -53,7 +53,7 @@ Client.prototype.createTransientProjection = async function (
   );
 
   return new Promise<void>((resolve, reject) => {
-    client.create(req, this.metadata(baseOptions), (error) => {
+    client.create(req, ...this.callArguments(baseOptions), (error) => {
       if (error) return reject(convertToCommandError(error));
       return resolve();
     });

--- a/src/projections/deleteProjection.ts
+++ b/src/projections/deleteProjection.ts
@@ -76,7 +76,7 @@ Client.prototype.deleteProjection = async function (
   );
 
   return new Promise<void>((resolve, reject) => {
-    client.delete(req, this.metadata(baseOptions), (error) => {
+    client.delete(req, ...this.callArguments(baseOptions), (error) => {
       if (error) return reject(convertToCommandError(error));
       return resolve();
     });

--- a/src/projections/disableProjection.ts
+++ b/src/projections/disableProjection.ts
@@ -52,7 +52,7 @@ Client.prototype.disableProjection = async function (
   );
 
   return new Promise<void>((resolve, reject) => {
-    client.disable(req, this.metadata(baseOptions), (error) => {
+    client.disable(req, ...this.callArguments(baseOptions), (error) => {
       if (error) return reject(convertToCommandError(error));
       return resolve();
     });

--- a/src/projections/enableProjection.ts
+++ b/src/projections/enableProjection.ts
@@ -45,7 +45,7 @@ Client.prototype.enableProjection = async function (
   );
 
   return new Promise<void>((resolve, reject) => {
-    client.enable(req, this.metadata(baseOptions), (error) => {
+    client.enable(req, ...this.callArguments(baseOptions), (error) => {
       if (error) return reject(convertToCommandError(error));
       return resolve();
     });

--- a/src/projections/getProjectionResult.ts
+++ b/src/projections/getProjectionResult.ts
@@ -53,9 +53,13 @@ Client.prototype.getProjectionResult = async function <T = unknown>(
   );
 
   return new Promise<T>((resolve, reject) => {
-    client.result(req, this.metadata(baseOptions), (error, response) => {
-      if (error) return reject(convertToCommandError(error));
-      return resolve(response.getResult()?.toJavaScript() as T);
-    });
+    client.result(
+      req,
+      ...this.callArguments(baseOptions),
+      (error, response) => {
+        if (error) return reject(convertToCommandError(error));
+        return resolve(response.getResult()?.toJavaScript() as T);
+      }
+    );
   });
 };

--- a/src/projections/getProjectionState.ts
+++ b/src/projections/getProjectionState.ts
@@ -43,7 +43,7 @@ Client.prototype.getProjectionState = async function <T = unknown>(
   );
 
   return new Promise<T>((resolve, reject) => {
-    client.state(req, this.metadata(baseOptions), (error, response) => {
+    client.state(req, ...this.callArguments(baseOptions), (error, response) => {
       if (error) return reject(convertToCommandError(error));
       return resolve(response.getState()?.toJavaScript() as T);
     });

--- a/src/projections/getProjectionStatistics.ts
+++ b/src/projections/getProjectionStatistics.ts
@@ -47,7 +47,7 @@ Client.prototype.getProjectionStatistics = async function (
     "getProjectionStatistics"
   );
 
-  const stream = client.statistics(req, this.metadata(baseOptions));
+  const stream = client.statistics(req, ...this.callArguments(baseOptions));
 
   return new Promise((resolve, reject) => {
     let projectionDetail: ProjectionDetails;

--- a/src/projections/listProjections.ts
+++ b/src/projections/listProjections.ts
@@ -57,7 +57,7 @@ const fetchAndTransformProjectionList = async function (
 
   const client = await this.getGRPCClient(ProjectionsClient, debugName);
 
-  const stream = client.statistics(req, this.metadata(baseOptions));
+  const stream = client.statistics(req, ...this.callArguments(baseOptions));
 
   return new Promise((resolve, reject) => {
     const projectionDetails: ProjectionDetails[] = [];

--- a/src/projections/resetProjection.ts
+++ b/src/projections/resetProjection.ts
@@ -50,7 +50,7 @@ Client.prototype.resetProjection = async function (
   const client = await this.getGRPCClient(ProjectionsClient, "resetProjection");
 
   return new Promise<void>((resolve, reject) => {
-    client.reset(req, this.metadata(baseOptions), (error) => {
+    client.reset(req, ...this.callArguments(baseOptions), (error) => {
       if (error) return reject(convertToCommandError(error));
       return resolve();
     });

--- a/src/projections/restartSubsystem.ts
+++ b/src/projections/restartSubsystem.ts
@@ -34,9 +34,13 @@ Client.prototype.restartSubsystem = async function (
   );
 
   return new Promise<void>((resolve, reject) => {
-    client.restartSubsystem(req, this.metadata(baseOptions), (error) => {
-      if (error) return reject(convertToCommandError(error));
-      return resolve();
-    });
+    client.restartSubsystem(
+      req,
+      ...this.callArguments(baseOptions),
+      (error) => {
+        if (error) return reject(convertToCommandError(error));
+        return resolve();
+      }
+    );
   });
 };

--- a/src/projections/updateProjection.ts
+++ b/src/projections/updateProjection.ts
@@ -63,7 +63,7 @@ Client.prototype.updateProjection = async function (
   );
 
   return new Promise<void>((resolve, reject) => {
-    client.update(req, this.metadata(baseOptions), (error) => {
+    client.update(req, ...this.callArguments(baseOptions), (error) => {
       if (error) return reject(convertToCommandError(error));
       return resolve();
     });

--- a/src/streams/appendToStream.ts
+++ b/src/streams/appendToStream.ts
@@ -82,73 +82,76 @@ Client.prototype.appendToStream = async function (
   const client = await this.getGRPCClient(StreamsClient, "appendToStream");
 
   return new Promise<AppendResult>((resolve, reject) => {
-    const sink = client.append(this.metadata(baseOptions), (error, resp) => {
-      if (error != null) {
-        return reject(convertToCommandError(error));
-      }
-
-      if (resp.hasWrongExpectedVersion()) {
-        const grpcError = resp.getWrongExpectedVersion()!;
-
-        let expected: AppendExpectedRevision = "any";
-
-        switch (true) {
-          case grpcError.hasExpectedRevision(): {
-            expected = BigInt(grpcError.getExpectedRevision()!);
-            break;
-          }
-          case grpcError.hasExpectedStreamExists(): {
-            expected = "stream_exists";
-            break;
-          }
-          case grpcError.hasExpectedNoStream(): {
-            expected = "no_stream";
-            break;
-          }
+    const sink = client.append(
+      ...this.callArguments(baseOptions),
+      (error, resp) => {
+        if (error != null) {
+          return reject(convertToCommandError(error));
         }
 
-        if (this.throwOnAppendFailure) {
-          return reject(
-            new WrongExpectedVersionError(null as never, {
-              streamName: streamName,
-              current: grpcError.hasCurrentRevision()
-                ? BigInt(grpcError.getCurrentRevision())
-                : "no_stream",
-              expected,
-            })
-          );
-        }
+        if (resp.hasWrongExpectedVersion()) {
+          const grpcError = resp.getWrongExpectedVersion()!;
 
-        const nextExpectedRevision = grpcError.hasCurrentRevision()
-          ? BigInt(grpcError.getCurrentRevision())
-          : BigInt(-1);
+          let expected: AppendExpectedRevision = "any";
 
-        return resolve({
-          success: false,
-          nextExpectedRevision,
-          position: undefined,
-        });
-      }
-
-      if (resp.hasSuccess()) {
-        const success = resp.getSuccess()!;
-        const nextExpectedRevision = BigInt(success.getCurrentRevision());
-        const grpcPosition = success.getPosition();
-
-        const position = grpcPosition
-          ? {
-              commit: BigInt(grpcPosition.getCommitPosition()),
-              prepare: BigInt(grpcPosition.getPreparePosition()),
+          switch (true) {
+            case grpcError.hasExpectedRevision(): {
+              expected = BigInt(grpcError.getExpectedRevision()!);
+              break;
             }
-          : undefined;
+            case grpcError.hasExpectedStreamExists(): {
+              expected = "stream_exists";
+              break;
+            }
+            case grpcError.hasExpectedNoStream(): {
+              expected = "no_stream";
+              break;
+            }
+          }
 
-        return resolve({
-          success: true,
-          nextExpectedRevision,
-          position,
-        });
+          if (this.throwOnAppendFailure) {
+            return reject(
+              new WrongExpectedVersionError(null as never, {
+                streamName: streamName,
+                current: grpcError.hasCurrentRevision()
+                  ? BigInt(grpcError.getCurrentRevision())
+                  : "no_stream",
+                expected,
+              })
+            );
+          }
+
+          const nextExpectedRevision = grpcError.hasCurrentRevision()
+            ? BigInt(grpcError.getCurrentRevision())
+            : BigInt(-1);
+
+          return resolve({
+            success: false,
+            nextExpectedRevision,
+            position: undefined,
+          });
+        }
+
+        if (resp.hasSuccess()) {
+          const success = resp.getSuccess()!;
+          const nextExpectedRevision = BigInt(success.getCurrentRevision());
+          const grpcPosition = success.getPosition();
+
+          const position = grpcPosition
+            ? {
+                commit: BigInt(grpcPosition.getCommitPosition()),
+                prepare: BigInt(grpcPosition.getPreparePosition()),
+              }
+            : undefined;
+
+          return resolve({
+            success: true,
+            nextExpectedRevision,
+            position,
+          });
+        }
       }
-    });
+    );
 
     sink.write(header);
 

--- a/src/streams/deleteStream.ts
+++ b/src/streams/deleteStream.ts
@@ -67,7 +67,7 @@ Client.prototype.deleteStream = async function (
   const client = await this.getGRPCClient(StreamsClient, "deleteStream");
 
   return new Promise<DeleteResult>((resolve, reject) => {
-    client.delete(req, this.metadata(baseOptions), (error, resp) => {
+    client.delete(req, ...this.callArguments(baseOptions), (error, resp) => {
       if (error) {
         return reject(convertToCommandError(error));
       }

--- a/src/streams/readAll.ts
+++ b/src/streams/readAll.ts
@@ -106,6 +106,6 @@ Client.prototype.readAll = async function (
   debug.command_grpc("readAll: %g", req);
 
   const client = await this.getGRPCClient(StreamsClient, "readAll");
-  const stream = client.read(req, this.metadata(baseOptions));
+  const stream = client.read(req, ...this.callArguments(baseOptions));
   return handleBatchRead(stream, convertAllStreamGrpcEvent);
 };

--- a/src/streams/readStream.ts
+++ b/src/streams/readStream.ts
@@ -113,6 +113,6 @@ Client.prototype.readStream = async function (
   debug.command_grpc("readStream: %g", req);
 
   const client = await this.getGRPCClient(StreamsClient, "readStream");
-  const readableStream = client.read(req, this.metadata(baseOptions));
+  const readableStream = client.read(req, ...this.callArguments(baseOptions));
   return handleBatchRead(readableStream, convertGrpcEvent);
 };

--- a/src/streams/subscribeToAll.ts
+++ b/src/streams/subscribeToAll.ts
@@ -1,7 +1,5 @@
 import { ReadableOptions } from "stream";
 
-import { CallOptions } from "@grpc/grpc-js";
-
 import { Empty } from "../../generated/shared_pb";
 import { StreamsClient } from "../../generated/streams_grpc_pb";
 import { ReadReq } from "../../generated/streams_pb";
@@ -138,10 +136,6 @@ Client.prototype.subscribeToAll = function (
 
   req.setOptions(options);
 
-  const callOptions: CallOptions = {
-    deadline: Infinity,
-  };
-
   debug.command("subscribeToAll: %O", {
     options: {
       fromPosition,
@@ -155,7 +149,12 @@ Client.prototype.subscribeToAll = function (
   return new OneWaySubscription(
     async () => {
       const client = await this.getGRPCClient(StreamsClient, "subscribeToAll");
-      return client.read(req, this.metadata(baseOptions), callOptions);
+      return client.read(
+        req,
+        ...this.callArguments(baseOptions, {
+          deadline: Infinity,
+        })
+      );
     },
     convertAllStreamGrpcEvent,
     readableOptions

--- a/src/streams/subscribeToStream.ts
+++ b/src/streams/subscribeToStream.ts
@@ -1,5 +1,4 @@
 import { ReadableOptions } from "stream";
-import { CallOptions } from "@grpc/grpc-js";
 
 import { StreamsClient } from "../../generated/streams_grpc_pb";
 import { ReadReq } from "../../generated/streams_pb";
@@ -88,10 +87,6 @@ Client.prototype.subscribeToStream = function (
 
   req.setOptions(options);
 
-  const callOptions: CallOptions = {
-    deadline: Infinity,
-  };
-
   debug.command("subscribeToStream: %O", {
     streamName,
     options: {
@@ -108,7 +103,12 @@ Client.prototype.subscribeToStream = function (
         StreamsClient,
         "subscribeToStream"
       );
-      return client.read(req, this.metadata(baseOptions), callOptions);
+      return client.read(
+        req,
+        ...this.callArguments(baseOptions, {
+          deadline: Infinity,
+        })
+      );
     },
     convertGrpcEvent,
     readableOptions

--- a/src/streams/tombstoneStream.ts
+++ b/src/streams/tombstoneStream.ts
@@ -71,7 +71,7 @@ Client.prototype.tombstoneStream = async function (
   const client = await this.getGRPCClient(StreamsClient, "tombstoneStream");
 
   return new Promise<DeleteResult>((resolve, reject) => {
-    client.tombstone(req, this.metadata(baseOptions), (error, resp) => {
+    client.tombstone(req, ...this.callArguments(baseOptions), (error, resp) => {
       if (error) {
         return reject(convertToCommandError(error));
       }


### PR DESCRIPTION
- replace `this.metadata` with `this.callArguments`
- return call arguments (metadata?, callOptions?) and spread into call
- pass credentials to call args
- grpc-node still sends credentials passed directly to callArgs, so explicitly dont send them over insecure connection.

Insecure headers:
![image](https://user-images.githubusercontent.com/11861797/106608230-6f195c00-6564-11eb-8d71-132f0c763016.png)
Secure headers:
![image](https://user-images.githubusercontent.com/11861797/106608298-82c4c280-6564-11eb-993c-6b54ac87edaf.png)
