### PR TITLE
Allow tests to pass with server versions before and after EventStore #2944

### DIFF
--- a/src/__test__/projections/disableProjection.test.ts
+++ b/src/__test__/projections/disableProjection.test.ts
@@ -58,7 +58,10 @@ describe("disableProjection", () => {
       );
 
       expect(afterDetails).toBeDefined();
-      expect(afterDetails.projectionStatus).toBe(ABORTED);
+
+      // Incorrect projection status was switched (ABORTED -> STOPPED) in
+      // https://github.com/EventStore/EventStore/pull/2944
+      expect([STOPPED, ABORTED]).toContain(afterDetails.projectionStatus);
     });
 
     test("do not write a checkpoint", async () => {
@@ -82,7 +85,10 @@ describe("disableProjection", () => {
       );
 
       expect(afterDetails).toBeDefined();
-      expect(afterDetails.projectionStatus).toBe(STOPPED);
+
+      // Incorrect projection status was fixed (STOPPED -> ABORTED) in
+      // https://github.com/EventStore/EventStore/pull/2944
+      expect([ABORTED, STOPPED]).toContain(afterDetails.projectionStatus);
     });
   });
 

--- a/src/__test__/projections/enableProjection.test.ts
+++ b/src/__test__/projections/enableProjection.test.ts
@@ -1,6 +1,12 @@
 import { createTestNode } from "../utils";
 
-import { ABORTED, EventStoreDBClient, RUNNING, UnknownError } from "../..";
+import {
+  ABORTED,
+  EventStoreDBClient,
+  RUNNING,
+  STOPPED,
+  UnknownError,
+} from "../..";
 
 describe("enableProjection", () => {
   const node = createTestNode();
@@ -40,7 +46,10 @@ describe("enableProjection", () => {
     const beforeDetails = await client.getProjectionStatistics(PROJECTION_NAME);
 
     expect(beforeDetails).toBeDefined();
-    expect(beforeDetails.projectionStatus).toBe(ABORTED);
+
+    // Incorrect projection status was switched (ABORTED -> STOPPED) in
+    // https://github.com/EventStore/EventStore/pull/2944
+    expect([STOPPED, ABORTED]).toContain(beforeDetails.projectionStatus);
 
     await client.enableProjection(PROJECTION_NAME);
 


### PR DESCRIPTION
Allow tests to pass with server versions before and after https://github.com/EventStore/EventStore/pull/2944

- Pass with previous (incorrect) projection status and new projection status
- Stop the projection in delete test, rather than aborting it, but abort it to stop it if we get back the wrong status