### PR TITLE
Do not base64 encode JSON data for performance gains

### DIFF
--- a/src/persistentSubscription/connectToPersistentSubscription.ts
+++ b/src/persistentSubscription/connectToPersistentSubscription.ts
@@ -49,7 +49,7 @@ Client.prototype.connectToPersistentSubscription = function <
   const req = new ReadReq();
   const options = new ReadReq.Options();
   const identifier = new StreamIdentifier();
-  identifier.setStreamname(Buffer.from(streamName).toString("base64"));
+  identifier.setStreamname(Uint8Array.from(Buffer.from(streamName, "utf8")));
 
   const uuidOption = new UUIDOption();
   uuidOption.setString(new Empty());

--- a/src/persistentSubscription/createPersistentSubscription.ts
+++ b/src/persistentSubscription/createPersistentSubscription.ts
@@ -103,7 +103,7 @@ Client.prototype.createPersistentSubscription = async function (
       break;
   }
 
-  identifier.setStreamname(Buffer.from(streamName).toString("base64"));
+  identifier.setStreamname(Uint8Array.from(Buffer.from(streamName, "utf8")));
 
   options.setGroupName(groupName);
   options.setStreamIdentifier(identifier);

--- a/src/persistentSubscription/deletePersistentSubscription.ts
+++ b/src/persistentSubscription/deletePersistentSubscription.ts
@@ -34,7 +34,7 @@ Client.prototype.deletePersistentSubscription = async function (
   const options = new DeleteReq.Options();
   const identifier = new StreamIdentifier();
 
-  identifier.setStreamname(Buffer.from(streamName).toString("base64"));
+  identifier.setStreamname(Uint8Array.from(Buffer.from(streamName, "utf8")));
   options.setStreamIdentifier(identifier);
   options.setGroupName(groupName);
   req.setOptions(options);

--- a/src/persistentSubscription/updatePersistentSubscription.ts
+++ b/src/persistentSubscription/updatePersistentSubscription.ts
@@ -95,7 +95,7 @@ Client.prototype.updatePersistentSubscription = async function (
       break;
   }
 
-  identifier.setStreamname(Buffer.from(streamName).toString("base64"));
+  identifier.setStreamname(Uint8Array.from(Buffer.from(streamName, "utf8")));
 
   options.setGroupName(groupName);
   options.setStreamIdentifier(identifier);

--- a/src/streams/appendToStream.ts
+++ b/src/streams/appendToStream.ts
@@ -53,7 +53,7 @@ Client.prototype.appendToStream = async function (
   const options = new AppendReq.Options();
   const identifier = new StreamIdentifier();
 
-  identifier.setStreamname(Buffer.from(streamName).toString("base64"));
+  identifier.setStreamname(Uint8Array.from(Buffer.from(streamName, "utf8")));
   options.setStreamIdentifier(identifier);
 
   switch (expectedRevision) {
@@ -172,7 +172,7 @@ Client.prototype.appendToStream = async function (
       switch (event.contentType) {
         case "application/json": {
           const data = JSON.stringify(event.data);
-          message.setData(Buffer.from(data, "utf8").toString("base64"));
+          message.setData(Uint8Array.from(Buffer.from(data, "utf8")));
           break;
         }
         case "application/octet-stream": {
@@ -187,7 +187,7 @@ Client.prototype.appendToStream = async function (
         } else {
           const metadata = JSON.stringify(event.metadata);
           message.setCustomMetadata(
-            Buffer.from(metadata, "utf8").toString("base64")
+            Uint8Array.from(Buffer.from(metadata, "utf8"))
           );
         }
       }

--- a/src/streams/deleteStream.ts
+++ b/src/streams/deleteStream.ts
@@ -37,7 +37,7 @@ Client.prototype.deleteStream = async function (
   const req = new DeleteReq();
   const options = new DeleteReq.Options();
   const identifier = new StreamIdentifier();
-  identifier.setStreamname(Buffer.from(streamName).toString("base64"));
+  identifier.setStreamname(Uint8Array.from(Buffer.from(streamName, "utf8")));
 
   options.setStreamIdentifier(identifier);
 

--- a/src/streams/readStream.ts
+++ b/src/streams/readStream.ts
@@ -74,7 +74,7 @@ Client.prototype.readStream = function <
   const req = new ReadReq();
   const options = new ReadReq.Options();
   const identifier = new StreamIdentifier();
-  identifier.setStreamname(Buffer.from(streamName).toString("base64"));
+  identifier.setStreamname(Uint8Array.from(Buffer.from(streamName, "utf8")));
 
   const uuidOption = new UUIDOption();
   uuidOption.setString(new Empty());

--- a/src/streams/subscribeToStream.ts
+++ b/src/streams/subscribeToStream.ts
@@ -62,7 +62,7 @@ Client.prototype.subscribeToStream = function <
   const req = new ReadReq();
   const options = new ReadReq.Options();
   const identifier = new StreamIdentifier();
-  identifier.setStreamname(Buffer.from(streamName).toString("base64"));
+  identifier.setStreamname(Uint8Array.from(Buffer.from(streamName, "utf8")));
 
   const uuidOption = new UUIDOption();
   uuidOption.setString(new Empty());

--- a/src/streams/tombstoneStream.ts
+++ b/src/streams/tombstoneStream.ts
@@ -37,7 +37,7 @@ Client.prototype.tombstoneStream = async function (
   const req = new TombstoneReq();
   const options = new TombstoneReq.Options();
   const identifier = new StreamIdentifier();
-  identifier.setStreamname(Buffer.from(streamName).toString("base64"));
+  identifier.setStreamname(Uint8Array.from(Buffer.from(streamName, "utf8")));
 
   options.setStreamIdentifier(identifier);
 


### PR DESCRIPTION
Based on performance tests in https://github.com/EventStore/test-client-node not encoding to base64 gives ~4x encoding speed.
This results in a small real world performance improvement.

Results from https://github.com/EventStore/test-client-node

### Raw encoding:

| encoding | events encoded             | speed improvement |
| -------- | -------------------------- | ----------------- |
| current  | 100000 in 5413ms (18474/s) | slowest           |
| this PR  | 100000 in 1362ms (73397/s) | ~4x faster        |

### Appending events

| client  | best     | average (without best and worst) |
| ------- | -------- | -------------------------------- |
| current | `2133/s` | `2088/s`                         |
| this PR | `2162/s` | `2091/s`                         |

