### PR TITLE
add `resolveLinkTos` to `readAll`

### DIFF
--- a/samples/reading-events.ts
+++ b/samples/reading-events.ts
@@ -187,7 +187,7 @@ describe("[sample] reading-events", () => {
       username: "admin",
       password: "changeit",
     };
-    
+
     const events = client.readAll({
       direction: FORWARDS,
       fromPosition: START,
@@ -223,7 +223,7 @@ describe("[sample] reading-events", () => {
     const events = client.readAll({
       direction: BACKWARDS,
       fromPosition: END,
-      // resolveLinkTos: true,
+      resolveLinkTos: true,
       maxCount: 10,
     });
     // endregion read-from-all-stream-resolving-link-Tos

--- a/src/streams/readAll.ts
+++ b/src/streams/readAll.ts
@@ -28,6 +28,13 @@ export interface ReadAllOptions extends BaseOptions {
    */
   fromPosition?: ReadPosition;
   /**
+   * The best way to explain link resolution is when using system projections. When reading the stream `$streams` (which
+   * contains all streams), each event is actually a link pointing to the first event of a stream. By enabling link
+   * resolution feature, the server will also return the event targeted by the link.
+   * @default false
+   */
+  resolveLinkTos?: boolean;
+  /**
    * Sets the read direction of the streamconnection.
    * @default FORWARDS
    */
@@ -53,6 +60,7 @@ Client.prototype.readAll = function (
   {
     maxCount = Number.MAX_SAFE_INTEGER,
     fromPosition = START,
+    resolveLinkTos = false,
     direction = FORWARDS,
     ...baseOptions
   }: ReadAllOptions = {},
@@ -85,8 +93,10 @@ Client.prototype.readAll = function (
       break;
     }
   }
-  options.setCount(maxCount.toString(10));
+
   options.setAll(allOptions);
+  options.setResolveLinks(resolveLinkTos);
+  options.setCount(maxCount.toString(10));
   options.setUuidOption(uuidOption);
   options.setNoFilter(new Empty());
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -46,6 +46,15 @@ export interface BinaryEventData<E extends BinaryEventType = BinaryEventType> {
 
 export type EventData = JSONEventData | BinaryEventData;
 
+export type LinkEvent = BinaryEventType<
+  "$>",
+  {
+    $causedBy?: string;
+    $correlationId?: string;
+    [key: string]: unknown;
+  }
+>;
+
 /**
  * Represents a previously written event.
  */
@@ -145,7 +154,7 @@ export interface ResolvedEvent<Event extends EventType = EventType> {
   /**
    * The link event if this ResolvedEvent is a link event.
    */
-  link?: EventTypeToRecordedEvent<Event>;
+  link?: EventTypeToRecordedEvent<LinkEvent>;
 
   /**
    * Commit position of the record.
@@ -165,7 +174,7 @@ export interface AllStreamResolvedEvent {
   /**
    * The link event if this ResolvedEvent is a link event.
    */
-  link?: AllStreamRecordedEvent;
+  link?: AllStreamBinaryRecordedEvent<LinkEvent>;
 
   /**
    * Commit position of the record.


### PR DESCRIPTION
- add option to resolve links in read all
- fix readAll grpc event mapping for links
- add LinkEvent type to event types
- add tests
- update sample

Fixes #186