### PR TITLE
Allow setting END for create persistent subscription fromRevision

### DIFF
--- a/src/persistentSubscription/createPersistentSubscription.ts
+++ b/src/persistentSubscription/createPersistentSubscription.ts
@@ -11,6 +11,7 @@ import {
 import { Client } from "../Client";
 import {
   DISPATCH_TO_SINGLE,
+  END,
   PINNED,
   ROUND_ROBIN,
   START,
@@ -54,6 +55,11 @@ Client.prototype.createPersistentSubscription = async function (
   switch (settings.fromRevision) {
     case START: {
       reqSettings.setRevision(BigInt(0).toString(10));
+      break;
+    }
+    case END: {
+      // This is the largest possible value of UInt64
+      reqSettings.setRevision("18446744073709551615");
       break;
     }
     default: {

--- a/src/utils/persistentSubscriptionSettings.ts
+++ b/src/utils/persistentSubscriptionSettings.ts
@@ -1,4 +1,4 @@
-import { ROUND_ROBIN, START, UNLIMITED } from "../constants";
+import { END, ROUND_ROBIN, START, UNLIMITED } from "../constants";
 import { ConsumerStrategy } from "../types";
 
 export interface PersistentSubscriptionSettings {
@@ -14,7 +14,7 @@ export interface PersistentSubscriptionSettings {
    * Starts the read at the given event revision.
    * @default START
    */
-  fromRevision: typeof START | bigint;
+  fromRevision: typeof START | typeof END | bigint;
 
   /**
    * Enables in depth latency statistics should be tracked on this subscription.


### PR DESCRIPTION
- update types
- update command
- add test

Note: END is sent as `"18446744073709551615"` in line with [dotnet client behaviour](https://github.com/EventStore/EventStore-Client-Dotnet/blob/master/src/EventStore.Client/StreamPosition.cs#L19).

fixes: #152