### PR TITLE
Prevent `appendToStream` from writing after the stream has closed

### DIFF
--- a/src/__test__/extra/write-after-end.test.ts
+++ b/src/__test__/extra/write-after-end.test.ts
@@ -1,0 +1,42 @@
+import { createTestNode, delay, jsonTestEvents } from "../utils";
+
+import { EventStoreDBClient } from "../..";
+import { UnavailableError } from "../../utils";
+
+describe("write after end", () => {
+  const node = createTestNode();
+  let client!: EventStoreDBClient;
+
+  beforeAll(async () => {
+    await node.up();
+    client = new EventStoreDBClient(
+      { endpoint: node.uri },
+      { rootCertificate: node.rootCertificate },
+      { username: "admin", password: "changeit" }
+    );
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  test("Should not write after end", async (done) => {
+    const STREAM_NAME = "json_stream_name";
+    await client.appendToStream(STREAM_NAME, jsonTestEvents());
+
+    client
+      .appendToStream(STREAM_NAME, jsonTestEvents(100_000))
+      .then((result) => {
+        expect(result).toBe("unreachable");
+      })
+      .catch((e) => {
+        expect(e).toBeInstanceOf(UnavailableError);
+      });
+
+    node.killNode(node.endpoints[0]);
+
+    // wait for any unhandled rejections
+    await delay(5_000);
+    done();
+  });
+});

--- a/src/streams/appendToStream.ts
+++ b/src/streams/appendToStream.ts
@@ -93,6 +93,8 @@ Client.prototype.appendToStream = async function (
           ...this.callArguments(baseOptions),
           (error, resp) => {
             if (error != null) {
+              // Make sure we don't write to the stream after it has closed.
+              sink.destroy();
               return reject(convertToCommandError(error));
             }
 


### PR DESCRIPTION
- Destroy the stream on error, to prevent further writes after the stream has closed.
- Add test to check for `write-after-end`
Before: 
![image](https://user-images.githubusercontent.com/11861797/132873263-4ff010c1-2a55-4c17-9745-1adf6e02fcab.png)
After:
![image](https://user-images.githubusercontent.com/11861797/132873301-88d6320c-fe02-4b64-bbd8-f55619077105.png)

fixes: #208 