### PR TITLE
Allow different casings of `nodePreference` in connection string

### DIFF
--- a/src/__test__/connection/__snapshots__/parseConnectionString.test.ts.snap
+++ b/src/__test__/connection/__snapshots__/parseConnectionString.test.ts.snap
@@ -14,7 +14,7 @@ exports[`connection string parser Should throw on invalid strings esdb://localho
 
 exports[`connection string parser Should throw on invalid strings esdb://localhost?throwOnAppendFailure=sometimes 1`] = `"Unexpected \\"sometimes\\" at position 38, expected true or false."`;
 
-exports[`connection string parser Should throw on invalid strings esdb://localhost?tlsVerifyCert=false&nodePreference=any 1`] = `"Unexpected \\"any\\" at position 52, expected follower or leader or random."`;
+exports[`connection string parser Should throw on invalid strings esdb://localhost?tlsVerifyCert=false&nodePreference=any 1`] = `"Unexpected \\"any\\" at position 52, expected leader or follower or read_only_replica or random."`;
 
 exports[`connection string parser Should throw on invalid strings esdb://localhost?tlsVerifyCert=false?nodePreference=follower 1`] = `"Unexpected \\"?\\" at position 36, expected &key=value."`;
 

--- a/src/__test__/connection/connectionStringMockups.ts
+++ b/src/__test__/connection/connectionStringMockups.ts
@@ -252,6 +252,19 @@ export const valid: Array<
     },
   ],
   [
+    "esdb+discover://host?nodePreference=Follower",
+    {
+      dnsDiscover: true,
+      nodePreference: "follower",
+      hosts: [
+        {
+          address: "host",
+          port: 2113,
+        },
+      ],
+    },
+  ],
+  [
     "esdb://host?tlsCAFile=/home/user/dev/cert.ca",
     {
       dnsDiscover: false,
@@ -385,6 +398,26 @@ export const valid: Array<
       discoveryInterval: 1000,
       gossipTimeout: 1,
       nodePreference: "leader",
+      tls: false,
+      tlsVerifyCert: false,
+      throwOnAppendFailure: false,
+      keepAliveInterval: 200,
+      hosts: [
+        {
+          address: "host",
+          port: 2113,
+        },
+      ],
+    },
+  ],
+  [
+    `esdb://host?MaxDiscoverAttempts=200&discovery-interval=1000&GOSSIP_TIMEOUT=1&node_preference=ReadOnlyReplica&TLS=false&TlsVerifyCert=false&THROWOnAppendFailure=false      &   KEEPALIVEinterval=200`,
+    {
+      dnsDiscover: false,
+      maxDiscoverAttempts: 200,
+      discoveryInterval: 1000,
+      gossipTimeout: 1,
+      nodePreference: "read_only_replica",
       tls: false,
       tlsVerifyCert: false,
       throwOnAppendFailure: false,


### PR DESCRIPTION
Update `parseConnectionString` to allow different casings of `nodePreference`
- ensure that every `nodePreference` is accounted for
- add some more parsing test cases