### PR TITLE
Remove console.log in the TwoWaySubscription file

### DIFF
--- a/src/utils/TwoWaySubscription.ts
+++ b/src/utils/TwoWaySubscription.ts
@@ -28,7 +28,6 @@ export class TwoWaySubscription
       (await this.#grpcStream)
         .on("error", (err: ServiceError) => {
           if (err.code === Status.CANCELLED) return;
-          console.log(err);
           const error = convertToCommandError(err);
           this.emit("error", error);
         })


### PR DESCRIPTION
I've got an annoying log in my standard output messing up with my logging management pipe.
Is this something you forgot to remove? Can we remove it or use `debug` instead?