### PR TITLE
Reconnect on node loss

### DIFF
--- a/src/Client/index.ts
+++ b/src/Client/index.ts
@@ -434,13 +434,18 @@ export class Client {
         : `${endpoint.address}:${endpoint.port}`;
     }
 
-    const { address, port } = await discoverEndpoint(
-      this.#connectionSettings,
-      this.#channelCredentials,
-      this.#nextChannelSettings?.failedEndpoint
-    );
-
-    return `${address}:${port}`;
+    try {
+      const { address, port } = await discoverEndpoint(
+        this.#connectionSettings,
+        this.#channelCredentials,
+        this.#nextChannelSettings?.failedEndpoint
+      );
+      return `${address}:${port}`;
+    } catch (error) {
+      this.#grpcClients.clear();
+      this.#channel = undefined;
+      throw error;
+    }
   };
 
   private createCredentialsMetadataGenerator =

--- a/src/__test__/connection/reconnect.test.ts
+++ b/src/__test__/connection/reconnect.test.ts
@@ -1,0 +1,184 @@
+import { createTestCluster, delay, jsonTestEvents } from "../utils";
+
+import {
+  jsonEvent,
+  EventStoreDBClient,
+  UnavailableError,
+  FOLLOWER,
+  NotLeaderError,
+  EndPoint,
+} from "../..";
+
+describe("reconnect", () => {
+  test("UnavailableError", async () => {
+    const cluster = createTestCluster();
+
+    await cluster.up();
+
+    const client = new EventStoreDBClient(
+      { endpoints: cluster.endpoints },
+      { rootCertificate: cluster.rootCertificate }
+    );
+
+    // make successful append to connect to node
+    const firstAppend = await client.appendToStream(
+      "my_stream",
+      jsonEvent({ type: "first-append", data: { message: "test" } })
+    );
+    expect(firstAppend).toBeDefined();
+
+    // Kill node we are connected to
+    const activeConnection = await getCurrentConnection(client);
+    await cluster.killNode(activeConnection);
+
+    // next append should fail, triggering reconnection
+    try {
+      const secondAppend = await client.appendToStream(
+        "my_stream",
+        jsonEvent({ type: "failed-append", data: { message: "test" } })
+      );
+      expect(secondAppend).toBe("Unreachable");
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnavailableError);
+    }
+
+    // next append should succeed, as it has connected to another node
+    // but it might take a couple of tries
+    let i = 0;
+    while (++i < 20) {
+      try {
+        const reconnectedAppend = await client.appendToStream(
+          "my_stream",
+          jsonEvent({ type: "reconnect-append", data: { message: "test" } })
+        );
+        expect(reconnectedAppend).toBeDefined();
+        break;
+      } catch (error) {
+        await delay(200);
+      }
+    }
+
+    expect(i).toBeLessThan(20);
+
+    await cluster.down();
+  });
+
+  test("NotLeaderError (should reconnect to leader)", async () => {
+    const cluster = createTestCluster();
+
+    await cluster.up();
+
+    const client = new EventStoreDBClient(
+      { endpoints: cluster.endpoints, nodePreference: FOLLOWER },
+      { rootCertificate: cluster.rootCertificate }
+    );
+
+    // make successful append to follower node
+    const firstAppend = await client.appendToStream(
+      "my_stream",
+      jsonEvent({ type: "first-append", data: { message: "test" } })
+    );
+    expect(firstAppend).toBeDefined();
+
+    let leader!: EndPoint;
+    try {
+      // state that append requires leader, causing failure
+      const secondAppend = await client.appendToStream(
+        "my_stream",
+        jsonEvent({ type: "failed-append", data: { message: "test" } }),
+        { requiresLeader: true }
+      );
+      expect(secondAppend).toBe("Unreachable");
+    } catch (error) {
+      expect(error).toBeInstanceOf(NotLeaderError);
+
+      if (error instanceof NotLeaderError) {
+        leader = error.leader;
+      }
+    }
+
+    // next append should succeed, as it has connected to another node
+    const reconnectedAppend = await client.appendToStream(
+      "my_stream",
+      jsonEvent({ type: "reconnect-append", data: { message: "test" } }),
+      { requiresLeader: true }
+    );
+    expect(reconnectedAppend).toBeDefined();
+
+    const { address, port } = await getCurrentConnection(client);
+
+    expect(address).toEqual(leader.address);
+    expect(port).toEqual(port);
+
+    await cluster.down();
+  });
+
+  test("Connection error mid stream should cause a reconnect", async () => {
+    const cluster = createTestCluster();
+
+    await cluster.up();
+
+    const client = new EventStoreDBClient(
+      { endpoints: cluster.endpoints },
+      { rootCertificate: cluster.rootCertificate }
+    );
+
+    // make successful append of 2000 events to node
+    const firstAppend = await client.appendToStream(
+      "my_stream",
+      jsonTestEvents(2000)
+    );
+    expect(firstAppend).toBeDefined();
+
+    try {
+      let i = 0;
+      for await (const event of client.readStream("my_stream")) {
+        expect(event).toBeDefined();
+
+        if (i === 12) {
+          // Kill node we are connected to
+          const activeConnection = await getCurrentConnection(client);
+          await cluster.killNode(activeConnection);
+        }
+
+        i++;
+      }
+
+      expect(i).toBe("unreachable");
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnavailableError);
+    }
+
+    // next append should succeed, as it has connected to another node
+    // but it might take a couple of tries
+    let i = 0;
+    while (++i < 20) {
+      try {
+        const reconnectedAppend = await client.appendToStream(
+          "my_stream",
+          jsonEvent({ type: "reconnect-append", data: { message: "test" } })
+        );
+        expect(reconnectedAppend).toBeDefined();
+        break;
+      } catch (error) {
+        await delay(200);
+      }
+    }
+
+    expect(i).toBeLessThan(20);
+
+    await cluster.down();
+  });
+});
+
+const getCurrentConnection = async (
+  client: EventStoreDBClient
+): Promise<EndPoint> => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const channel = await (client as any).getChannel();
+  const [_protocol, address, port] = channel.getTarget().split(":");
+  return {
+    address,
+    port: Number.parseInt(port),
+  };
+};

