### PR TITLE
export ChannelCredentialOptions interface

### DIFF
--- a/src/Client/index.ts
+++ b/src/Client/index.ts
@@ -79,7 +79,7 @@ export type ConnectionTypeOptions =
   | GossipClusterOptions
   | SingleNodeOptions;
 
-interface ChannelCredentialOptions {
+export interface ChannelCredentialOptions {
   insecure?: boolean;
   rootCertificate?: Buffer;
   privateKey?: Buffer;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import "./streams";
 export {
   Client as EventStoreDBClient,
   ConnectionTypeOptions,
-  ChannelCredentialOptions
+  ChannelCredentialOptions,
 } from "./Client";
 export * from "./events";
 export * from "./constants";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,11 @@ import "./persistentSubscription";
 import "./projections";
 import "./streams";
 
-export { Client as EventStoreDBClient } from "./Client";
+export {
+  Client as EventStoreDBClient,
+  ConnectionTypeOptions,
+  ChannelCredentialOptions
+} from "./Client";
 export * from "./events";
 export * from "./constants";
 export * from "./types";


### PR DESCRIPTION
It would be handy to have all interfaces exported, as for example I'm creating a wrapper for NestJS and I would like to keep the same input interfaces as for the constructor