### PR TITLE
Re-work event types

### DIFF
--- a/src/__test__/extra/typedEvents.test.ts
+++ b/src/__test__/extra/typedEvents.test.ts
@@ -1,0 +1,335 @@
+import { createTestNode } from "../utils";
+
+import {
+  binaryEvent,
+  BinaryEventType,
+  EventStoreDBClient,
+  jsonEvent,
+  JSONEventType,
+} from "../..";
+import { persistentSubscriptionSettingsFromDefaults } from "../../utils";
+
+describe("typed events should compile", () => {
+  const node = createTestNode();
+  let client!: EventStoreDBClient;
+
+  beforeAll(async () => {
+    await node.up();
+    client = new EventStoreDBClient(
+      { endpoint: node.uri },
+      { rootCertificate: node.rootCertificate },
+      { username: "admin", password: "changeit" }
+    );
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  test("jsonEvent", () => {
+    type MyFirstEvent = JSONEventType<
+      "my-first-event",
+      { hello: string },
+      { meta: string }
+    >;
+
+    jsonEvent<MyFirstEvent>({
+      type: "my-first-event",
+      data: { hello: "hi" },
+      metadata: { meta: "data" },
+    });
+
+    jsonEvent<MyFirstEvent>(
+      // @ts-expect-error metadata is required in the event type
+      {
+        type: "my-first-event",
+        data: { hello: "hi" },
+      }
+    );
+
+    jsonEvent<MyFirstEvent>({
+      // @ts-expect-error wrong type
+      type: "my-second-event",
+      data: { hello: "hi" },
+      metadata: { meta: "data" },
+    });
+
+    type MyOtherEvent = JSONEventType<"my-other-event", { hello: string }>;
+
+    // not specifying metadata in type means it is optional
+    jsonEvent<MyOtherEvent>({
+      type: "my-other-event",
+      data: { hello: "hi" },
+    });
+
+    jsonEvent<MyOtherEvent>({
+      type: "my-other-event",
+      data: { hello: "hi" },
+      metadata: { however: "I can pass something, if I need" },
+    });
+
+    // dont have to pass type
+    jsonEvent({
+      type: "any_event",
+      data: { hello: "hi" },
+      metadata: { meta: "data" },
+    });
+
+    // metadata is optional by default
+    jsonEvent({
+      type: "any_event",
+      data: { hello: "hi" },
+    });
+
+    // @ts-expect-error wont take a BinaryEventType
+    jsonEvent<BinaryEventType>({
+      type: "any_event",
+      data: { hello: "hi" },
+    });
+  });
+
+  test("binaryEvent", () => {
+    type MySecondEvent = BinaryEventType<"my-second-event", { meta: string }>;
+
+    binaryEvent<MySecondEvent>({
+      type: "my-second-event",
+      data: new Uint8Array(),
+      metadata: { meta: "data" },
+    });
+
+    binaryEvent<MySecondEvent>(
+      // @ts-expect-error metadata is required in the event type
+      {
+        type: "my-second-event",
+        data: new Uint8Array(),
+      }
+    );
+
+    binaryEvent<MySecondEvent>({
+      // @ts-expect-error wrong type
+      type: "my-first-event",
+      data: new Uint8Array(),
+      metadata: { meta: "data" },
+    });
+
+    type MyOtherEvent = BinaryEventType<"my-other-event">;
+
+    // not specifying metadata in type means it is optional
+    binaryEvent<MyOtherEvent>({
+      type: "my-other-event",
+      data: new Uint8Array(),
+    });
+
+    binaryEvent<MyOtherEvent>({
+      type: "my-other-event",
+      data: new Uint8Array(),
+      metadata: { however: "I can pass something, if I need" },
+    });
+
+    // dont have to pass type
+    binaryEvent({
+      type: "any_event",
+      data: new Uint8Array(),
+      metadata: { meta: "data" },
+    });
+
+    // metadata is optional by default
+    binaryEvent({
+      type: "any_event",
+      data: new Uint8Array(),
+    });
+
+    // @ts-expect-error wont take a JSONEventType
+    binaryEvent<JSONEventType>({
+      type: "any_event",
+      data: new Uint8Array(),
+    });
+  });
+
+  test("readStream", async () => {
+    const STREAM_NAME = "known_types_in_stream";
+
+    // set up event types
+
+    type MyEvent = JSONEventType<
+      "my-event",
+      { hello: string },
+      { meta: string }
+    >;
+
+    type MyOtherEvent = JSONEventType<
+      "my-other-event",
+      { hi: string },
+      { metadata: string }
+    >;
+
+    type KnownEvents = MyEvent | MyOtherEvent;
+
+    const event1 = jsonEvent<MyEvent>({
+      type: "my-event",
+      data: { hello: "hi there" },
+      metadata: { meta: "data" },
+    });
+
+    const event2 = jsonEvent<MyOtherEvent>({
+      type: "my-other-event",
+      data: { hi: "hello there" },
+      metadata: { metadata: "goes here" },
+    });
+
+    await client.appendToStream(STREAM_NAME, [event1, event2]);
+
+    const [resolvedEvent] = await client.readStream<KnownEvents>(STREAM_NAME, {
+      maxCount: 1,
+    });
+
+    switch (resolvedEvent.event?.type) {
+      case "my-event":
+        // `hello` exists on the data of `my-event` so we can access it deirectly
+        expect(resolvedEvent.event.data.hello).toBeDefined();
+        break;
+      case "my-other-event":
+        // @ts-expect-error `hello` doesnt exist on `my-other-event`, so this errors
+        expect(resolvedEvent.event.data.hello).not.toBeDefined();
+        break;
+    }
+  });
+
+  test("subscribeToStream", async () => {
+    const STREAM_NAME = "known_types_in_stream_subscription";
+
+    // set up event types
+
+    type MyGreatEvent = JSONEventType<
+      "my-great-event",
+      { yay: true; reason: string },
+      { feels: string }
+    >;
+
+    enum WhatWentWrong {
+      "bad-stuff",
+      "kinda-bad-stuff",
+    }
+
+    type MyNotSoGreatEvent = JSONEventType<
+      "my-not-so-great-event",
+      { ohno: WhatWentWrong },
+      { feels: string }
+    >;
+
+    type KnownEvents = MyGreatEvent | MyNotSoGreatEvent;
+
+    const event1 = jsonEvent<MyGreatEvent>({
+      type: "my-great-event",
+      data: { yay: true, reason: "I wrote an event!" },
+      metadata: { feels: "great" },
+    });
+
+    const event2 = jsonEvent<MyNotSoGreatEvent>({
+      type: "my-not-so-great-event",
+      data: { ohno: WhatWentWrong["kinda-bad-stuff"] },
+      metadata: { feels: "terrible" },
+    });
+
+    await client.appendToStream(STREAM_NAME, [event1, event2]);
+
+    for await (const { event } of client.subscribeToStream<KnownEvents>(
+      STREAM_NAME
+    )) {
+      switch (event?.type) {
+        case "my-great-event":
+          // `yay` exists on the data of `my-event` so we can access it deirectly
+          expect(event.data.yay).toBeDefined();
+          // same here
+          expect(event.metadata.feels).toBeDefined();
+          break;
+        case "my-not-so-great-event":
+          //  jest infers this type as being `WhatWentWrong` so we can see that enum types work
+          expect(event.data.ohno).not.toBe(WhatWentWrong["kinda-bad-stuff"]);
+          break;
+        // @ts-expect-error this type doesnt exist
+        case "my-other-event":
+          // event is never
+          expect(event).not.toBeDefined();
+          break;
+      }
+
+      // we only care about the TS here
+      break;
+    }
+  });
+
+  test("connectToPersistantSubscription", async () => {
+    const STREAM_NAME = "known_types_in_persistant_subscription";
+    const GROUP_NAME = "some_group";
+
+    // set up event types
+
+    type MyGreatEvent = JSONEventType<
+      "my-great-event",
+      { yay: true; reason: string },
+      { feels: string }
+    >;
+
+    enum WhatWentWrong {
+      "bad-stuff",
+      "kinda-bad-stuff",
+    }
+
+    type MyNotSoGreatEvent = JSONEventType<
+      "my-not-so-great-event",
+      { ohno: WhatWentWrong },
+      { feels: string }
+    >;
+
+    type KnownEvents = MyGreatEvent | MyNotSoGreatEvent;
+
+    const event1 = jsonEvent<MyGreatEvent>({
+      type: "my-great-event",
+      data: { yay: true, reason: "I wrote an event!" },
+      metadata: { feels: "great" },
+    });
+
+    const event2 = jsonEvent<MyNotSoGreatEvent>({
+      type: "my-not-so-great-event",
+      data: { ohno: WhatWentWrong["kinda-bad-stuff"] },
+      metadata: { feels: "terrible" },
+    });
+
+    await client.createPersistentSubscription(
+      STREAM_NAME,
+      GROUP_NAME,
+      persistentSubscriptionSettingsFromDefaults()
+    );
+
+    await client.appendToStream(STREAM_NAME, [event1, event2]);
+
+    for await (const {
+      event,
+    } of client.connectToPersistentSubscription<KnownEvents>(
+      STREAM_NAME,
+      GROUP_NAME
+    )) {
+      switch (event?.type) {
+        case "my-great-event":
+          // `yay` exists on the data of `my-event` so we can access it deirectly
+          expect(event.data.yay).toBeDefined();
+          // same here
+          expect(event.metadata.feels).toBeDefined();
+          break;
+        case "my-not-so-great-event":
+          //  jest infers this type as being `WhatWentWrong` so we can see that enum types work
+          expect(event.data.ohno).not.toBe(WhatWentWrong["kinda-bad-stuff"]);
+          break;
+        // @ts-expect-error this type doesnt exist
+        case "my-other-event":
+          // event is never
+          expect(event).not.toBeDefined();
+          break;
+      }
+
+      // we only care about the TS here
+      break;
+    }
+  });
+});

--- a/src/__test__/streams/subscribeToAll.test.ts
+++ b/src/__test__/streams/subscribeToAll.test.ts
@@ -329,7 +329,9 @@ describe("subscribeToAll", () => {
           await delay(10);
 
           if (event.event.isJson) {
-            readEvents.add((event.event.data as TestEventData).index);
+            readEvents.add(
+              ((event.event.data as unknown) as TestEventData).index
+            );
           }
         }
 

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,7 +1,2 @@
-import { BinaryEventData } from "./binaryEvent";
-import { JSONEventData } from "./jsonEvent";
-
-export type EventData = JSONEventData | BinaryEventData;
-
 export * from "./binaryEvent";
 export * from "./jsonEvent";

--- a/src/events/jsonEvent.ts
+++ b/src/events/jsonEvent.ts
@@ -1,24 +1,25 @@
 import { v4 as uuid } from "uuid";
+import { JSONEventData, JSONEventType, MetadataType } from "../types";
 import { convertMetadata } from "./convertMetadata";
-import { JSONType, MetadataType } from "./types";
 
-export interface JSONEventData<
-  Type extends string = string,
-  Data extends JSONType = JSONType,
-  Metadata extends MetadataType = MetadataType
-> {
-  id: string;
-  contentType: "application/json";
-  type: Type;
-  data: Data;
-  metadata?: Metadata;
-}
+// https://github.com/Microsoft/TypeScript/issues/12400
+type OptionalMetadata<
+  E extends JSONEventType
+> = E["metadata"] extends MetadataType
+  ? {
+      /**
+       * The metadata of the event
+       */
+      metadata: E["metadata"];
+    }
+  : {
+      /**
+       * The metadata of the event
+       */
+      metadata?: E["metadata"];
+    };
 
-export interface JSONEventOptions<
-  Type extends string = string,
-  Data extends JSONType = JSONType,
-  Metadata extends MetadataType = MetadataType | Buffer
-> {
+export type JSONEventOptions<E extends JSONEventType> = {
   /**
    * The id to this event. By default, the id will be generated.
    */
@@ -26,34 +27,24 @@ export interface JSONEventOptions<
   /**
    * The event type
    */
-  type: Type;
+  type: E["type"];
   /**
    * The data of the event
    */
-  data: Data;
-  /**
-   * The meta data of the event
-   */
-  metadata?: Metadata;
-}
+  data: E["data"];
+} & OptionalMetadata<E>;
 
-export const jsonEvent = <
-  Type extends string = string,
-  Data extends JSONType = JSONType,
-  Metadata extends MetadataType = MetadataType
->({
+export const jsonEvent = <E extends JSONEventType>({
   type,
   data,
   metadata,
   id = uuid(),
-}: JSONEventOptions<Type, Data, Metadata>): JSONEventData<
-  Type,
-  Data,
-  Metadata
-> => ({
+}: JSONEventOptions<E>): JSONEventData<E> => ({
   id,
   contentType: "application/json",
   type,
-  data,
-  metadata: convertMetadata<Metadata>(metadata),
+  data: data as JSONEventData<E>["data"],
+  metadata: convertMetadata<E["metadata"]>(
+    metadata
+  ) as JSONEventData<E>["metadata"],
 });

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -1,2 +1,0 @@
-export type JSONType = Record<string | number, unknown> | unknown[];
-export type MetadataType = JSONType | Uint8Array;

--- a/src/persistentSubscription/connectToPersistentSubscription.ts
+++ b/src/persistentSubscription/connectToPersistentSubscription.ts
@@ -5,7 +5,7 @@ import { ReadReq } from "../../generated/persistent_pb";
 import { PersistentSubscriptionsClient } from "../../generated/persistent_grpc_pb";
 import UUIDOption = ReadReq.Options.UUIDOption;
 
-import { PersistentSubscription, BaseOptions } from "../types";
+import { PersistentSubscription, BaseOptions, EventType } from "../types";
 import { TwoWaySubscription, debug } from "../utils";
 import { Client } from "../Client";
 
@@ -25,16 +25,18 @@ declare module "../Client" {
      * @param group A group name
      * @param options Connection options
      */
-    connectToPersistentSubscription(
+    connectToPersistentSubscription<E extends EventType = EventType>(
       streamName: string,
       groupName: string,
       options?: ConnectToPersistentSubscriptionOptions,
       duplexOptions?: DuplexOptions
-    ): PersistentSubscription;
+    ): PersistentSubscription<E>;
   }
 }
 
-Client.prototype.connectToPersistentSubscription = function (
+Client.prototype.connectToPersistentSubscription = function <
+  E extends EventType = EventType
+>(
   this: Client,
   streamName: string,
   groupName: string,
@@ -43,7 +45,7 @@ Client.prototype.connectToPersistentSubscription = function (
     ...baseOptions
   }: ConnectToPersistentSubscriptionOptions = {},
   duplexOptions: DuplexOptions = {}
-): PersistentSubscription {
+): PersistentSubscription<E> {
   const req = new ReadReq();
   const options = new ReadReq.Options();
   const identifier = new StreamIdentifier();

--- a/src/streams/appendToStream.ts
+++ b/src/streams/appendToStream.ts
@@ -4,8 +4,13 @@ import { StreamsClient } from "../../generated/streams_grpc_pb";
 
 import { Client } from "../Client";
 import { ANY } from "../constants";
-import { BaseOptions, AppendResult, AppendExpectedRevision } from "../types";
-import { EventData } from "../events";
+import {
+  BaseOptions,
+  AppendResult,
+  AppendExpectedRevision,
+  EventData,
+} from "../types";
+
 import {
   convertToCommandError,
   debug,

--- a/src/streams/subscribeToStream.ts
+++ b/src/streams/subscribeToStream.ts
@@ -6,7 +6,12 @@ import { Empty, StreamIdentifier } from "../../generated/shared_pb";
 import UUIDOption = ReadReq.Options.UUIDOption;
 import SubscriptionOptions = ReadReq.Options.SubscriptionOptions;
 
-import { ReadRevision, StreamSubscription, BaseOptions } from "../types";
+import {
+  ReadRevision,
+  StreamSubscription,
+  BaseOptions,
+  EventType,
+} from "../types";
 import { Client } from "../Client";
 import { END, START } from "../constants";
 import { debug, convertGrpcEvent, OneWaySubscription } from "../utils";
@@ -33,15 +38,17 @@ declare module "../Client" {
      * @param streamName A stream name.
      * @param options Writing options
      */
-    subscribeToStream(
+    subscribeToStream<KnownEventType extends EventType = EventType>(
       streamName: string,
       options?: SubscribeToStreamOptions,
       readableOptions?: ReadableOptions
-    ): StreamSubscription;
+    ): StreamSubscription<KnownEventType>;
   }
 }
 
-Client.prototype.subscribeToStream = function (
+Client.prototype.subscribeToStream = function <
+  KnownEventType extends EventType = EventType
+>(
   this: Client,
   streamName: string,
   {
@@ -50,7 +57,7 @@ Client.prototype.subscribeToStream = function (
     ...baseOptions
   }: SubscribeToStreamOptions = {},
   readableOptions: ReadableOptions = {}
-): StreamSubscription {
+): StreamSubscription<KnownEventType> {
   const req = new ReadReq();
   const options = new ReadReq.Options();
   const identifier = new StreamIdentifier();

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,0 +1,220 @@
+import { Position } from "../types";
+
+export type JSONType = Record<string | number, unknown> | unknown[] | string;
+export type MetadataType = JSONType | Uint8Array;
+
+export interface JSONEventType<
+  Type extends string = string,
+  Data extends JSONType = JSONType,
+  Metadata extends MetadataType | unknown = unknown
+> {
+  type: Type;
+  data: Data;
+  metadata: Metadata;
+}
+
+export interface BinaryEventType<
+  Type extends string = string,
+  Metadata extends MetadataType | unknown = unknown
+> {
+  type: Type;
+  data: Uint8Array;
+  metadata: Metadata;
+}
+
+export type EventType = JSONEventType | BinaryEventType;
+
+export interface JSONEventData<E extends JSONEventType = JSONEventType> {
+  id: string;
+  contentType: "application/json";
+  type: E["type"];
+  data: E["data"];
+  metadata: E["metadata"] extends MetadataType
+    ? E["metadata"]
+    : MetadataType | undefined;
+}
+
+export interface BinaryEventData<E extends BinaryEventType = BinaryEventType> {
+  id: string;
+  contentType: "application/octet-stream";
+  type: E["type"];
+  data: E["data"];
+  metadata: E["metadata"] extends MetadataType
+    ? E["metadata"]
+    : MetadataType | undefined;
+}
+
+export type EventData = JSONEventData | BinaryEventData;
+
+/**
+ * Represents a previously written event.
+ */
+interface RecordedEventBase<E extends EventType = EventType> {
+  /**
+   * The event stream that events belongs to.
+   */
+  streamId: string;
+
+  /**
+   * Unique identifier representing this event. UUID format.
+   */
+  id: string;
+
+  /**
+   * Number of this event in the stream.
+   */
+  revision: bigint;
+
+  /**
+   * Type of this event.
+   */
+  type: E["type"];
+
+  /**
+   * Representing when this event was created in the database system.
+   */
+  created: number;
+
+  /**
+   * Representing the metadata associated with this event.
+   */
+  metadata: E["metadata"] extends MetadataType
+    ? E["metadata"]
+    : MetadataType | undefined;
+}
+
+export interface JSONRecordedEvent<E extends JSONEventType = JSONEventType>
+  extends RecordedEventBase<E> {
+  /**
+   * Indicates whether the content is internally marked as JSON.
+   */
+  isJson: true;
+
+  /**
+   * Data of this event.
+   */
+  data: E["data"];
+}
+
+export interface BinaryRecordedEvent<
+  E extends BinaryEventType = BinaryEventType
+> extends RecordedEventBase<E> {
+  /**
+   * Indicates whether the content is internally marked as JSON.
+   */
+  isJson: false;
+
+  /**
+   * Data of this event.
+   */
+  data: Uint8Array;
+}
+
+export interface AllStreamJSONRecordedEvent<
+  E extends JSONEventType = JSONEventType
+> extends JSONRecordedEvent<E> {
+  /**
+   * Position of this event in the transaction log.
+   */
+  position: Position;
+}
+
+export interface AllStreamBinaryRecordedEvent<
+  E extends BinaryEventType = BinaryEventType
+> extends BinaryRecordedEvent<E> {
+  /**
+   * Position of this event in the transaction log.
+   */
+  position: Position;
+}
+
+export type RecordedEvent = JSONRecordedEvent | BinaryRecordedEvent;
+export type AllStreamRecordedEvent =
+  | AllStreamJSONRecordedEvent
+  | AllStreamBinaryRecordedEvent;
+
+/**
+ * A structure representing a single event or an resolved link event.
+ */
+export interface ResolvedEvent<Event extends EventType = EventType> {
+  /**
+   * The event, or the resolved link event if this {@link ResolvedEvent} is a link event.
+   */
+  event?: EventTypeToRecordedEvent<Event>;
+
+  /**
+   * The link event if this ResolvedEvent is a link event.
+   */
+  link?: EventTypeToRecordedEvent<Event>;
+
+  /**
+   * Commit position of the record.
+   */
+  commitPosition?: bigint;
+}
+
+/**
+ * A structure representing a single event or an resolved link event.
+ */
+export interface AllStreamResolvedEvent {
+  /**
+   * The event, or the resolved link event if this {@link ResolvedEvent} is a link event.
+   */
+  event?: AllStreamRecordedEvent;
+
+  /**
+   * The link event if this ResolvedEvent is a link event.
+   */
+  link?: AllStreamRecordedEvent;
+
+  /**
+   * Commit position of the record.
+   */
+  commitPosition?: bigint;
+}
+
+export type EventTypeToRecordedEvent<
+  T extends EventType
+> = T extends JSONEventType
+  ? JSONRecordedEvent<T>
+  : T extends BinaryEventType
+  ? BinaryRecordedEvent<T>
+  : never;
+
+export type RecordedEventToEventType<
+  T extends RecordedEvent
+> = T extends JSONRecordedEvent<infer E>
+  ? E
+  : T extends BinaryRecordedEvent<infer E>
+  ? E
+  : never;
+
+export type EventTypeToEventData<T extends EventType> = T extends JSONEventType
+  ? JSONEventData<T>
+  : T extends BinaryEventType
+  ? BinaryEventData<T>
+  : never;
+
+export type EventDataToEventType<T extends EventData> = T extends JSONEventData<
+  infer E
+>
+  ? E
+  : T extends BinaryEventData<infer E>
+  ? E
+  : never;
+
+export type RecordedEventToEventData<
+  T extends RecordedEvent
+> = T extends JSONRecordedEvent<infer E>
+  ? JSONEventData<E>
+  : T extends BinaryRecordedEvent<infer E>
+  ? BinaryEventData<E>
+  : never;
+
+export type EventDataToRecordedEvent<
+  T extends EventData
+> = T extends JSONRecordedEvent<infer E>
+  ? JSONEventData<E>
+  : T extends BinaryRecordedEvent<infer E>
+  ? BinaryEventData<E>
+  : never;

--- a/src/utils/convertGrpcEvent.ts
+++ b/src/utils/convertGrpcEvent.ts
@@ -7,10 +7,11 @@ import PersistentRecordedEvent = PersistentEvent.RecordedEvent;
 
 import { debug } from "./debug";
 import {
-  RecordedEvent,
-  Position,
-  ResolvedEvent,
   AllStreamResolvedEvent,
+  JSONType,
+  Position,
+  RecordedEvent,
+  ResolvedEvent,
 } from "../types";
 
 export type GRPCReadResp = StreamsReadResp | PersistentReadResp;
@@ -124,7 +125,7 @@ export const convertGrpcRecord = (
   if (isJson) {
     const dataStr = Buffer.from(grpcRecord.getData()).toString("binary");
 
-    const data = safeParseJSON(
+    const data = safeParseJSON<JSONType>(
       dataStr,
       (d) => d,
       `Malformed JSON data in event ${id}`


### PR DESCRIPTION
- have a generic `EventType` that can be used to share typings across read / write events
- allow `readEvents`, `subscribeToEvents` and `connectToPersistantSubscription` to be typed

![image](https://user-images.githubusercontent.com/11861797/107379329-19f1c300-6aed-11eb-9811-99e086e200cd.png)
![image](https://user-images.githubusercontent.com/11861797/107379405-2bd36600-6aed-11eb-9dd0-b55f2be879a7.png)
