### PR TITLE
fix CI workflows

### DIFF
--- a/.github/workflows/test_20_10.yml
+++ b/.github/workflows/test_20_10.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Test
-    uses: EventStore/EventStore-Client-NodeJS/.github/workflows/tests.yml@split-up-ci-tests
+    uses: EventStore/EventStore-Client-NodeJS/.github/workflows/tests.yml@master
     with:
       version: "20.10.4-buster-slim"
     secrets:

--- a/.github/workflows/test_21_10.yml
+++ b/.github/workflows/test_21_10.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Test
-    uses: EventStore/EventStore-Client-NodeJS/.github/workflows/tests.yml@split-up-ci-tests
+    uses: EventStore/EventStore-Client-NodeJS/.github/workflows/tests.yml@master
     with:
       version: "21.10.0-buster-slim"
     secrets:

--- a/.github/workflows/test_21_6.yml
+++ b/.github/workflows/test_21_6.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Test
-    uses: EventStore/EventStore-Client-NodeJS/.github/workflows/tests.yml@split-up-ci-tests
+    uses: EventStore/EventStore-Client-NodeJS/.github/workflows/tests.yml@master
     with:
       version: "21.6.0-buster-slim"
     secrets:


### PR DESCRIPTION
Prevents CI from breaking when `split-up-ci-tests` branch is deleted