### PR TITLE
update broken link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ We have a community discussion space at [Event Store Discuss].
 Development is done on the `master` branch. We attempt to do our best to ensure that the history remains clean and to do so, we generally ask contributors to squash their commits into a set or single logical commit.
 
 [event store support]: https://eventstore.com/support/
-[event store docs]: https://developers.eventstore.com/server/v21.2/docs/installation/
+[event store docs]: https://developers.eventstore.com/server/v20.10/docs/installation/
 [event store discuss]: https://discuss.eventstore.com/
 [yarn]: https://yarnpkg.com/
 [jest]: https://jestjs.io/

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ We have a community discussion space at [Event Store Discuss].
 Development is done on the `master` branch. We attempt to do our best to ensure that the history remains clean and to do so, we generally ask contributors to squash their commits into a set or single logical commit.
 
 [event store support]: https://eventstore.com/support/
-[event store docs]: https://developers.eventstore.com/server/20.6/server/installation/
+[event store docs]: https://developers.eventstore.com/server/v21.2/docs/installation/
 [event store discuss]: https://discuss.eventstore.com/
 [yarn]: https://yarnpkg.com/
 [jest]: https://jestjs.io/


### PR DESCRIPTION
The current link just shows 404
![image](https://user-images.githubusercontent.com/1562848/116462249-eb74c000-a871-11eb-8313-999bfd28367b.png)
