### PR TITLE
Allow whitespace between tokens in connection string

### DIFF
--- a/src/Client/parseConnectionString.ts
+++ b/src/Client/parseConnectionString.ts
@@ -106,7 +106,7 @@ const parseCredentials = (
 
   if (match.groups?.credentials) {
     nextPosition += match[0].length;
-    const [username, password] = match.groups.credentials.split(":");
+    const [username, password] = match.groups.credentials.trim().split(":");
     return parseHosts(
       connectionString,
       nextPosition,
@@ -143,7 +143,11 @@ const parseHosts = (
   if (match && match.groups?.host) {
     nextPosition += match[0].length;
 
-    const [address, rawPort = "2113", ...rest] = match.groups?.host.split(":");
+    const [
+      address,
+      rawPort = "2113",
+      ...rest
+    ] = match.groups?.host.trim().split(":");
 
     if (rest.length) {
       throw new ParseError(
@@ -153,7 +157,7 @@ const parseHosts = (
       );
     }
 
-    const port = parseInt(rawPort);
+    const port = parseInt(rawPort.trim());
 
     if (Number.isNaN(port)) {
       throw new ParseError(
@@ -230,12 +234,13 @@ interface KeyValuePair {
 }
 
 const verifyKeyValuePair = (
-  { key: rawKey, value }: RawKeyPair,
+  { key: rawKey, value: rawValue }: RawKeyPair,
   connectionString: string,
   [from, to]: ParsingLocation
 ): KeyValuePair | null => {
   const keyFrom = from + `&${rawKey}=`.length;
-  const key = lowerToKey[rawKey.toLowerCase()] ?? rawKey;
+  const key = lowerToKey[rawKey.trim().toLowerCase()] ?? rawKey;
+  const value = rawValue.trim();
 
   if (notCurrentlySupported.includes(key)) {
     debug.connection(

--- a/src/__test__/connection/connectionString.test.ts
+++ b/src/__test__/connection/connectionString.test.ts
@@ -69,7 +69,11 @@ describe("connectionString", () => {
           .map(({ address, port }) => `${address}:${port}`)
           .join(",");
 
-        const client = EventStoreDBClient.connectionString`esdb://${gossipEndpoints}?tls=false&nodePreference=leader`;
+        const client = EventStoreDBClient.connectionString`
+          esdb://${gossipEndpoints}
+            ?tls=false
+            &nodePreference=leader
+        `;
 
         const appendResult = await client.appendToStream(
           STREAM_NAME,

--- a/src/__test__/connection/connectionStringMockups.ts
+++ b/src/__test__/connection/connectionStringMockups.ts
@@ -511,6 +511,37 @@ export const valid: Array<
       ],
     },
   ],
+  [
+    `esdb://     host
+      ?    MaxDiscoverAttempts=200
+      &discoveryinterval=1000
+      &GOSSIPTIMEOUT=1
+      &nOdEpReFeReNcE=leader
+      &TLS=false
+      &TlsVerifyCert=false
+      &
+      THROWOnAppendFailure
+      =
+      false      &   KEEPALIVEinterval=200`,
+    {
+      dnsDiscover: false,
+      maxDiscoverAttempts: 200,
+      discoveryInterval: 1000,
+      gossipTimeout: 1,
+      nodePreference: "leader",
+      tls: false,
+      tlsVerifyCert: false,
+      throwOnAppendFailure: false,
+      keepAliveInterval: 200,
+      keepAliveTimeout: 10_000,
+      hosts: [
+        {
+          address: "host",
+          port: 2113,
+        },
+      ],
+    },
+  ],
 ];
 
 export const invalid: string[] = [


### PR DESCRIPTION
```ts
const client = EventStoreDBClient.connectionString`
    esdb://${gossipEndpoints}
        ?tls=false
        &nodePreference=leader
`;
```