--- a/src/__test__/connection/reconnect.test.ts
+++ b/src/__test__/connection/reconnect.test.ts
@@ -1,3 +1,6 @@
+import { Channel } from "@grpc/grpc-js";
+import { ConnectivityState } from "@grpc/grpc-js/build/src/channel";
+
 import { createTestCluster, delay, jsonTestEvents } from "../utils";
 
 import {
@@ -8,6 +11,7 @@ import {
   NotLeaderError,
   FOLLOWER,
   EndPoint,
+  TimeoutError,
 } from "../..";
 
 describe("reconnect", () => {
@@ -275,6 +279,95 @@ describe("reconnect", () => {
     const afterChannel = await (client as any).getChannel();
 
     expect(priorChannel).toBe(afterChannel);
+
+    await cluster.down();
+  });
+
+  test("Cluster down during reconnection", async () => {
+    const cluster = createTestCluster();
+
+    await cluster.up();
+
+    const client = new EventStoreDBClient(
+      { endpoints: cluster.endpoints },
+      { rootCertificate: cluster.rootCertificate }
+    );
+
+    // make successful append to connect to node
+    const firstAppend = await client.appendToStream(
+      "my_stream",
+      jsonEvent({ type: "first-append", data: { message: "test" } })
+    );
+    expect(firstAppend).toBeDefined();
+
+    // Kill node we are connected to
+    const activeConnection = await getCurrentConnection(client);
+    await cluster.killNode(activeConnection);
+
+    // next append should fail, triggering reconnection
+    try {
+      const secondAppend = await client.appendToStream(
+        "my_stream",
+        jsonEvent({ type: "failed-append", data: { message: "test" } })
+      );
+      expect(secondAppend).toBe("Unreachable");
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnavailableError);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const channel: Channel = await (client as any).getChannel();
+
+    // channel should be IDLE, pending usage
+    expect(channel.getConnectivityState(false)).toBe(ConnectivityState.IDLE);
+
+    channel.watchConnectivityState(
+      channel.getConnectivityState(false),
+      Infinity,
+      () => {
+        // channel has transitioned to CONNECTING
+        expect(channel.getConnectivityState(false)).toBe(
+          ConnectivityState.CONNECTING
+        );
+
+        const [_protocol, address, port] = channel.getTarget().split(":");
+        // lets kill the node its connecting to
+        return cluster.killNode({
+          address,
+          port: Number.parseInt(port),
+        });
+      }
+    );
+
+    // next append should fail with a TimeoutError, due to error in reconnection
+    try {
+      const secondAppend = await client.appendToStream(
+        "my_stream",
+        jsonEvent({ type: "failed-append", data: { message: "test" } })
+      );
+
+      expect(secondAppend).toBe("Unreachable");
+    } catch (error) {
+      expect(error).toBeInstanceOf(TimeoutError);
+    }
+
+    // next append should succeed, as it has connected to another node
+    // but it might take a couple of tries
+    let i = 0;
+    while (++i < 20) {
+      try {
+        const reconnectedAppend = await client.appendToStream(
+          "my_stream",
+          jsonEvent({ type: "reconnect-append", data: { message: "test" } })
+        );
+        expect(reconnectedAppend).toBeDefined();
+        break;
+      } catch (error) {
+        await delay(200);
+      }
+    }
+
+    expect(i).toBeLessThan(20);
 
     await cluster.down();
   });

--- a/src/__test__/utils/Cluster.ts
+++ b/src/__test__/utils/Cluster.ts
@@ -338,8 +338,10 @@ export class Cluster {
     try {
       await rmdir(this.path(), { recursive: true });
     } catch (error) {
-      // TODO:
-      // removing the directory fails on github actions
+      if (process.env.CI) return;
+      console.log(
+        `Failed to clean up test files at "${this.path()}": ${error}`
+      );
     }
   };
 

--- a/src/persistentSubscription/connectToPersistentSubscription.ts
+++ b/src/persistentSubscription/connectToPersistentSubscription.ts
@@ -69,17 +69,19 @@ Client.prototype.connectToPersistentSubscription = function <
   });
   debug.command_grpc("connectToPersistentSubscription: %g", req);
 
-  return new TwoWaySubscription(async () => {
-    const client = await this.getGRPCClient(
-      PersistentSubscriptionsClient,
-      "connectToPersistentSubscription"
-    );
-    const stream = client.read(
-      ...this.callArguments(baseOptions, {
-        deadline: Infinity,
-      })
-    );
-    stream.write(req);
-    return stream;
-  }, duplexOptions);
+  const createGRPCStream = this.GRPCStreamCreator(
+    PersistentSubscriptionsClient,
+    "connectToPersistentSubscription",
+    (client) => {
+      const stream = client.read(
+        ...this.callArguments(baseOptions, {
+          deadline: Infinity,
+        })
+      );
+      stream.write(req);
+      return stream;
+    }
+  );
+
+  return new TwoWaySubscription(createGRPCStream, duplexOptions);
 };

