### PR TITLE
Improve write after end mitigation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     "no-constant-condition": ["error", { checkLoops: false }],
     // prettier decides
     "no-unexpected-multiline": ["off"],
+    "no-async-promise-executor": ["off"],
     "@typescript-eslint/no-empty-interface": [
       "error",
       {

--- a/src/streams/appendToStream/batchAppend.ts
+++ b/src/streams/appendToStream/batchAppend.ts
@@ -11,6 +11,7 @@ import {
   createUUID,
   parseUUID,
   convertToCommandError,
+  backpressuredWrite,
 } from "../../utils";
 
 import {
@@ -113,7 +114,7 @@ export const batchAppend = async function (
     streamCache
   )();
 
-  return new Promise((...batchPromise) => {
+  return new Promise(async (...batchPromise) => {
     promiseBank.set(correlationId, batchPromise);
 
     const correlationUUID = createUUID(correlationId);
@@ -147,7 +148,7 @@ export const batchAppend = async function (
       batchAppendSize
     )) {
       debug.command_grpc("batchAppend: %g", batch);
-      stream.write(batch);
+      await backpressuredWrite(stream, batch);
     }
   });
 };

--- a/src/utils/backpressuredWrite.ts
+++ b/src/utils/backpressuredWrite.ts
@@ -1,0 +1,11 @@
+import type { ClientWritableStream } from "@grpc/grpc-js";
+
+export const backpressuredWrite = <T>(
+  stream: ClientWritableStream<T>,
+  data: T
+) =>
+  new Promise<void>((resolve) => {
+    const written = stream.write(data);
+    if (written) return resolve();
+    stream.once("drain", resolve);
+  });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./backpressuredWrite";
 export * from "./CommandError";
 export * from "./convertGrpcEvent";
 export * from "./convertGrpcProjectionDetails";


### PR DESCRIPTION
- remove prior mitigation
- add backpressured write util to respect backpressure when pushing to streams
- apply backpressued write to append, ack, nack, persistentSubscription
- catch errors on sink in standard append

#247 