### PR TITLE
Improve tlsVerifyCert not supported message

### DIFF
--- a/src/Client/parseConnectionString.ts
+++ b/src/Client/parseConnectionString.ts
@@ -44,8 +44,6 @@ const caseMap = <T extends string>(options: { [K in T]: K }) => {
   return MapTo;
 };
 
-const notCurrentlySupported = ["tlsVerifyCert"];
-
 const mapToNodePreference = caseMap<NodePreference>({
   [LEADER]: LEADER,
   [FOLLOWER]: FOLLOWER,
@@ -259,9 +257,15 @@ const verifyKeyValuePair = (
   const key = mapToQueryOption(rawKey) ?? rawKey;
   const value = rawValue.trim();
 
-  if (notCurrentlySupported.includes(key)) {
-    debug.connection(
-      `${key} is not currently supported by this client, and will have no effect.`
+  if (key === "tlsVerifyCert" && value === "false") {
+    console.warn(
+      [
+        `"tlsVerifyCert" is not currently supported by this client, and will have no effect.`,
+        `Consider either:`,
+        `    Passing "tlsCAFile" in the connection string.`,
+        `    Setting NODE_EXTRA_CA_CERTS https://nodejs.org/api/cli.html#cli_node_extra_ca_certs_file`,
+        errorLocationString(connectionString, [from + `&`.length, to]),
+      ].join("\n")
     );
   }
 

--- a/src/__test__/connection/__snapshots__/parseConnectionString.test.ts.snap
+++ b/src/__test__/connection/__snapshots__/parseConnectionString.test.ts.snap
@@ -2,43 +2,43 @@
 
 exports[`connection string parser Should throw on invalid strings esbd+discovery://localhost 1`] = `"Unexpected \\"esbd+discovery://\\" at position 0, expected esdb:// or esdb+discover://."`;
 
-exports[`connection string parser Should throw on invalid strings esdb://host1,host2:200:300?tlsVerifyCert=false 1`] = `"Unexpected \\":300\\" at position 22, expected , or ?key=value."`;
+exports[`connection string parser Should throw on invalid strings esdb://host1,host2:200:300?throwOnAppendFailure=false 1`] = `"Unexpected \\":300\\" at position 22, expected , or ?key=value."`;
 
-exports[`connection string parser Should throw on invalid strings esdb://host1;host2;host3?tlsVerifyCert=false 1`] = `"Unexpected \\";\\" at position 12, expected ?key=value."`;
+exports[`connection string parser Should throw on invalid strings esdb://host1;host2;host3?throwOnAppendFailure=false 1`] = `"Unexpected \\";\\" at position 12, expected ?key=value."`;
 
-exports[`connection string parser Should throw on invalid strings esdb://localhost/&tlsVerifyCert=false 1`] = `"Unexpected \\"&\\" at position 17, expected ?key=value."`;
+exports[`connection string parser Should throw on invalid strings esdb://localhost/&throwOnAppendFailure=false 1`] = `"Unexpected \\"&\\" at position 17, expected ?key=value."`;
 
 exports[`connection string parser Should throw on invalid strings esdb://localhost?keepAliveInterval=XXIV 1`] = `"Unexpected \\"XXIV\\" at position 35, expected Integer."`;
 
 exports[`connection string parser Should throw on invalid strings esdb://localhost?keepAliveTimeout=please 1`] = `"Unexpected \\"please\\" at position 34, expected Integer."`;
 
+exports[`connection string parser Should throw on invalid strings esdb://localhost?throwOnAppendFailure=false&nodePreference=any 1`] = `"Unexpected \\"any\\" at position 59, expected leader or follower or read_only_replica or random."`;
+
+exports[`connection string parser Should throw on invalid strings esdb://localhost?throwOnAppendFailure=false?nodePreference=follower 1`] = `"Unexpected \\"?\\" at position 43, expected &key=value."`;
+
+exports[`connection string parser Should throw on invalid strings esdb://localhost?throwOnAppendFailure=if you feel like it 1`] = `"Unexpected \\"if you feel like it\\" at position 38, expected true or false."`;
+
 exports[`connection string parser Should throw on invalid strings esdb://localhost?throwOnAppendFailure=sometimes 1`] = `"Unexpected \\"sometimes\\" at position 38, expected true or false."`;
 
-exports[`connection string parser Should throw on invalid strings esdb://localhost?tlsVerifyCert=false&nodePreference=any 1`] = `"Unexpected \\"any\\" at position 52, expected leader or follower or read_only_replica or random."`;
+exports[`connection string parser Should throw on invalid strings esdb://my:great@username:UyeXx8$^PsOo4jG88FlCauR1Coz25q@host?nodePreference=follower&throwOnAppendFailure=false 1`] = `"Unexpected \\"UyeXx8\\" at position 25, expected port number."`;
 
-exports[`connection string parser Should throw on invalid strings esdb://localhost?tlsVerifyCert=false?nodePreference=follower 1`] = `"Unexpected \\"?\\" at position 36, expected &key=value."`;
-
-exports[`connection string parser Should throw on invalid strings esdb://localhost?tlsVerifyCert=if you feel like it 1`] = `"Unexpected \\"if you feel like it\\" at position 31, expected true or false."`;
-
-exports[`connection string parser Should throw on invalid strings esdb://my:great@username:UyeXx8$^PsOo4jG88FlCauR1Coz25q@host?nodePreference=follower&tlsVerifyCert=false 1`] = `"Unexpected \\"UyeXx8\\" at position 25, expected port number."`;
-
-exports[`connection string parser Should throw on invalid strings esdb://tlsVerifyCert=false 1`] = `"Unexpected \\"=\\" at position 20, expected ?key=value."`;
+exports[`connection string parser Should throw on invalid strings esdb://throwOnAppendFailure=false 1`] = `"Unexpected \\"=\\" at position 27, expected ?key=value."`;
 
 exports[`connection string parser Should throw on invalid strings https://console.eventstore.cloud/ 1`] = `"Unexpected \\"https://\\" at position 0, expected esdb:// or esdb+discover://."`;
 
 exports[`connection string parser Should throw on invalid strings localhost 1`] = `"Unexpected \\"l\\" at position 0, expected esdb:// or esdb+discover://."`;
 
-exports[`connection string parser Should warn on unknown keys esdb://localhost?catchOnAppendFailure=true&tlsVerifyCert=false 1`] = `
+exports[`connection string parser Should warn on unknown and unsupported keys esdb://localhost?catchOnAppendFailure=true&throwOnAppendFailure=false 1`] = `
 Array [
   Array [
     "Unknown option key \\"catchOnAppendFailure\\", setting will be ignored.
-esdb://localhost?catchOnAppendFailure=true&tlsVerifyCert=false
+esdb://localhost?catchOnAppendFailure=true&throwOnAppendFailure=false
                  ^^^^^^^^^^^^^^^^^^^^",
   ],
 ]
 `;
 
-exports[`connection string parser Should warn on unknown keys esdb://localhost?someNonsense=follower&doTheThing=true 1`] = `
+exports[`connection string parser Should warn on unknown and unsupported keys esdb://localhost?someNonsense=follower&doTheThing=true 1`] = `
 Array [
   Array [
     "Unknown option key \\"someNonsense\\", setting will be ignored.
@@ -49,6 +49,19 @@ esdb://localhost?someNonsense=follower&doTheThing=true
     "Unknown option key \\"doTheThing\\", setting will be ignored.
 esdb://localhost?someNonsense=follower&doTheThing=true
                                        ^^^^^^^^^^",
+  ],
+]
+`;
+
+exports[`connection string parser Should warn on unknown and unsupported keys esdb://localhost?tlsVerifyCert=false 1`] = `
+Array [
+  Array [
+    "\\"tlsVerifyCert\\" is not currently supported by this client, and will have no effect.
+Consider either:
+    Passing \\"tlsCAFile\\" in the connection string.
+    Setting NODE_EXTRA_CA_CERTS https://nodejs.org/api/cli.html#cli_node_extra_ca_certs_file
+esdb://localhost?tlsVerifyCert=false
+                 ^^^^^^^^^^^^^^^^^^^",
   ],
 ]
 `;

--- a/src/__test__/connection/parseConnectionString.test.ts
+++ b/src/__test__/connection/parseConnectionString.test.ts
@@ -18,7 +18,7 @@ describe("connection string parser", () => {
     });
   });
 
-  describe("Should warn on unknown keys", () => {
+  describe("Should warn on unknown and unsupported keys", () => {
     test.each(warning)("%s", (connectionString, expected) => {
       const warnSpy = jest.spyOn(console, "warn").mockImplementation();
       const parsed = parseConnectionString(connectionString);

--- a/src/__test__/connection/parseConnectionStringMockups.ts
+++ b/src/__test__/connection/parseConnectionStringMockups.ts
@@ -60,10 +60,10 @@ export const valid: Array<
     },
   ],
   [
-    "esdb://user:pass@localhost:2114/?tlsVerifyCert=false",
+    "esdb://user:pass@localhost:2114/?throwOnAppendFailure=false",
     {
       dnsDiscover: false,
-      tlsVerifyCert: false,
+      throwOnAppendFailure: false,
       defaultCredentials: {
         username: "user",
         password: "pass",
@@ -213,10 +213,10 @@ export const valid: Array<
     },
   ],
   [
-    "esdb://host1,host2,host3?tlsVerifyCert=false",
+    "esdb://host1,host2,host3?throwOnAppendFailure=false",
     {
       dnsDiscover: false,
-      tlsVerifyCert: false,
+      throwOnAppendFailure: false,
       hosts: [
         {
           address: "host1",
@@ -234,11 +234,11 @@ export const valid: Array<
     },
   ],
   [
-    "esdb+discover://user:pass@host?nodePreference=follower&tlsVerifyCert=false",
+    "esdb+discover://user:pass@host?nodePreference=follower&throwOnAppendFailure=false",
     {
       dnsDiscover: true,
       nodePreference: "follower",
-      tlsVerifyCert: false,
+      throwOnAppendFailure: false,
       defaultCredentials: {
         username: "user",
         password: "pass",
@@ -331,11 +331,11 @@ export const valid: Array<
     },
   ],
   [
-    "esdb://my%3Agreat%40username:UyeXx8%24%5EPsOo4jG88FlCauR1Coz25q@host?nodePreference=follower&tlsVerifyCert=false",
+    "esdb://my%3Agreat%40username:UyeXx8%24%5EPsOo4jG88FlCauR1Coz25q@host?nodePreference=follower&throwOnAppendFailure=false",
     {
       dnsDiscover: false,
       nodePreference: "follower",
-      tlsVerifyCert: false,
+      throwOnAppendFailure: false,
       defaultCredentials: {
         username: "my:great@username",
         password: "UyeXx8$^PsOo4jG88FlCauR1Coz25q",
@@ -349,11 +349,11 @@ export const valid: Array<
     },
   ],
   [
-    "esdb+discover://user:pass@морда-кошки.ru,ощущение-картофеля.ru?nodePreference=follower&tlsVerifyCert=false",
+    "esdb+discover://user:pass@морда-кошки.ru,ощущение-картофеля.ru?nodePreference=follower&throwOnAppendFailure=false",
     {
       dnsDiscover: true,
       nodePreference: "follower",
-      tlsVerifyCert: false,
+      throwOnAppendFailure: false,
       defaultCredentials: {
         username: "user",
         password: "pass",
@@ -371,7 +371,7 @@ export const valid: Array<
     },
   ],
   [
-    "esdb://host?maxDiscoverAttempts=200&discoveryInterval=1000&gossipTimeout=1&nodePreference=leader&tls=false&tlsVerifyCert=false&throwOnAppendFailure=false&keepAliveInterval=10",
+    "esdb://host?maxDiscoverAttempts=200&discoveryInterval=1000&gossipTimeout=1&nodePreference=leader&tls=false&tlsVerifyCert=true&throwOnAppendFailure=false&keepAliveInterval=10",
     {
       dnsDiscover: false,
       maxDiscoverAttempts: 200,
@@ -379,7 +379,7 @@ export const valid: Array<
       gossipTimeout: 1,
       nodePreference: "leader",
       tls: false,
-      tlsVerifyCert: false,
+      tlsVerifyCert: true,
       throwOnAppendFailure: false,
       keepAliveInterval: 10,
       hosts: [
@@ -391,7 +391,7 @@ export const valid: Array<
     },
   ],
   [
-    "esdb://host?MaxDiscoverAttempts=200&discoveryinterval=1000&GOSSIPTIMEOUT=1&nOdEpReFeReNcE=leader&TLS=false&TlsVerifyCert=false&THROWOnAppendFailure=false&KEEPALIVEinterval=200",
+    "esdb://host?MaxDiscoverAttempts=200&discoveryinterval=1000&GOSSIPTIMEOUT=1&nOdEpReFeReNcE=leader&TLS=false&TlsVerifyCert=true&THROWOnAppendFailure=false&KEEPALIVEinterval=200",
     {
       dnsDiscover: false,
       maxDiscoverAttempts: 200,
@@ -399,7 +399,7 @@ export const valid: Array<
       gossipTimeout: 1,
       nodePreference: "leader",
       tls: false,
-      tlsVerifyCert: false,
+      tlsVerifyCert: true,
       throwOnAppendFailure: false,
       keepAliveInterval: 200,
       hosts: [
@@ -411,7 +411,7 @@ export const valid: Array<
     },
   ],
   [
-    `esdb://host?MaxDiscoverAttempts=200&discovery-interval=1000&GOSSIP_TIMEOUT=1&node_preference=ReadOnlyReplica&TLS=false&TlsVerifyCert=false&THROWOnAppendFailure=false      &   KEEPALIVEinterval=200`,
+    `esdb://host?MaxDiscoverAttempts=200&discovery-interval=1000&GOSSIP_TIMEOUT=1&node_preference=ReadOnlyReplica&TLS=false&TlsVerifyCert=true&THROWOnAppendFailure=false      &   KEEPALIVEinterval=200`,
     {
       dnsDiscover: false,
       maxDiscoverAttempts: 200,
@@ -419,7 +419,7 @@ export const valid: Array<
       gossipTimeout: 1,
       nodePreference: "read_only_replica",
       tls: false,
-      tlsVerifyCert: false,
+      tlsVerifyCert: true,
       throwOnAppendFailure: false,
       keepAliveInterval: 200,
       hosts: [
@@ -437,7 +437,7 @@ export const valid: Array<
       &GOSSIPTIMEOUT=1
       &nOdEpReFeReNcE=leader
       &TLS=false
-      &TlsVerifyCert=false
+      &TlsVerifyCert=true
       &
       THROWOnAppendFailure
       =
@@ -449,7 +449,7 @@ export const valid: Array<
       gossipTimeout: 1,
       nodePreference: "leader",
       tls: false,
-      tlsVerifyCert: false,
+      tlsVerifyCert: true,
       throwOnAppendFailure: false,
       keepAliveInterval: 200,
       hosts: [
@@ -466,14 +466,14 @@ export const invalid: string[] = [
   "localhost",
   "https://console.eventstore.cloud/",
   "esbd+discovery://localhost",
-  "esdb://my:great@username:UyeXx8$^PsOo4jG88FlCauR1Coz25q@host?nodePreference=follower&tlsVerifyCert=false",
-  "esdb://host1;host2;host3?tlsVerifyCert=false",
-  "esdb://host1,host2:200:300?tlsVerifyCert=false",
-  "esdb://tlsVerifyCert=false",
-  "esdb://localhost/&tlsVerifyCert=false",
-  "esdb://localhost?tlsVerifyCert=false?nodePreference=follower",
-  "esdb://localhost?tlsVerifyCert=false&nodePreference=any",
-  "esdb://localhost?tlsVerifyCert=if you feel like it",
+  "esdb://my:great@username:UyeXx8$^PsOo4jG88FlCauR1Coz25q@host?nodePreference=follower&throwOnAppendFailure=false",
+  "esdb://host1;host2;host3?throwOnAppendFailure=false",
+  "esdb://host1,host2:200:300?throwOnAppendFailure=false",
+  "esdb://throwOnAppendFailure=false",
+  "esdb://localhost/&throwOnAppendFailure=false",
+  "esdb://localhost?throwOnAppendFailure=false?nodePreference=follower",
+  "esdb://localhost?throwOnAppendFailure=false&nodePreference=any",
+  "esdb://localhost?throwOnAppendFailure=if you feel like it",
   "esdb://localhost?throwOnAppendFailure=sometimes",
   "esdb://localhost?keepAliveTimeout=please",
   "esdb://localhost?keepAliveInterval=XXIV",
@@ -483,10 +483,10 @@ export const warning: Array<
   [connectionString: string, expected: ConnectionOptions]
 > = [
   [
-    "esdb://localhost?catchOnAppendFailure=true&tlsVerifyCert=false",
+    "esdb://localhost?catchOnAppendFailure=true&throwOnAppendFailure=false",
     {
       dnsDiscover: false,
-      tlsVerifyCert: false,
+      throwOnAppendFailure: false,
       hosts: [
         {
           address: "localhost",
@@ -499,6 +499,19 @@ export const warning: Array<
     "esdb://localhost?someNonsense=follower&doTheThing=true",
     {
       dnsDiscover: false,
+      hosts: [
+        {
+          address: "localhost",
+          port: 2113,
+        },
+      ],
+    },
+  ],
+  [
+    "esdb://localhost?tlsVerifyCert=false",
+    {
+      dnsDiscover: false,
+      tlsVerifyCert: false,
       hosts: [
         {
           address: "localhost",


### PR DESCRIPTION
- Warning to the console, not just a debug message.
- Suggest some alternatives
- Update tests
  - Prevent warnings in tests using `tlsVerifyCert` by replacing or setting to true
  - Add `tlsVerifyCert=false` mockup for warning snapshot 
  
  
![image](https://user-images.githubusercontent.com/11861797/147659153-41547368-c1df-4234-92da-40b6fcc95c7b.png)


fixes: #254 