--- a/src/persistentSubscription/createPersistentSubscription.ts
+++ b/src/persistentSubscription/createPersistentSubscription.ts
@@ -119,15 +119,15 @@ Client.prototype.createPersistentSubscription = async function (
   });
   debug.command_grpc("createPersistentSubscription: %g", req);
 
-  const client = await this.getGRPCClient(
+  return this.execute(
     PersistentSubscriptionsClient,
-    "createPersistentSubscription"
+    "createPersistentSubscription",
+    (client) =>
+      new Promise<void>((resolve, reject) => {
+        client.create(req, ...this.callArguments(baseOptions), (error) => {
+          if (error) return reject(convertToCommandError(error));
+          return resolve();
+        });
+      })
   );
-
-  return new Promise<void>((resolve, reject) => {
-    client.create(req, ...this.callArguments(baseOptions), (error) => {
-      if (error) return reject(convertToCommandError(error));
-      return resolve();
-    });
-  });
 };

--- a/src/persistentSubscription/deletePersistentSubscription.ts
+++ b/src/persistentSubscription/deletePersistentSubscription.ts
@@ -46,15 +46,15 @@ Client.prototype.deletePersistentSubscription = async function (
   });
   debug.command_grpc("deletePersistentSubscription: %g", req);
 
-  const client = await this.getGRPCClient(
+  return this.execute(
     PersistentSubscriptionsClient,
-    "deletePersistentSubscription"
+    "deletePersistentSubscription",
+    (client) =>
+      new Promise<void>((resolve, reject) => {
+        client.delete(req, ...this.callArguments(baseOptions), (error) => {
+          if (error) return reject(convertToCommandError(error));
+          return resolve();
+        });
+      })
   );
-
-  return new Promise<void>((resolve, reject) => {
-    client.delete(req, ...this.callArguments(baseOptions), (error) => {
-      if (error) return reject(convertToCommandError(error));
-      return resolve();
-    });
-  });
 };

