### PR TITLE
Pass path to Certificate File in Connection String

### DIFF
--- a/src/Client/parseConnectionString.ts
+++ b/src/Client/parseConnectionString.ts
@@ -8,6 +8,7 @@ export interface QueryOptions {
   nodePreference?: NodePreference;
   tls?: boolean;
   tlsVerifyCert?: boolean;
+  tlsCAFile?: string;
   throwOnAppendFailure?: boolean;
   keepAliveInterval?: number;
   keepAliveTimeout?: number;
@@ -32,6 +33,7 @@ const lowerToKey: {
   nodepreference: "nodePreference",
   tls: "tls",
   tlsverifycert: "tlsVerifyCert",
+  tlscafile: "tlsCAFile",
   throwonappendfailure: "throwOnAppendFailure",
   keepaliveinterval: "keepAliveInterval",
   keepalivetimeout: "keepAliveTimeout",
@@ -253,6 +255,9 @@ const verifyKeyValuePair = (
       }
 
       return { key, value };
+    }
+    case "tlsCAFile": {
+      return { key, value: value };
     }
     case "maxDiscoverAttempts":
     case "discoveryInterval":

--- a/src/__test__/connection/__snapshots__/tlsCAFile.test.ts.snap
+++ b/src/__test__/connection/__snapshots__/tlsCAFile.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tlsCAFile If a file was not found, error should be thrown 1`] = `"Failed to load certificate file. File was not found."`;

--- a/src/__test__/connection/connectionStringMockups.ts
+++ b/src/__test__/connection/connectionStringMockups.ts
@@ -252,6 +252,58 @@ export const valid: Array<
     },
   ],
   [
+    "esdb://host?tlsCAFile=/home/user/dev/cert.ca",
+    {
+      dnsDiscover: false,
+      tlsCAFile: "/home/user/dev/cert.ca",
+      hosts: [
+        {
+          address: "host",
+          port: 2113,
+        },
+      ],
+    },
+  ],
+  [
+    "esdb://host?tlsCAFile=./cert.ca",
+    {
+      dnsDiscover: false,
+      tlsCAFile: "./cert.ca",
+      hosts: [
+        {
+          address: "host",
+          port: 2113,
+        },
+      ],
+    },
+  ],
+  [
+    "esdb://host?tlsCAFile=C:\\Certificates\\EventStore\\Cert.ca",
+    {
+      dnsDiscover: false,
+      tlsCAFile: "C:\\Certificates\\EventStore\\Cert.ca",
+      hosts: [
+        {
+          address: "host",
+          port: 2113,
+        },
+      ],
+    },
+  ],
+  [
+    "esdb://host?tlsCAFile=..\\EventStore\\Cert.ca",
+    {
+      dnsDiscover: false,
+      tlsCAFile: "..\\EventStore\\Cert.ca",
+      hosts: [
+        {
+          address: "host",
+          port: 2113,
+        },
+      ],
+    },
+  ],
+  [
     "esdb://host?keepAliveInterval=-1&keepAliveTimeout=-1",
     {
       dnsDiscover: false,

--- a/src/__test__/connection/tlsCAFile.test.ts
+++ b/src/__test__/connection/tlsCAFile.test.ts
@@ -1,0 +1,46 @@
+import { createTestNode, jsonTestEvents } from "../utils";
+import { EventStoreDBClient } from "../..";
+import { relative, resolve } from "path";
+
+describe("tlsCAFile", () => {
+  const node = createTestNode();
+
+  beforeAll(async () => {
+    await node.up();
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  test.each([
+    ["relative", () => relative(process.cwd(), node.certPath)],
+    [
+      "absolute",
+      // in case node.certPath implementation changes to be relative, make certain it is absolute
+      () => resolve(process.cwd(), relative(process.cwd(), node.certPath)),
+    ],
+  ])("Path can be %s", async (name, tlsCAFile) => {
+    const STREAM_NAME = `${name}_stream`;
+
+    const client = EventStoreDBClient.connectionString`esdb://${
+      node.uri
+    }?tlsCAFile=${tlsCAFile()}`;
+
+    const appendResult = await client.appendToStream(
+      STREAM_NAME,
+      jsonTestEvents()
+    );
+    const readResult = await client.readStream(STREAM_NAME, { maxCount: 10 });
+
+    expect(appendResult).toBeDefined();
+    expect(readResult).toBeDefined();
+  });
+
+  test("If a file was not found, error should be thrown", () => {
+    expect(
+      () =>
+        EventStoreDBClient.connectionString`esdb://${node.uri}?tlsCAFile=/some/path.ca`
+    ).toThrowErrorMatchingSnapshot();
+  });
+});


### PR DESCRIPTION
- add `tlsCAFile` to connection string
- resolve to file and pass to options
- add tests

[RFC017](https://github.com/EventStore/home/blob/master/RFCs/017%20-%20Pass%20path%20to%20Certificate%20File%20in%20Connection%20String.md)