### PR TITLE
Fix incorrect buffer encoding and decoding

### DIFF
--- a/src/__test__/streams/appendToStream.test.ts
+++ b/src/__test__/streams/appendToStream.test.ts
@@ -31,6 +31,29 @@ describe("appendToStream", () => {
       expect(result.nextExpectedRevision).toBeGreaterThanOrEqual(0);
     });
 
+    test("unicode string in json event", async () => {
+      const eventType = "TestEncode";
+      const streamName = "encode1";
+      const killer = "CC ‐ 1830";
+
+      const client = new EventStoreDBClient(
+        { endpoint: node.uri },
+        { rootCertificate: node.rootCertificate }
+      );
+
+      await client.appendToStream(
+        streamName,
+        jsonEvent({
+          type: eventType,
+          data: killer,
+        })
+      );
+
+      const [event] = await client.readStream(streamName);
+
+      expect(event.event?.data).toStrictEqual(killer);
+    });
+
     test("binary events", async () => {
       const STREAM_NAME = "binary_stream_name";
 

--- a/src/streams/appendToStream.ts
+++ b/src/streams/appendToStream.ts
@@ -172,7 +172,7 @@ Client.prototype.appendToStream = async function (
       switch (event.contentType) {
         case "application/json": {
           const data = JSON.stringify(event.data);
-          message.setData(Buffer.from(data, "binary").toString("base64"));
+          message.setData(Buffer.from(data, "utf8").toString("base64"));
           break;
         }
         case "application/octet-stream": {
@@ -187,7 +187,7 @@ Client.prototype.appendToStream = async function (
         } else {
           const metadata = JSON.stringify(event.metadata);
           message.setCustomMetadata(
-            Buffer.from(metadata, "binary").toString("base64")
+            Buffer.from(metadata, "utf8").toString("base64")
           );
         }
       }

--- a/src/utils/CommandError.ts
+++ b/src/utils/CommandError.ts
@@ -79,7 +79,7 @@ export class StreamNotFoundError extends CommandErrorBase {
   ): string => {
     const name = streamName ?? error?.metadata?.getMap()["stream-name"] ?? "";
     if (typeof name === "string") return name;
-    return Buffer.from(name).toString("binary");
+    return Buffer.from(name).toString("utf8");
   };
 
   constructor(error?: ServiceError, streamName?: string | Uint8Array) {

--- a/src/utils/convertGrpcEvent.ts
+++ b/src/utils/convertGrpcEvent.ts
@@ -91,7 +91,7 @@ const parseMetadata = (grpcRecord: GRPCRecordedEvent, id: string) => {
   const metadata = grpcRecord.getCustomMetadata_asU8();
   if (!metadata.length) return;
   try {
-    return JSON.parse(Buffer.from(metadata).toString("binary"));
+    return JSON.parse(Buffer.from(metadata).toString("utf8"));
   } catch (error) {
     return metadata;
   }
@@ -112,7 +112,7 @@ export const convertGrpcRecord = (
   }
   const streamId = Buffer.from(
     grpcRecord.getStreamIdentifier()!.getStreamname()
-  ).toString("binary");
+  ).toString("utf8");
 
   if (!grpcRecord.hasId()) {
     throw "Impossible situation where id is undefined in a recorded event";
@@ -123,7 +123,7 @@ export const convertGrpcRecord = (
   const isJson = contentType === "application/json";
 
   if (isJson) {
-    const dataStr = Buffer.from(grpcRecord.getData()).toString("binary");
+    const dataStr = Buffer.from(grpcRecord.getData()).toString("utf8");
 
     const data = safeParseJSON<JSONType>(
       dataStr,


### PR DESCRIPTION
- Add test for encoding breaking string (#144)
- Replace all buffer encoding and decoding from `binary` (latin1) to `utf8`

fixes: #144