--- a/src/persistentSubscription/updatePersistentSubscription.ts
+++ b/src/persistentSubscription/updatePersistentSubscription.ts
@@ -111,15 +111,15 @@ Client.prototype.updatePersistentSubscription = async function (
   });
   debug.command_grpc("updatePersistentSubscription: %g", req);
 
-  const client = await this.getGRPCClient(
+  return this.execute(
     PersistentSubscriptionsClient,
-    "updatePersistentSubscription"
+    "updatePersistentSubscription",
+    (client) =>
+      new Promise<void>((resolve, reject) => {
+        client.update(req, ...this.callArguments(baseOptions), (error) => {
+          if (error) return reject(convertToCommandError(error));
+          return resolve();
+        });
+      })
   );
-
-  return new Promise<void>((resolve, reject) => {
-    client.update(req, ...this.callArguments(baseOptions), (error) => {
-      if (error) return reject(convertToCommandError(error));
-      return resolve();
-    });
-  });
 };

--- a/src/projections/createContinuousProjection.ts
+++ b/src/projections/createContinuousProjection.ts
@@ -60,15 +60,15 @@ Client.prototype.createContinuousProjection = async function (
   });
   debug.command_grpc("createContinuousProjection: %g", req);
 
-  const client = await this.getGRPCClient(
+  return this.execute(
     ProjectionsClient,
-    "createContinuousProjection"
+    "createContinuousProjection",
+    (client) =>
+      new Promise<void>((resolve, reject) => {
+        client.create(req, ...this.callArguments(baseOptions), (error) => {
+          if (error) return reject(convertToCommandError(error));
+          return resolve();
+        });
+      })
   );
-
-  return new Promise<void>((resolve, reject) => {
-    client.create(req, ...this.callArguments(baseOptions), (error) => {
-      if (error) return reject(convertToCommandError(error));
-      return resolve();
-    });
-  });
 };

--- a/src/projections/createOneTimeProjection.ts
+++ b/src/projections/createOneTimeProjection.ts
@@ -54,19 +54,21 @@ Client.prototype.createOneTimeProjection = async function (
   });
   debug.command_grpc("createOneTimeProjection: %g", req);
 
