### PR TITLE
Spilt up CI tests for faster CI

### DIFF
--- a/.github/workflows/test_20_10.yml
+++ b/.github/workflows/test_20_10.yml
@@ -1,4 +1,4 @@
-name: Test against 20.10
+name: "20.10"
 
 on:
   pull_request:
@@ -10,8 +10,8 @@ on:
 
 jobs:
   test:
-    name: Test against 20.10.4
-    uses: EventStore/EventStore-Client-NodeJS/.github/workflows/tests.yml@test-against-servers
+    name: Test
+    uses: EventStore/EventStore-Client-NodeJS/.github/workflows/tests.yml@split-up-ci-tests
     with:
       version: "20.10.4-buster-slim"
     secrets:

--- a/.github/workflows/test_21_10.yml
+++ b/.github/workflows/test_21_10.yml
@@ -1,4 +1,4 @@
-name: Test against 21.10
+name: "21.10"
 
 on:
   pull_request:
@@ -10,8 +10,8 @@ on:
 
 jobs:
   test:
-    name: Test against 21.10.0
-    uses: EventStore/EventStore-Client-NodeJS/.github/workflows/tests.yml@test-against-servers
+    name: Test
+    uses: EventStore/EventStore-Client-NodeJS/.github/workflows/tests.yml@split-up-ci-tests
     with:
       version: "21.10.0-buster-slim"
     secrets:

--- a/.github/workflows/test_21_6.yml
+++ b/.github/workflows/test_21_6.yml
@@ -1,4 +1,4 @@
-name: Test against 21.6
+name: "21.6"
 
 on:
   pull_request:
@@ -10,8 +10,8 @@ on:
 
 jobs:
   test:
-    name: Test against 21.6.0
-    uses: EventStore/EventStore-Client-NodeJS/.github/workflows/tests.yml@test-against-servers
+    name: Test
+    uses: EventStore/EventStore-Client-NodeJS/.github/workflows/tests.yml@split-up-ci-tests
     with:
       version: "21.6.0-buster-slim"
     secrets:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,30 @@ on:
 
 jobs:
   tests:
+    name: "${{ matrix.group.name }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          - name: samples
+            path: ./samples
+            tailscale: true
+
+          - name: connection
+            path: ./src/__test__/connection
+            tailscale: true
+
+          - name: extra
+            path: ./src/__test__/extra
+
+          - name: persistentSubscription
+            path: ./src/__test__/persistentSubscription
+
+          - name: projections
+            path: ./src/__test__/projections
+
+          - name: streams
+            path: ./src/__test__/streams
     env:
       # Github only passes secrets to the main repo, so we need to skip some things if they are unavailable
       SECRETS_AVAILABLE: ${{ secrets.eventstore_cloud_id != null }}
@@ -21,31 +45,24 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Connect to tailscale
-        if: ${{ env.SECRETS_AVAILABLE == 'true' }}
+        if: ${{ matrix.group.tailscale && env.SECRETS_AVAILABLE == 'true' }}
         run: |
           curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/eoan.gpg | sudo apt-key add -
           curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/eoan.list | sudo tee /etc/apt/sources.list.d/tailscale.list
           sudo apt-get update
           sudo apt-get install tailscale
           sudo tailscale up --authkey ${{ secrets.tailscale_auth }} --hostname "node-client-ci-${{ inputs.version }}-$(date +'%Y-%m-%dT%H:%M:%S')" --advertise-tags=tag:ci --accept-routes
-      # Install up to date version of node
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
           node-version: "12.x"
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install
         run: yarn
       - name: Run Tests
-        run: yarn test --ci --run-in-band --coverage --forceExit
+        run: yarn test ${{ matrix.group.path }} --ci --run-in-band --forceExit
         env:
           EVENTSTORE_IMAGE: github:${{ inputs.version }}
           EVENTSTORE_CLOUD_ID: ${{ secrets.eventstore_cloud_id }}
       - name: Disconnect from tailscale
-        if: ${{ always() && env.SECRETS_AVAILABLE == 'true' }}
+        if: ${{ always() && matrix.group.tailscale && env.SECRETS_AVAILABLE == 'true' }}
         run: sudo tailscale down


### PR DESCRIPTION
Breaks up tests into groups and runs them at the same time, reducing CI time from ~17mins to ~6mins.