### PR TITLE
Batch append

### DIFF
--- a/src/Client/ServerFeatures.ts
+++ b/src/Client/ServerFeatures.ts
@@ -60,9 +60,9 @@ export class ServerFeatures {
       : this.#supported.has(path);
 
     if (isSupported) {
-      debug.connection("%s %s is Supported", path, feature);
+      debug.connection("%s %s is Supported", path, feature ?? "");
     } else {
-      debug.connection("%s %s is not Supported", path, feature);
+      debug.connection("%s %s is not Supported", path, feature ?? "");
     }
 
     return isSupported;

--- a/src/__test__/connection/reconnect.test.ts
+++ b/src/__test__/connection/reconnect.test.ts
@@ -26,7 +26,9 @@ describe("reconnect", () => {
     // make successful append to connect to node
     const firstAppend = await client.appendToStream(
       "my_stream",
-      jsonEvent({ type: "first-append", data: { message: "test" } })
+      jsonEvent({ type: "first-append", data: { message: "test" } }),
+      // batch append triggers reconnect as soon as stream drops, so we need to force regular append
+      { credentials: { username: "admin", password: "changeit" } }
     );
     expect(firstAppend).toBeDefined();
 
@@ -38,7 +40,9 @@ describe("reconnect", () => {
     try {
       const secondAppend = await client.appendToStream(
         "my_stream",
-        jsonEvent({ type: "failed-append", data: { message: "test" } })
+        jsonEvent({ type: "failed-append", data: { message: "test" } }),
+        // batch append triggers reconnect as soon as stream drops, so we need to force regular append
+        { credentials: { username: "admin", password: "changeit" } }
       );
       expect(secondAppend).toBe("Unreachable");
     } catch (error) {
@@ -52,7 +56,9 @@ describe("reconnect", () => {
       try {
         const reconnectedAppend = await client.appendToStream(
           "my_stream",
-          jsonEvent({ type: "reconnect-append", data: { message: "test" } })
+          jsonEvent({ type: "reconnect-append", data: { message: "test" } }),
+          // batch append triggers reconnect as soon as stream drops, so we need to force regular append
+          { credentials: { username: "admin", password: "changeit" } }
         );
         expect(reconnectedAppend).toBeDefined();
         break;
@@ -79,7 +85,9 @@ describe("reconnect", () => {
     // make successful append to follower node
     const firstAppend = await client.appendToStream(
       "my_stream",
-      jsonEvent({ type: "first-append", data: { message: "test" } })
+      jsonEvent({ type: "first-append", data: { message: "test" } }),
+      // batch append triggers reconnect as soon as stream drops, so we need to force regular append
+      { credentials: { username: "admin", password: "changeit" } }
     );
     expect(firstAppend).toBeDefined();
 
@@ -89,7 +97,11 @@ describe("reconnect", () => {
       const secondAppend = await client.appendToStream(
         "my_stream",
         jsonEvent({ type: "failed-append", data: { message: "test" } }),
-        { requiresLeader: true }
+        {
+          requiresLeader: true,
+          // batch append triggers reconnect as soon as stream drops, so we need to force regular append
+          credentials: { username: "admin", password: "changeit" },
+        }
       );
       expect(secondAppend).toBe("Unreachable");
     } catch (error) {
@@ -104,7 +116,11 @@ describe("reconnect", () => {
     const reconnectedAppend = await client.appendToStream(
       "my_stream",
       jsonEvent({ type: "reconnect-append", data: { message: "test" } }),
-      { requiresLeader: true }
+      {
+        requiresLeader: true,
+        // batch append triggers reconnect as soon as stream drops, so we need to force regular append
+        credentials: { username: "admin", password: "changeit" },
+      }
     );
     expect(reconnectedAppend).toBeDefined();
 
@@ -129,7 +145,9 @@ describe("reconnect", () => {
     // make successful append of 2000 events to node
     const firstAppend = await client.appendToStream(
       "my_stream",
-      jsonTestEvents(2000)
+      jsonTestEvents(2000),
+      // batch append triggers reconnect as soon as stream drops, so we need to force regular append
+      { credentials: { username: "admin", password: "changeit" } }
     );
     expect(firstAppend).toBeDefined();
 
@@ -159,7 +177,8 @@ describe("reconnect", () => {
       try {
         const reconnectedAppend = await client.appendToStream(
           "my_stream",
-          jsonEvent({ type: "reconnect-append", data: { message: "test" } })
+          jsonEvent({ type: "reconnect-append", data: { message: "test" } }), // batch append triggers reconnect as soon as stream drops, so we need to force regular append
+          { credentials: { username: "admin", password: "changeit" } }
         );
         expect(reconnectedAppend).toBeDefined();
         break;
@@ -186,7 +205,9 @@ describe("reconnect", () => {
     // make successful append to connect to node
     const firstAppend = await client.appendToStream(
       "my_stream",
-      jsonEvent({ type: "first-append", data: { message: "test" } })
+      jsonEvent({ type: "first-append", data: { message: "test" } }),
+      // batch append triggers reconnect as soon as stream drops, so we need to force regular append
+      { credentials: { username: "admin", password: "changeit" } }
     );
     expect(firstAppend).toBeDefined();
 
@@ -199,7 +220,9 @@ describe("reconnect", () => {
     try {
       const secondAppend = await client.appendToStream(
         "my_stream",
-        jsonEvent({ type: "failed-append", data: { message: "test" } })
+        jsonEvent({ type: "failed-append", data: { message: "test" } }),
+        // batch append triggers reconnect as soon as stream drops, so we need to force regular append
+        { credentials: { username: "admin", password: "changeit" } }
       );
       expect(secondAppend).toBe("Unreachable");
     } catch (error) {
@@ -210,7 +233,9 @@ describe("reconnect", () => {
     try {
       const secondAppend = await client.appendToStream(
         "my_stream",
-        jsonEvent({ type: "failed-append", data: { message: "test" } })
+        jsonEvent({ type: "failed-append", data: { message: "test" } }),
+        // batch append triggers reconnect as soon as stream drops, so we need to force regular append
+        { credentials: { username: "admin", password: "changeit" } }
       );
       expect(secondAppend).toBe("Unreachable");
     } catch (error) {
@@ -229,7 +254,9 @@ describe("reconnect", () => {
       try {
         const reconnectedAppend = await client.appendToStream(
           "my_stream",
-          jsonEvent({ type: "reconnect-append", data: { message: "test" } })
+          jsonEvent({ type: "reconnect-append", data: { message: "test" } }),
+          // batch append triggers reconnect as soon as stream drops, so we need to force regular append
+          { credentials: { username: "admin", password: "changeit" } }
         );
         expect(reconnectedAppend).toBeDefined();
         break;
@@ -257,7 +284,9 @@ describe("reconnect", () => {
     // make successful append to connect to node
     const firstAppend = await client.appendToStream(
       "my_stream",
-      jsonEvent({ type: "first-append", data: { message: "test" } })
+      jsonEvent({ type: "first-append", data: { message: "test" } }),
+      // batch append triggers reconnect as soon as stream drops, so we need to force regular append
+      { credentials: { username: "admin", password: "changeit" } }
     );
     expect(firstAppend).toBeDefined();
 

--- a/src/__test__/extra/http2-assertion-failure.test.ts
+++ b/src/__test__/extra/http2-assertion-failure.test.ts
@@ -14,11 +14,7 @@ describe("http2 assertion failure", () => {
   beforeAll(async () => {
     await node.up();
 
-    client = new EventStoreDBClient(
-      { endpoint: node.uri },
-      { insecure: true },
-      { username: "admin", password: "changeit" }
-    );
+    client = new EventStoreDBClient({ endpoint: node.uri }, { insecure: true });
   });
 
   afterAll(async () => {
@@ -33,6 +29,8 @@ describe("http2 assertion failure", () => {
 
       const appendRes = await client.appendToStream(stream, priorEvents, {
         expectedRevision: NO_STREAM,
+        // we want to test classic append
+        credentials: { username: "admin", password: "changeit" },
       });
 
       const received: ResolvedEvent[] = [];
@@ -52,6 +50,8 @@ describe("http2 assertion failure", () => {
       while (received.length < 3) await delay(10);
       await client.appendToStream(stream, postEvents, {
         expectedRevision: appendRes.nextExpectedRevision,
+        // we want to test classic append
+        credentials: { username: "admin", password: "changeit" },
       });
 
       while (received.length < 10) await delay(10);

--- a/src/__test__/extra/write-after-end.test.ts
+++ b/src/__test__/extra/write-after-end.test.ts
@@ -1,39 +1,96 @@
-import { createTestNode, delay, jsonTestEvents } from "@test-utils";
+/** @jest-environment ./src/__test__/utils/enableVersionCheck.ts */
+
+import {
+  createTestNode,
+  delay,
+  jsonTestEvents,
+  matchServerVersion,
+  optionalTest,
+} from "@test-utils";
 import { EventStoreDBClient, UnavailableError } from "@eventstore/db-client";
 
+// These tests can take time.
+jest.setTimeout(120_000);
+
 describe("write after end", () => {
-  const node = createTestNode();
-  let client!: EventStoreDBClient;
-
-  beforeAll(async () => {
-    await node.up();
-    client = new EventStoreDBClient(
-      { endpoint: node.uri },
-      { rootCertificate: node.rootCertificate },
-      { username: "admin", password: "changeit" }
-    );
-  });
-
-  afterAll(async () => {
-    await node.down();
-  });
-
   test("Should not write after end", async () => {
-    const STREAM_NAME = "json_stream_name";
-    await client.appendToStream(STREAM_NAME, jsonTestEvents());
+    const node = createTestNode();
+    await node.up();
 
-    client
-      .appendToStream(STREAM_NAME, jsonTestEvents(100_000))
-      .then((result) => {
-        expect(result).toBe("unreachable");
-      })
-      .catch((e) => {
-        expect(e).toBeInstanceOf(UnavailableError);
+    const client = new EventStoreDBClient(
+      { endpoint: node.uri },
+      { rootCertificate: node.rootCertificate }
+    );
+
+    const STREAM_NAME = "json_stream_name";
+    await client.appendToStream(STREAM_NAME, jsonTestEvents(), {
+      // credentials enforces classic append
+      credentials: { username: "admin", password: "changeit" },
+    });
+
+    const writeUntilError = () =>
+      new Promise((resolve) => {
+        const writeOnLoop = (): Promise<never> =>
+          client
+            .appendToStream(STREAM_NAME, jsonTestEvents(30_000), {
+              // credentials enforces classic append
+              credentials: { username: "admin", password: "changeit" },
+            })
+            .then(writeOnLoop);
+
+        writeOnLoop().catch((e) => {
+          resolve(e);
+        });
       });
 
-    node.killNode(node.endpoints[0]);
+    const errorPromise = writeUntilError();
+
+    await node.killNode(node.endpoints[0]);
+
+    const error = await errorPromise;
+    expect(error).toBeInstanceOf(UnavailableError);
 
     // wait for any unhandled rejections
     await delay(5_000);
+
+    await node.down();
   });
+
+  optionalTest(matchServerVersion`>=21.10`)(
+    "Should not write after end (batch append)",
+    async () => {
+      const node = createTestNode();
+      await node.up();
+
+      const client = new EventStoreDBClient(
+        { endpoint: node.uri },
+        { rootCertificate: node.rootCertificate }
+      );
+
+      const STREAM_NAME = "json_stream_name";
+      await client.appendToStream(STREAM_NAME, jsonTestEvents());
+
+      const writeUntilError = () =>
+        new Promise((resolve) => {
+          const writeOnLoop = (): Promise<never> =>
+            client
+              .appendToStream(STREAM_NAME, jsonTestEvents(30_000))
+              .then(writeOnLoop);
+
+          writeOnLoop().catch((e) => {
+            resolve(e);
+          });
+        });
+
+      const errorPromise = writeUntilError();
+
+      await node.killNode(node.endpoints[0]);
+
+      const error = await errorPromise;
+      expect(error).toBeInstanceOf(UnavailableError);
+
+      // wait for any unhandled rejections
+      await delay(5_000);
+    }
+  );
 });

--- a/src/__test__/streams/appendToStream-batch-append.test.ts
+++ b/src/__test__/streams/appendToStream-batch-append.test.ts
@@ -1,0 +1,141 @@
+/** @jest-environment ./src/__test__/utils/enableVersionCheck.ts */
+import type { Duplex } from "stream";
+
+import {
+  createTestNode,
+  jsonTestEvents,
+  matchServerVersion,
+  optionalDescribe,
+} from "@test-utils";
+import { EventStoreDBClient } from "@eventstore/db-client";
+import { StreamsClient } from "../../../generated/streams_grpc_pb";
+
+describe("appendToStream - batch append", () => {
+  const supported = matchServerVersion`>=21.10`;
+
+  const node = createTestNode();
+  let client!: EventStoreDBClient;
+  let batchSpy!: jest.SpiedFunction<EventStoreDBClient["GRPCStreamCreator"]>;
+  let executeSpy!: jest.SpiedFunction<EventStoreDBClient["execute"]>;
+
+  beforeAll(async () => {
+    await node.up();
+    client = new EventStoreDBClient(
+      { endpoint: node.uri },
+      { rootCertificate: node.rootCertificate }
+    );
+    batchSpy = spyOn.call(client, "GRPCStreamCreator");
+    executeSpy = spyOn.call(client, "execute");
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  afterEach(() => {
+    batchSpy.mockClear();
+    executeSpy.mockClear();
+  });
+
+  optionalDescribe(!supported)("Not Supported (<21.10)", () => {
+    test("Uses normal append", async () => {
+      const STREAM_NAME = "uses_normal_append";
+
+      const result = await client.appendToStream(STREAM_NAME, jsonTestEvents());
+      expect(result).toBeDefined();
+      expect(result.nextExpectedRevision).toBeGreaterThanOrEqual(0);
+
+      expect(batchSpy).not.toHaveBeenCalled();
+      expect(executeSpy).toHaveBeenCalledWith(
+        StreamsClient,
+        "appendToStream",
+        expect.any(Function)
+      );
+    });
+  });
+
+  optionalDescribe(supported)("Supported (>=21.10)", () => {
+    test("Uses batch append", async () => {
+      const STREAM_NAME = "uses_batch_append";
+
+      const result = await client.appendToStream(STREAM_NAME, jsonTestEvents());
+      expect(result).toBeDefined();
+      expect(result.nextExpectedRevision).toBeGreaterThanOrEqual(0);
+
+      expect(batchSpy).toHaveBeenCalledWith(
+        StreamsClient,
+        "appendToStream",
+        expect.any(Function),
+        expect.any(WeakMap)
+      );
+    });
+
+    test("Uses normal append if a credentials are passed", async () => {
+      const STREAM_NAME = "uses_normal_append_if_creds_are_passed";
+
+      const result = await client.appendToStream(
+        STREAM_NAME,
+        jsonTestEvents(),
+        { credentials: { username: "admin", password: "changeit" } }
+      );
+      expect(result).toBeDefined();
+      expect(result.nextExpectedRevision).toBeGreaterThanOrEqual(0);
+
+      expect(batchSpy).not.toHaveBeenCalled();
+      expect(executeSpy).toHaveBeenCalledWith(
+        StreamsClient,
+        "appendToStream",
+        expect.any(Function)
+      );
+    });
+
+    test("Batches events into batches", async () => {
+      await client.appendToStream("open_stream", jsonTestEvents());
+
+      const stream = await extractBatchStream.call(
+        client,
+        ...batchSpy.mock.calls[0]
+      );
+
+      const writeSpy = jest.spyOn(stream, "write");
+
+      const result = await client.appendToStream(
+        "small_batch_size",
+        jsonTestEvents(5_000),
+        { batchAppendSize: 1024 }
+      );
+
+      expect(result).toBeDefined();
+      expect(result.nextExpectedRevision).toBeGreaterThanOrEqual(0);
+
+      expect(writeSpy).toHaveBeenCalledTimes(
+        // (test event is 128 bytes)
+        // (size * event count) / requested batch size
+        (128 * 5_000) / 1024
+      );
+    });
+  });
+});
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+function spyOn(this: EventStoreDBClient, method: string) {
+  return jest.spyOn(this, method as never) as any;
+}
+
+function extractBatchStream(
+  this: EventStoreDBClient,
+  clientConstructor: any,
+  name: any,
+  _: any,
+  cache: any
+): Promise<Duplex> {
+  return this.GRPCStreamCreator(
+    clientConstructor,
+    name,
+    () => {
+      throw "Creator shouldn't be called as it will take the client from the cache";
+    },
+    cache
+  )();
+}

--- a/src/__test__/streams/appendToStream-errors.test.ts
+++ b/src/__test__/streams/appendToStream-errors.test.ts
@@ -1,0 +1,178 @@
+/** @jest-environment ./src/__test__/utils/enableVersionCheck.ts */
+
+import {
+  createTestNode,
+  jsonTestEvents,
+  matchServerVersion,
+  optionalTest,
+} from "@test-utils";
+
+import {
+  EventStoreDBClient,
+  WrongExpectedVersionError,
+  NO_STREAM,
+  StreamDeletedError,
+  MaxAppendSizeExceededError,
+  AccessDeniedError,
+  TimeoutError,
+} from "@eventstore/db-client";
+
+describe("appendToStream - errors", () => {
+  const node = createTestNode();
+  const timeoutNode = createTestNode()
+    .setOption("EVENTSTORE_COMMIT_TIMEOUT_MS", 1)
+    .setOption("EVENTSTORE_PREPARE_TIMEOUT_MS", 1);
+  let client!: EventStoreDBClient;
+  let timeoutClient!: EventStoreDBClient;
+
+  beforeAll(async () => {
+    await node.up();
+    await timeoutNode.up();
+    client = new EventStoreDBClient(
+      { endpoint: node.uri, throwOnAppendFailure: true },
+      { rootCertificate: node.rootCertificate }
+    );
+    timeoutClient = new EventStoreDBClient(
+      { endpoint: timeoutNode.uri, throwOnAppendFailure: true },
+      { rootCertificate: timeoutNode.rootCertificate }
+    );
+  });
+
+  afterAll(async () => {
+    await node.down();
+    await timeoutNode.down();
+  });
+
+  describe.each([
+    ["Batch append (>21.10)", matchServerVersion`>=21.10`, undefined],
+    ["Normal Append", true, { username: "admin", password: "changeit" }],
+  ])("%s", (prefix, supported, credentials) => {
+    optionalTest(supported)("WrongExpectedVersion", async () => {
+      const STREAM_NAME = `${prefix}_no_stream_here_but_there_is`;
+
+      await client.appendToStream(STREAM_NAME, jsonTestEvents(), {
+        credentials,
+      });
+
+      try {
+        const result = await client.appendToStream(
+          STREAM_NAME,
+          jsonTestEvents(),
+          {
+            expectedRevision: "no_stream",
+            credentials,
+          }
+        );
+
+        expect(result).toBe("unreachable");
+      } catch (error) {
+        expect(error).toBeInstanceOf(WrongExpectedVersionError);
+
+        if (error instanceof WrongExpectedVersionError) {
+          expect(error.streamName).toBe(STREAM_NAME);
+          expect(error.expectedVersion).toBe(NO_STREAM);
+          expect(error.actualVersion).toBeGreaterThanOrEqual(1);
+        }
+      }
+    });
+
+    optionalTest(supported)("StreamDeleted", async () => {
+      const STREAM_NAME = `${prefix}_i_will_be_deleted`;
+
+      await client.appendToStream(STREAM_NAME, jsonTestEvents(), {
+        credentials,
+      });
+      await client.tombstoneStream(STREAM_NAME, { credentials });
+
+      try {
+        const result = await client.appendToStream(
+          STREAM_NAME,
+          jsonTestEvents(),
+          {
+            credentials,
+          }
+        );
+
+        expect(result).toBe("unreachable");
+      } catch (error) {
+        expect(error).toBeInstanceOf(StreamDeletedError);
+
+        if (error instanceof StreamDeletedError) {
+          expect(error.streamName).toBe(STREAM_NAME);
+        }
+      }
+    });
+
+    optionalTest(supported)("AccessDenied", async () => {
+      const STREAM_NAME = `${prefix}_no_entry`;
+
+      await client.appendToStream(STREAM_NAME, jsonTestEvents(), {
+        credentials,
+      });
+
+      await client.setStreamMetadata(STREAM_NAME, {
+        acl: {
+          writeRoles: ["some_user"],
+        },
+      });
+
+      try {
+        const result = await client.appendToStream(
+          STREAM_NAME,
+          jsonTestEvents(),
+          {
+            credentials: credentials
+              ? { username: "AzureDiamond", password: "hunter2" }
+              : undefined,
+          }
+        );
+
+        expect(result).toBe("unreachable");
+      } catch (error) {
+        expect(error).toBeInstanceOf(AccessDeniedError);
+      }
+    });
+
+    optionalTest(supported)("Timeout", async () => {
+      const STREAM_NAME = `${prefix}_timeout`;
+
+      try {
+        for (let i = 0; i < 10; i++) {
+          await timeoutClient.appendToStream(
+            STREAM_NAME,
+            jsonTestEvents(30_000),
+            {
+              credentials,
+            }
+          );
+        }
+
+        expect("this point").toBe("unreachable");
+      } catch (error) {
+        expect(error).toBeInstanceOf(TimeoutError);
+      }
+    });
+
+    optionalTest(supported)("MaximumAppendSizeExceeded", async () => {
+      const STREAM_NAME = `${prefix}_i_am_too_many`;
+
+      try {
+        const result = await client.appendToStream(
+          STREAM_NAME,
+          jsonTestEvents(40_000),
+          {
+            credentials,
+          }
+        );
+
+        expect(result).toBe("unreachable");
+      } catch (error) {
+        expect(error).toBeInstanceOf(MaxAppendSizeExceededError);
+
+        if (error instanceof MaxAppendSizeExceededError) {
+          expect(typeof error.maxAppendSize).toBe("number");
+        }
+      }
+    });
+  });
+});

--- a/src/streams/appendToStream/append.ts
+++ b/src/streams/appendToStream/append.ts
@@ -1,55 +1,24 @@
-import { AppendReq } from "../../generated/streams_pb";
-import { StreamIdentifier, Empty } from "../../generated/shared_pb";
-import { StreamsClient } from "../../generated/streams_grpc_pb";
+import { AppendReq } from "../../../generated/streams_pb";
+import { StreamIdentifier, Empty } from "../../../generated/shared_pb";
+import { StreamsClient } from "../../../generated/streams_grpc_pb";
 
-import { Client } from "../Client";
-import { ANY } from "../constants";
-import {
-  BaseOptions,
-  AppendResult,
-  AppendExpectedRevision,
-  EventData,
-} from "../types";
+import { Client } from "../../Client";
+import { AppendResult, AppendExpectedRevision, EventData } from "../../types";
 
 import {
   convertToCommandError,
   createUUID,
   debug,
   WrongExpectedVersionError,
-} from "../utils";
+} from "../../utils";
+import { InternalAppendToStreamOptions } from ".";
 
-export interface AppendToStreamOptions extends BaseOptions {
-  /**
-   * Asks the server to check the stream is at specific revision before writing events.
-   * @default ANY
-   */
-  expectedRevision?: AppendExpectedRevision;
-}
-
-declare module "../Client" {
-  interface Client {
-    /**
-     * Appends events to a given stream.
-     * @param streamName A stream name.
-     * @param events Events or event to write.
-     * @param options Writing options.
-     */
-    appendToStream(
-      streamName: string,
-      events: EventData | EventData[],
-      options?: AppendToStreamOptions
-    ): Promise<AppendResult>;
-  }
-}
-
-Client.prototype.appendToStream = async function (
+export const append = async function (
   this: Client,
   streamName: string,
-  event: EventData | EventData[],
-  { expectedRevision = ANY, ...baseOptions }: AppendToStreamOptions = {}
+  events: EventData[],
+  { expectedRevision, ...baseOptions }: InternalAppendToStreamOptions
 ): Promise<AppendResult> {
-  const events = Array.isArray(event) ? event : [event];
-
   const header = new AppendReq();
   const options = new AppendReq.Options();
   const identifier = new StreamIdentifier();

--- a/src/streams/appendToStream/batchAppend.ts
+++ b/src/streams/appendToStream/batchAppend.ts
@@ -1,0 +1,212 @@
+import { v4 as uuid } from "uuid";
+
+import { StreamsClient } from "../../../generated/streams_grpc_pb";
+import { BatchAppendReq, BatchAppendResp } from "../../../generated/streams_pb";
+import { Empty, StreamIdentifier, UUID } from "../../../generated/shared_pb";
+
+import { Client } from "../../Client";
+import { AppendResult, EventData } from "../../types";
+import {
+  debug,
+  createUUID,
+  parseUUID,
+  convertToCommandError,
+} from "../../utils";
+
+import {
+  unpackToCommandError,
+  unpackWrongExpectedVersion,
+} from "./unpackError";
+import { InternalAppendToStreamOptions } from ".";
+
+const streamCache = new WeakMap<
+  StreamsClient,
+  ReturnType<StreamsClient["batchAppend"]>
+>();
+
+export const batchAppend = async function (
+  this: Client,
+  streamName: string,
+  events: EventData[],
+  {
+    expectedRevision,
+    batchAppendSize,
+    ...baseOptions
+  }: InternalAppendToStreamOptions
+): Promise<AppendResult> {
+  const correlationId = uuid();
+
+  const stream = await this.GRPCStreamCreator(
+    StreamsClient,
+    "appendToStream",
+    (client) =>
+      client.batchAppend(
+        ...this.callArguments(baseOptions, {
+          deadline: Infinity,
+        })
+      ),
+    streamCache
+  )();
+
+  return new Promise((resolve, reject) => {
+    const detach = () => {
+      stream.off("data", handleData).off("error", handleError);
+    };
+
+    const handleData = (resp: BatchAppendResp) => {
+      const resultingId = parseUUID(resp.getCorrelationId());
+      if (correlationId !== resultingId) return;
+
+      detach();
+
+      if (resp.hasError()) {
+        const grpcError = resp.getError()!;
+
+        if (!this.throwOnAppendFailure) {
+          const wrongExpectedVersion = unpackWrongExpectedVersion(grpcError);
+
+          if (wrongExpectedVersion) {
+            const nextExpectedRevision =
+              wrongExpectedVersion.hasCurrentStreamRevision()
+                ? BigInt(wrongExpectedVersion.hasCurrentStreamRevision())
+                : BigInt(-1);
+
+            return resolve({
+              success: false,
+              nextExpectedRevision,
+              position: undefined,
+            });
+          }
+        }
+
+        return reject(unpackToCommandError(grpcError, streamName));
+      }
+
+      const success = resp.getSuccess()!;
+      const nextExpectedRevision = BigInt(success.getCurrentRevision());
+      const grpcPosition = success.getPosition();
+
+      const position = grpcPosition
+        ? {
+            commit: BigInt(grpcPosition.getCommitPosition()),
+            prepare: BigInt(grpcPosition.getPreparePosition()),
+          }
+        : undefined;
+
+      return resolve({
+        success: true,
+        nextExpectedRevision,
+        position,
+      });
+    };
+
+    const handleError = (error: Error) => {
+      detach();
+      return reject(convertToCommandError(error));
+    };
+
+    stream.on("data", handleData).on("error", handleError);
+
+    const correlationUUID = createUUID(correlationId);
+    const options = new BatchAppendReq.Options();
+    const identifier = new StreamIdentifier();
+    identifier.setStreamName(Uint8Array.from(Buffer.from(streamName, "utf8")));
+    options.setStreamIdentifier(identifier);
+    switch (expectedRevision) {
+      case "any": {
+        options.setAny(new Empty());
+        break;
+      }
+      case "no_stream": {
+        options.setNoStream(new Empty());
+        break;
+      }
+      case "stream_exists": {
+        options.setStreamExists(new Empty());
+        break;
+      }
+      default: {
+        options.setStreamPosition(expectedRevision.toString(10));
+        break;
+      }
+    }
+
+    for (const batch of eventBatcher(
+      events,
+      correlationUUID,
+      options,
+      batchAppendSize
+    )) {
+      debug.command_grpc("batchAppend: %g", batch);
+      stream.write(batch);
+    }
+  });
+};
+
+function* eventBatcher(
+  events: EventData[],
+  correlationId: UUID,
+  options: BatchAppendReq.Options,
+  maxBatchSize: number
+) {
+  const createAppendRequest = (addOptions = false) => {
+    const appendRequest = new BatchAppendReq();
+    if (addOptions) {
+      appendRequest.setOptions(options);
+    }
+    appendRequest.setCorrelationId(correlationId);
+    appendRequest.setIsFinal(false);
+    return appendRequest;
+  };
+
+  let appendRequest = createAppendRequest(true);
+  let batchSize = 0;
+
+  for (const event of events) {
+    const message = new BatchAppendReq.ProposedMessage();
+
+    const id = new UUID();
+    id.setString(event.id);
+    message.setId(id);
+    message.getMetadataMap().set("type", event.type);
+    message.getMetadataMap().set("content-type", event.contentType);
+
+    switch (event.contentType) {
+      case "application/json": {
+        const data = JSON.stringify(event.data);
+        message.setData(Buffer.from(data, "utf8").toString("base64"));
+        break;
+      }
+      case "application/octet-stream": {
+        message.setData(event.data);
+        break;
+      }
+    }
+
+    if (event.metadata) {
+      if (event.metadata.constructor === Uint8Array) {
+        message.setCustomMetadata(event.metadata);
+      } else {
+        const metadata = JSON.stringify(event.metadata);
+        message.setCustomMetadata(
+          Buffer.from(metadata, "utf8").toString("base64")
+        );
+      }
+    }
+
+    const messageSize = message.serializeBinary().length;
+
+    if (batchSize + messageSize >= maxBatchSize) {
+      yield appendRequest;
+      appendRequest = createAppendRequest(false);
+      batchSize = 0;
+    }
+
+    batchSize += messageSize;
+    appendRequest.addProposedMessages(message);
+  }
+
+  appendRequest.setIsFinal(true);
+
+  yield appendRequest;
+}

--- a/src/streams/appendToStream/index.ts
+++ b/src/streams/appendToStream/index.ts
@@ -1,0 +1,77 @@
+import { StreamsService } from "../../../generated/streams_grpc_pb";
+
+import { Client } from "../../Client";
+import { ANY } from "../../constants";
+import {
+  BaseOptions,
+  AppendResult,
+  AppendExpectedRevision,
+  EventData,
+} from "../../types";
+
+import { append } from "./append";
+import { batchAppend } from "./batchAppend";
+
+export interface AppendToStreamOptions extends BaseOptions {
+  /**
+   * Asks the server to check the stream is at specific revision before writing events.
+   * @default ANY
+   */
+  expectedRevision?: AppendExpectedRevision;
+  /**
+   * The batch size, in bytes.
+   * @default 3 * 1024 * 1024
+   */
+  batchAppendSize?: number;
+}
+
+export type InternalAppendToStreamOptions = Required<
+  Omit<AppendToStreamOptions, keyof BaseOptions>
+> &
+  BaseOptions;
+
+declare module "../../Client" {
+  interface Client {
+    /**
+     * Appends events to a given stream.
+     * @param streamName A stream name.
+     * @param events Events or event to write.
+     * @param options Writing options.
+     */
+    appendToStream(
+      streamName: string,
+      events: EventData | EventData[],
+      options?: AppendToStreamOptions
+    ): Promise<AppendResult>;
+  }
+}
+
+Client.prototype.appendToStream = async function (
+  this: Client,
+  streamName: string,
+  event: EventData | EventData[],
+  {
+    expectedRevision = ANY,
+    batchAppendSize = 3 * 1024 * 1024,
+    ...baseOptions
+  }: AppendToStreamOptions = {}
+): Promise<AppendResult> {
+  const events = Array.isArray(event) ? event : [event];
+
+  if (
+    !baseOptions.credentials &&
+    (await this.supports(StreamsService.batchAppend))
+  ) {
+    return batchAppend.call(this, streamName, events, {
+      expectedRevision,
+      batchAppendSize,
+      ...baseOptions,
+    });
+  }
+
+  return append.call(this, streamName, events, {
+    expectedRevision,
+    batchAppendSize,
+    ...baseOptions,
+  });
+};

--- a/src/streams/appendToStream/unpackError.ts
+++ b/src/streams/appendToStream/unpackError.ts
@@ -1,0 +1,81 @@
+import { Status } from "../../../generated/status_pb";
+import {
+  AccessDenied,
+  MaximumAppendSizeExceeded,
+  StreamDeleted,
+  Timeout,
+  Unknown,
+  WrongExpectedVersion,
+} from "../../../generated/shared_pb";
+import {
+  AccessDeniedError,
+  MaxAppendSizeExceededError,
+  StreamDeletedError,
+  TimeoutError,
+  UnknownError,
+  WrongExpectedVersionError,
+} from "../..";
+
+export const unpackWrongExpectedVersion = (grpcError: Status) =>
+  grpcError
+    .getDetails()
+    ?.unpack(
+      WrongExpectedVersion.deserializeBinary,
+      "event_store.client.WrongExpectedVersion"
+    ) ?? null;
+
+export const unpackToCommandError = (grpcError: Status, streamName: string) => {
+  const details = grpcError.getDetails()!;
+  const typename = details.getTypeName();
+
+  switch (typename) {
+    case "event_store.client.WrongExpectedVersion": {
+      const unpacked = details.unpack(
+        WrongExpectedVersion.deserializeBinary,
+        typename
+      );
+      if (!unpacked) break;
+      return WrongExpectedVersionError.fromWrongExpectedVersion(
+        unpacked,
+        streamName
+      );
+    }
+    case "event_store.client.StreamDeleted": {
+      const unpacked = details.unpack(
+        StreamDeleted.deserializeBinary,
+        typename
+      );
+      if (!unpacked) break;
+      return StreamDeletedError.fromStreamName(streamName);
+    }
+    case "event_store.client.AccessDenied": {
+      const unpacked = details.unpack(AccessDenied.deserializeBinary, typename);
+      if (!unpacked) break;
+      return new AccessDeniedError();
+    }
+    case "event_store.client.Timeout": {
+      const unpacked = details.unpack(Timeout.deserializeBinary, typename);
+      if (!unpacked) break;
+      return new TimeoutError();
+    }
+    case "event_store.client.Unknown": {
+      const unpacked = details.unpack(Unknown.deserializeBinary, typename);
+      if (!unpacked) break;
+      return new UnknownError();
+    }
+    case "event_store.client.MaximumAppendSizeExceeded": {
+      const unpacked = details.unpack(
+        MaximumAppendSizeExceeded.deserializeBinary,
+        typename
+      );
+      if (!unpacked) break;
+      return MaxAppendSizeExceededError.fromMaxAppendSize(
+        unpacked.getMaxappendsize()
+      );
+    }
+  }
+  return new UnknownError(
+    undefined,
+    `Could not recognize ${grpcError.getMessage()}`
+  );
+};


### PR DESCRIPTION
 - Add batch append
 - decide if should batch append or append based off of support and credentials
 - update tests
  - http2-assertion-failure should use classic append
  - write-after-end should test both append styles (also fixes:  #215)
 - reconnect tests should use classic append