-  const client = await this.getGRPCClient(
+  return this.execute(
     ProjectionsClient,
-    "createOneTimeProjection"
+    "createOneTimeProjection",
+    (client) =>
+      new Promise<void>((resolve, reject) => {
+        client.create(
+          req,
+          ...this.callArguments(
+            typeof baseOptions === "string" ? {} : baseOptions
+          ),
+          (error) => {
+            if (error) return reject(convertToCommandError(error));
+            return resolve();
+          }
+        );
+      })
   );
-
-  return new Promise<void>((resolve, reject) => {
-    client.create(
-      req,
-      ...this.callArguments(typeof baseOptions === "string" ? {} : baseOptions),
-      (error) => {
-        if (error) return reject(convertToCommandError(error));
-        return resolve();
-      }
-    );
-  });
 };

--- a/src/projections/createTransientProjection.ts
+++ b/src/projections/createTransientProjection.ts
@@ -47,15 +47,15 @@ Client.prototype.createTransientProjection = async function (
   });
   debug.command_grpc("createTransientProjection: %g", req);
 
-  const client = await this.getGRPCClient(
+  return this.execute(
     ProjectionsClient,
-    "CreateTransientProjection"
+    "CreateTransientProjection",
+    (client) =>
+      new Promise<void>((resolve, reject) => {
+        client.create(req, ...this.callArguments(baseOptions), (error) => {
+          if (error) return reject(convertToCommandError(error));
+          return resolve();
+        });
+      })
   );
-
-  return new Promise<void>((resolve, reject) => {
-    client.create(req, ...this.callArguments(baseOptions), (error) => {
-      if (error) return reject(convertToCommandError(error));
-      return resolve();
-    });
-  });
 };

--- a/src/projections/deleteProjection.ts
+++ b/src/projections/deleteProjection.ts
@@ -70,15 +70,15 @@ Client.prototype.deleteProjection = async function (
   });
   debug.command_grpc("deleteProjection: %g", req);
 
-  const client = await this.getGRPCClient(
+  return this.execute(
     ProjectionsClient,
-    "deleteProjection"
+    "deleteProjection",
+    (client) =>
+      new Promise<void>((resolve, reject) => {
+        client.delete(req, ...this.callArguments(baseOptions), (error) => {
+          if (error) return reject(convertToCommandError(error));
+          return resolve();
+        });
+      })
   );
-
-  return new Promise<void>((resolve, reject) => {
-    client.delete(req, ...this.callArguments(baseOptions), (error) => {
-      if (error) return reject(convertToCommandError(error));
-      return resolve();
-    });
-  });
 };

--- a/src/projections/disableProjection.ts
+++ b/src/projections/disableProjection.ts
@@ -46,15 +46,15 @@ Client.prototype.disableProjection = async function (
   });
   debug.command_grpc("disableProjection: %g", req);
 
-  const client = await this.getGRPCClient(
+  return this.execute(
     ProjectionsClient,
-    "disableProjection"
+    "disableProjection",
+    (client) =>
+      new Promise<void>((resolve, reject) => {
+        client.disable(req, ...this.callArguments(baseOptions), (error) => {
+          if (error) return reject(convertToCommandError(error));
+          return resolve();
+        });
+      })
   );
-
-  return new Promise<void>((resolve, reject) => {
-    client.disable(req, ...this.callArguments(baseOptions), (error) => {
-      if (error) return reject(convertToCommandError(error));
-      return resolve();
-    });
-  });
 };

--- a/src/projections/enableProjection.ts
+++ b/src/projections/enableProjection.ts
@@ -39,15 +39,15 @@ Client.prototype.enableProjection = async function (
   });
   debug.command_grpc("enableProjection: %g", req);
 
-  const client = await this.getGRPCClient(
+  return this.execute(
     ProjectionsClient,
-    "enableProjection"
+    "enableProjection",
+    (client) =>
+      new Promise<void>((resolve, reject) => {
+        client.enable(req, ...this.callArguments(baseOptions), (error) => {
+          if (error) return reject(convertToCommandError(error));
+          return resolve();
+        });
+      })
   );
-
-  return new Promise<void>((resolve, reject) => {
-    client.enable(req, ...this.callArguments(baseOptions), (error) => {
-      if (error) return reject(convertToCommandError(error));
-      return resolve();
-    });
-  });
 };

