### PR TITLE
Implement timeoutAfter option

### DIFF
--- a/src/Client/parseConnectionString.ts
+++ b/src/Client/parseConnectionString.ts
@@ -11,6 +11,7 @@ export interface QueryOptions {
   throwOnAppendFailure?: boolean;
   keepAliveInterval?: number;
   keepAliveTimeout?: number;
+  timeoutAfter?: number;
 }
 
 export interface ConnectionOptions extends QueryOptions {
@@ -35,6 +36,7 @@ const lowerToKey: {
   throwonappendfailure: "throwOnAppendFailure",
   keepaliveinterval: "keepAliveInterval",
   keepalivetimeout: "keepAliveTimeout",
+  timeoutafter: "timeoutAfter",
 };
 
 export const parseConnectionString = (
@@ -258,7 +260,8 @@ const verifyKeyValuePair = (
     case "discoveryInterval":
     case "gossipTimeout":
     case "keepAliveInterval":
-    case "keepAliveTimeout": {
+    case "keepAliveTimeout":
+    case "timeoutAfter": {
       const parsedValue = parseInt(value);
 
       if (Number.isNaN(parsedValue)) {

--- a/src/__test__/connection/__snapshots__/timeoutAfter.effects.test.ts.snap
+++ b/src/__test__/connection/__snapshots__/timeoutAfter.effects.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`timeoutAfter should time out a call call options 1`] = `"4 DEADLINE_EXCEEDED: Deadline exceeded"`;
+
+exports[`timeoutAfter should time out a call call options override 1`] = `"4 DEADLINE_EXCEEDED: Deadline exceeded"`;
+
+exports[`timeoutAfter should time out a call client settings 1`] = `"4 DEADLINE_EXCEEDED: Deadline exceeded"`;

--- a/src/__test__/connection/__snapshots__/timeoutAfter.settings.test.ts.snap
+++ b/src/__test__/connection/__snapshots__/timeoutAfter.settings.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`timeoutAfter settings should throw on negative connectionString 1`] = `"Invalid timeoutAfter \\"-1\\". Please provide a positive integer."`;
+
+exports[`timeoutAfter settings should throw on negative connectionString 2`] = `"Invalid timeoutAfter \\"-1000000000000000\\". Please provide a positive integer."`;
+
+exports[`timeoutAfter settings should throw on negative constructor 1`] = `"Invalid timeoutAfter \\"-1\\". Please provide a positive integer."`;
+
+exports[`timeoutAfter settings should throw on negative constructor 2`] = `"Invalid timeoutAfter \\"-1000000000000000\\". Please provide a positive integer."`;
+
+exports[`timeoutAfter settings should throw on zero connectionString 1`] = `"Invalid timeoutAfter \\"0\\". Please provide a positive integer."`;
+
+exports[`timeoutAfter settings should throw on zero constructor 1`] = `"Invalid timeoutAfter \\"0\\". Please provide a positive integer."`;

--- a/src/__test__/connection/connectionStringMockups.ts
+++ b/src/__test__/connection/connectionStringMockups.ts
@@ -306,7 +306,7 @@ export const valid: Array<
     },
   ],
   [
-    "esdb://host?maxDiscoverAttempts=200&discoveryInterval=1000&gossipTimeout=1&nodePreference=leader&tls=false&tlsVerifyCert=false&throwOnAppendFailure=false&keepAliveInterval=10",
+    "esdb://host?maxDiscoverAttempts=200&discoveryInterval=1000&gossipTimeout=1&nodePreference=leader&tls=false&tlsVerifyCert=false&throwOnAppendFailure=false&keepAliveInterval=10&timeoutAfter=10000000",
     {
       dnsDiscover: false,
       maxDiscoverAttempts: 200,
@@ -317,6 +317,7 @@ export const valid: Array<
       tlsVerifyCert: false,
       throwOnAppendFailure: false,
       keepAliveInterval: 10,
+      timeoutAfter: 10_000_000,
       hosts: [
         {
           address: "host",
@@ -326,7 +327,7 @@ export const valid: Array<
     },
   ],
   [
-    "esdb://host?MaxDiscoverAttempts=200&discoveryinterval=1000&GOSSIPTIMEOUT=1&nOdEpReFeReNcE=leader&TLS=false&TlsVerifyCert=false&THROWOnAppendFailure=false&KEEPALIVEinterval=200",
+    "esdb://host?MaxDiscoverAttempts=200&discoveryinterval=1000&GOSSIPTIMEOUT=1&nOdEpReFeReNcE=leader&TLS=false&TlsVerifyCert=false&THROWOnAppendFailure=false&KEEPALIVEinterval=200&TIMEOUTaFTER=12",
     {
       dnsDiscover: false,
       maxDiscoverAttempts: 200,
@@ -337,6 +338,7 @@ export const valid: Array<
       tlsVerifyCert: false,
       throwOnAppendFailure: false,
       keepAliveInterval: 200,
+      timeoutAfter: 12,
       hosts: [
         {
           address: "host",

--- a/src/__test__/connection/timeoutAfter.effects.test.ts
+++ b/src/__test__/connection/timeoutAfter.effects.test.ts
@@ -1,0 +1,49 @@
+import { EventStoreDBClient } from "../..";
+import { createTestNode, jsonTestEvents } from "../utils";
+
+describe("timeoutAfter", () => {
+  const node = createTestNode();
+
+  beforeAll(async () => {
+    await node.up();
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  describe("should time out a call", () => {
+    test.each([
+      [
+        "client settings",
+        () =>
+          new EventStoreDBClient(
+            { endpoint: node.uri, timeoutAfter: 1 },
+            { rootCertificate: node.rootCertificate }
+          ).appendToStream("client_settings", jsonTestEvents()),
+      ],
+      [
+        "call options",
+        () =>
+          new EventStoreDBClient(
+            { endpoint: node.uri },
+            { rootCertificate: node.rootCertificate }
+          ).appendToStream("call_options", jsonTestEvents(), {
+            timeoutAfter: 1,
+          }),
+      ],
+      [
+        "call options override",
+        () =>
+          new EventStoreDBClient(
+            { endpoint: node.uri, timeoutAfter: 20000 },
+            { rootCertificate: node.rootCertificate }
+          ).appendToStream("call_options_override", jsonTestEvents(), {
+            timeoutAfter: 1,
+          }),
+      ],
+    ])("%s", async (_, makeCall) => {
+      await expect(makeCall).rejects.toThrowErrorMatchingSnapshot();
+    });
+  });
+});

--- a/src/__test__/connection/timeoutAfter.settings.test.ts
+++ b/src/__test__/connection/timeoutAfter.settings.test.ts
@@ -1,0 +1,125 @@
+import { Channel } from "@grpc/grpc-js";
+
+import { EventStoreDBClient } from "../..";
+
+/*
+Mocking this file breaks grpc, but allows us to check the settings passed to grpc
+These tests need to be kept seperate to any tests that need to actually make calls 
+*/
+jest.mock("@grpc/grpc-js/build/src/channel.js");
+const ChannelMock = Channel as jest.Mock<Channel>;
+
+describe("timeoutAfter settings", () => {
+  beforeEach(() => {
+    ChannelMock.mockClear();
+  });
+
+  describe.each([
+    [
+      "should default to 5_000", // test name
+      "esdb://host", // connection string
+      {}, // constructor options
+      undefined, // call options
+      5_000, // expected
+    ],
+    [
+      "should be settable: 1",
+      "esdb://host?timeoutAfter=1",
+      { timeoutAfter: 1 },
+      undefined,
+      1,
+    ],
+    [
+      "should be settable: 100000",
+      "esdb://host?timeoutAfter=100000",
+      { timeoutAfter: 10_0000 },
+      undefined,
+      10_0000,
+    ],
+    [
+      "passing in call options should override default",
+      "esdb://host",
+      {},
+      { timeoutAfter: 10_0000 },
+      10_0000,
+    ],
+    [
+      "passing in call options should override settings",
+      "esdb://host?timeoutAfter=100000",
+      { timeoutAfter: 10_0000 },
+      { timeoutAfter: 10 },
+      10,
+    ],
+  ])("%s", (_, connectionString, constructorOptions, callOptions, expected) => {
+    test.each([
+      [
+        "connectionString",
+        () => EventStoreDBClient.connectionString(connectionString),
+      ],
+      [
+        "constructor",
+        () =>
+          new EventStoreDBClient({
+            endpoint: "host:1234",
+            ...constructorOptions,
+          }),
+      ],
+    ])("%s", async (_, createClient) => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+      const client = createClient();
+      const before = Date.now();
+
+      try {
+        await client.restartSubsystem(callOptions);
+      } catch (_) {
+        // We're not actually connecting to anything, just triggering channel creation
+      }
+
+      const after = Date.now();
+
+      const ChannelInstance = ChannelMock.mock.instances[0];
+      const createCall = (ChannelInstance.createCall as unknown) as jest.Mock<
+        Channel["createCall"]
+      >;
+
+      const deadline = createCall.mock.calls[0][1];
+
+      expect(deadline).toBeGreaterThanOrEqual(before + expected);
+      expect(deadline).toBeLessThanOrEqual(after + expected);
+
+      expect(warnSpy).not.toBeCalled();
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe.each([
+    ["should throw on zero", "esdb://host?timeoutAfter=0", { timeoutAfter: 0 }],
+    [
+      "should throw on negative",
+      "esdb://host?timeoutAfter=-1",
+      { timeoutAfter: -1 },
+    ],
+    [
+      "should throw on negative",
+      "esdb://host?timeoutAfter=-1000000000000000",
+      { timeoutAfter: -1000000000000000 },
+    ],
+  ])("%s", (_, connectionString, constructorOptions) => {
+    test.each([
+      [
+        "connectionString",
+        () => EventStoreDBClient.connectionString(connectionString),
+      ],
+      [
+        "constructor",
+        () =>
+          new EventStoreDBClient({
+            endpoint: "host:1234",
+            ...constructorOptions,
+          }),
+      ],
+    ])("%s", async (_, createClient) => {
+      expect(() => createClient()).toThrowErrorMatchingSnapshot();
+    });
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,10 @@ export interface BaseOptions {
    * Command requires a leader node.
    */
   requiresLeader?: boolean;
+  /**
+   * Overwrite default length of time (in milliseconds) for gRPC deadlines.
+   */
+  timeoutAfter?: number;
 }
 
 /**


### PR DESCRIPTION
- pass deadline to grpc based on `timeoutAfter` option
- add to client settings
- add to connection string
- allow override per call
- default to 5000ms