--- a/src/projections/getProjectionResult.ts
+++ b/src/projections/getProjectionResult.ts
@@ -47,19 +47,19 @@ Client.prototype.getProjectionResult = async function <T = unknown>(
   });
   debug.command_grpc("getProjectionResult: %g", req);
 
-  const client = await this.getGRPCClient(
+  return this.execute(
     ProjectionsClient,
-    "getProjectionResult"
+    "getProjectionResult",
+    (client) =>
+      new Promise<T>((resolve, reject) => {
+        client.result(
+          req,
+          ...this.callArguments(baseOptions),
+          (error, response) => {
+            if (error) return reject(convertToCommandError(error));
+            return resolve(response.getResult()?.toJavaScript() as T);
+          }
+        );
+      })
   );
-
-  return new Promise<T>((resolve, reject) => {
-    client.result(
-      req,
-      ...this.callArguments(baseOptions),
-      (error, response) => {
-        if (error) return reject(convertToCommandError(error));
-        return resolve(response.getResult()?.toJavaScript() as T);
-      }
-    );
-  });
 };

--- a/src/projections/getProjectionState.ts
+++ b/src/projections/getProjectionState.ts
@@ -37,15 +37,19 @@ Client.prototype.getProjectionState = async function <T = unknown>(
   });
   debug.command_grpc("getProjectionState: %g", req);
 
-  const client = await this.getGRPCClient(
+  return this.execute(
     ProjectionsClient,
-    "getProjectionState"
+    "getProjectionState",
+    (client) =>
+      new Promise<T>((resolve, reject) => {
+        client.state(
+          req,
+          ...this.callArguments(baseOptions),
+          (error, response) => {
+            if (error) return reject(convertToCommandError(error));
+            return resolve(response.getState()?.toJavaScript() as T);
+          }
+        );
+      })
   );
-
-  return new Promise<T>((resolve, reject) => {
-    client.state(req, ...this.callArguments(baseOptions), (error, response) => {
-      if (error) return reject(convertToCommandError(error));
-      return resolve(response.getState()?.toJavaScript() as T);
-    });
-  });
 };

--- a/src/projections/resetProjection.ts
+++ b/src/projections/resetProjection.ts
@@ -47,12 +47,15 @@ Client.prototype.resetProjection = async function (
   });
   debug.command_grpc("resetProjection: %g", req);
 
-  const client = await this.getGRPCClient(ProjectionsClient, "resetProjection");
-
-  return new Promise<void>((resolve, reject) => {
-    client.reset(req, ...this.callArguments(baseOptions), (error) => {
-      if (error) return reject(convertToCommandError(error));
-      return resolve();
-    });
-  });
+  return this.execute(
+    ProjectionsClient,
+    "resetProjection",
+    (client) =>
+      new Promise<void>((resolve, reject) => {
+        client.reset(req, ...this.callArguments(baseOptions), (error) => {
+          if (error) return reject(convertToCommandError(error));
+          return resolve();
+        });
+      })
+  );
 };

--- a/src/projections/restartSubsystem.ts
+++ b/src/projections/restartSubsystem.ts
@@ -28,19 +28,19 @@ Client.prototype.restartSubsystem = async function (
   });
   debug.command_grpc("restartSubsystem: %g", req);
 
-  const client = await this.getGRPCClient(
+  return this.execute(
     ProjectionsClient,
-    "restartSubsystem"
+    "restartSubsystem",
+    (client) =>
+      new Promise<void>((resolve, reject) => {
+        client.restartSubsystem(
+          req,
+          ...this.callArguments(baseOptions),
+          (error) => {
+            if (error) return reject(convertToCommandError(error));
+            return resolve();
+          }
+        );
+      })
   );
-
-  return new Promise<void>((resolve, reject) => {
-    client.restartSubsystem(
-      req,
-      ...this.callArguments(baseOptions),
-      (error) => {
-        if (error) return reject(convertToCommandError(error));
-        return resolve();
-      }
-    );
-  });
 };

--- a/src/projections/updateProjection.ts
+++ b/src/projections/updateProjection.ts
@@ -57,15 +57,15 @@ Client.prototype.updateProjection = async function (
   });
   debug.command_grpc("updateProjection: %g", req);
 
-  const client = await this.getGRPCClient(
+  return this.execute(
     ProjectionsClient,
-    "updateProjection"
+    "updateProjection",
+    (client) =>
+      new Promise<void>((resolve, reject) => {
+        client.update(req, ...this.callArguments(baseOptions), (error) => {
+          if (error) return reject(convertToCommandError(error));
+          return resolve();
+        });
+      })
   );
-
-  return new Promise<void>((resolve, reject) => {
-    client.update(req, ...this.callArguments(baseOptions), (error) => {
-      if (error) return reject(convertToCommandError(error));
-      return resolve();
-    });
-  });
 };

--- a/src/streams/appendToStream.ts
+++ b/src/streams/appendToStream.ts
@@ -198,71 +198,7 @@ Client.prototype.appendToStream = async function (
           sink.write(entry);
         }
 
-<<<<<<< HEAD
-        if (resp.hasSuccess()) {
-          const success = resp.getSuccess()!;
-          const nextExpectedRevision = BigInt(success.getCurrentRevision());
-          const grpcPosition = success.getPosition();
-
-          const position = grpcPosition
-            ? {
-                commit: BigInt(grpcPosition.getCommitPosition()),
-                prepare: BigInt(grpcPosition.getPreparePosition()),
-              }
-            : undefined;
-
-          return resolve({
-            success: true,
-            nextExpectedRevision,
-            position,
-          });
-        }
-      }
-    );
-
-    sink.write(header);
-
-    for (const event of events) {
-      const entry = new AppendReq();
-      const message = new AppendReq.ProposedMessage();
-      const id = new UUID();
-      id.setString(event.id);
-      message.setId(id);
-      message.getMetadataMap().set("type", event.type);
-      message.getMetadataMap().set("content-type", event.contentType);
-
-      switch (event.contentType) {
-        case "application/json": {
-          const data = JSON.stringify(event.data);
-          message.setData(Uint8Array.from(Buffer.from(data, "utf8")));
-          break;
-        }
-        case "application/octet-stream": {
-          message.setData(event.data);
-          break;
-        }
-      }
-
-      if (event.metadata) {
-        if (event.metadata.constructor === Uint8Array) {
-          message.setCustomMetadata(event.metadata);
-        } else {
-          const metadata = JSON.stringify(event.metadata);
-          message.setCustomMetadata(
-            Uint8Array.from(Buffer.from(metadata, "utf8"))
-          );
-        }
-      }
-
-      entry.setProposedMessage(message);
-      sink.write(entry);
-    }
-
-    sink.end();
-  });
-=======
         sink.end();
       })
   );
->>>>>>> 5942cd5 (Reconnect on node loss)
 };

--- a/src/streams/readAll.ts
+++ b/src/streams/readAll.ts
@@ -113,16 +113,20 @@ Client.prototype.readAll = function (
   });
   debug.command_grpc("readAll: %g", req);
 
-  return new ReadStream(
-    async () => {
-      const client = await this.getGRPCClient(StreamsClient, "readAll");
-      return client.read(
+  const createGRPCStream = this.GRPCStreamCreator(
+    StreamsClient,
+    "readAll",
+    (client) =>
+      client.read(
         req,
         ...this.callArguments(baseOptions, {
           deadline: Infinity,
         })
-      );
-    },
+      )
+  );
+
+  return new ReadStream(
+    createGRPCStream,
     convertAllStreamGrpcEvent,
     readableOptions
   );

--- a/src/streams/readStream.ts
+++ b/src/streams/readStream.ts
@@ -128,17 +128,17 @@ Client.prototype.readStream = function <
   });
   debug.command_grpc("readStream: %g", req);
 
-  return new ReadStream(
-    async () => {
-      const client = await this.getGRPCClient(StreamsClient, "readStream");
-      return client.read(
+  const createGRPCStream = this.GRPCStreamCreator(
+    StreamsClient,
+    "readStream",
+    (client) =>
+      client.read(
         req,
         ...this.callArguments(baseOptions, {
           deadline: Infinity,
         })
-      );
-    },
-    convertGrpcEvent,
-    readableOptions
+      )
   );
+
+  return new ReadStream(createGRPCStream, convertGrpcEvent, readableOptions);
 };

--- a/src/streams/subscribeToAll.ts
+++ b/src/streams/subscribeToAll.ts
@@ -149,16 +149,20 @@ Client.prototype.subscribeToAll = function (
   });
   debug.command_grpc("subscribeToAll: %g", req);
 
-  return new OneWaySubscription(
-    async () => {
-      const client = await this.getGRPCClient(StreamsClient, "subscribeToAll");
-      return client.read(
+  const createGRPCStream = this.GRPCStreamCreator(
+    StreamsClient,
+    "subscribeToAll",
+    (client) =>
+      client.read(
         req,
         ...this.callArguments(baseOptions, {
           deadline: Infinity,
         })
-      );
-    },
+      )
+  );
+
+  return new OneWaySubscription(
+    createGRPCStream,
     convertAllStreamGrpcEvent,
     readableOptions
   );

--- a/src/streams/subscribeToStream.ts
+++ b/src/streams/subscribeToStream.ts
@@ -105,19 +105,20 @@ Client.prototype.subscribeToStream = function <
   });
   debug.command_grpc("subscribeToStream: %g", req);
 
-  return new OneWaySubscription(
-    async () => {
-      const client = await this.getGRPCClient(
-        StreamsClient,
-        "subscribeToStream"
-      );
-      return client.read(
+  const createGRPCStream = this.GRPCStreamCreator(
+    StreamsClient,
+    "subscribeToStream",
+    (client) =>
+      client.read(
         req,
         ...this.callArguments(baseOptions, {
           deadline: Infinity,
         })
-      );
-    },
+      )
+  );
+
+  return new OneWaySubscription(
+    createGRPCStream,
     convertGrpcEvent,
     readableOptions
   );

--- a/src/utils/CommandError.ts
+++ b/src/utils/CommandError.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 
-import { status as StatusCode, ServiceError } from "@grpc/grpc-js";
+import { status as StatusCode, ServiceError, Metadata } from "@grpc/grpc-js";
 import { CurrentRevision, EndPoint, AppendExpectedRevision } from "../types";
 
 export enum ErrorType {
@@ -302,7 +302,9 @@ export type CommandError =
   | UnavailableError
   | UnknownError;
 
-export const convertToCommandError = (error: ServiceError): CommandError => {
+export const convertToCommandError = (error: Error): CommandError | Error => {
+  if (isCommandError(error) || !isServiceError(error)) return error;
+
   const exeption = error.metadata?.getMap()["exception"]?.toString();
 
   switch (exeption) {
@@ -356,4 +358,11 @@ export const convertToCommandError = (error: ServiceError): CommandError => {
 
 export const isCommandError = (error: Error): error is CommandError => {
   return error instanceof CommandErrorBase;
+};
+
+const isServiceError = (error: Error | ServiceError): error is ServiceError => {
+  return (
+    ("metadata" in error && error.metadata instanceof Metadata) ||
+    ("code" in error && typeof error.code === "number")
+  );
 };


### PR DESCRIPTION
- wrap calls in execute to capture errors
- check for errors that require reconnection
- wrap streaming calls with `createGRPCStream`
- listen to errors and check if reconnection is required
- reconnect on connection errors

fixes: #176 

RFC: https://github.com/EventStore/home/issues/574