### PR TITLE
[RFC 123] Standardize gRPC client deadlines

### DIFF
--- a/src/Client/parseConnectionString.ts
+++ b/src/Client/parseConnectionString.ts
@@ -4,6 +4,7 @@ import { debug } from "../utils";
 
 export interface QueryOptions {
   maxDiscoverAttempts?: number;
+  defaultDeadline?: number;
   discoveryInterval?: number;
   gossipTimeout?: number;
   nodePreference?: NodePreference;
@@ -53,6 +54,7 @@ const mapToNodePreference = caseMap<NodePreference>({
 
 const mapToQueryOption = caseMap<keyof QueryOptions>({
   maxDiscoverAttempts: "maxDiscoverAttempts",
+  defaultDeadline: "defaultDeadline",
   discoveryInterval: "discoveryInterval",
   gossipTimeout: "gossipTimeout",
   nodePreference: "nodePreference",
@@ -287,6 +289,7 @@ const verifyKeyValuePair = (
       return { key, value };
     }
     case "maxDiscoverAttempts":
+    case "defaultDeadline":
     case "discoveryInterval":
     case "gossipTimeout":
     case "keepAliveInterval":

--- a/src/__test__/connection/deadline/__snapshots__/deadline-settings.test.ts.snap
+++ b/src/__test__/connection/deadline/__snapshots__/deadline-settings.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`deadline should throw on negative connectionString 1`] = `"Invalid defaultDeadline \\"-1\\". Please provide a positive integer."`;
+
+exports[`deadline should throw on negative connectionString 2`] = `"Invalid defaultDeadline \\"-1000000000000000\\". Please provide a positive integer."`;
+
+exports[`deadline should throw on negative constructor 1`] = `"Invalid defaultDeadline \\"-1\\". Please provide a positive integer."`;
+
+exports[`deadline should throw on negative constructor 2`] = `"Invalid defaultDeadline \\"-1000000000000000\\". Please provide a positive integer."`;
+
+exports[`deadline should throw on zero connectionString 1`] = `"Invalid defaultDeadline \\"0\\". Please provide a positive integer."`;
+
+exports[`deadline should throw on zero constructor 1`] = `"Invalid defaultDeadline \\"0\\". Please provide a positive integer."`;

--- a/src/__test__/connection/deadline/deadline-effects.test.ts
+++ b/src/__test__/connection/deadline/deadline-effects.test.ts
@@ -1,0 +1,66 @@
+import { createTestCluster, jsonTestEvents } from "@test-utils";
+import {
+  EventStoreDBClient,
+  DeadlineExceededError,
+} from "@eventstore/db-client";
+
+describe("deadline", () => {
+  const cluster = createTestCluster();
+
+  beforeAll(async () => {
+    await cluster.up();
+  });
+
+  afterAll(async () => {
+    await cluster.down();
+  });
+
+  describe("should time out a call", () => {
+    test.each([
+      [
+        "client settings",
+        () =>
+          new EventStoreDBClient(
+            { endpoints: cluster.endpoints, defaultDeadline: 1 },
+            { rootCertificate: cluster.rootCertificate }
+          ).listProjections(),
+      ],
+      [
+        "call options",
+        () =>
+          new EventStoreDBClient(
+            { endpoints: cluster.endpoints },
+            { rootCertificate: cluster.rootCertificate }
+          ).listProjections({
+            deadline: 1,
+          }),
+      ],
+      [
+        "call options override",
+        () =>
+          new EventStoreDBClient(
+            { endpoints: cluster.endpoints, defaultDeadline: 200_000 },
+            { rootCertificate: cluster.rootCertificate }
+          ).listProjections({
+            deadline: 1,
+          }),
+      ],
+      [
+        "append",
+        () =>
+          new EventStoreDBClient(
+            { endpoints: cluster.endpoints, defaultDeadline: 200_000 },
+            { rootCertificate: cluster.rootCertificate }
+          ).appendToStream("deadline", jsonTestEvents(), {
+            deadline: 1,
+          }),
+      ],
+    ])("%s", async (_, makeCall) => {
+      try {
+        await makeCall();
+      } catch (error) {
+        expect(error).toBeInstanceOf(DeadlineExceededError);
+      }
+    });
+  });
+});

--- a/src/__test__/connection/deadline/deadline-settings.test.ts
+++ b/src/__test__/connection/deadline/deadline-settings.test.ts
@@ -1,0 +1,141 @@
+import { Channel } from "@grpc/grpc-js";
+
+import {
+  BaseOptions,
+  DNSClusterOptions,
+  EventStoreDBClient,
+} from "@eventstore/db-client";
+
+/*
+Mocking this file breaks grpc, but allows us to check the settings passed to grpc
+These tests need to be kept seperate to any tests that need to actually make calls 
+*/
+jest.mock("@grpc/grpc-js/build/src/channel.js");
+const ChannelMock = Channel as jest.Mock<Channel>;
+
+describe("deadline", () => {
+  beforeEach(() => {
+    ChannelMock.mockClear();
+  });
+
+  describe.each<
+    [
+      test_name: string,
+      connection_string: string,
+      constructor_options: Partial<DNSClusterOptions>,
+      call_options: BaseOptions,
+      expected: number
+    ]
+  >([
+    ["should default to 10_000", "esdb://host", {}, {}, 10_000],
+    [
+      "should be settable: 1",
+      "esdb://host?defaultDeadline=1",
+      { defaultDeadline: 1 },
+      {},
+      1,
+    ],
+    [
+      "should be settable: 100000",
+      "esdb://host?defaultDeadline=100000",
+      { defaultDeadline: 10_0000 },
+      {},
+      10_0000,
+    ],
+    [
+      "passing in call options should override default",
+      "esdb://host",
+      {},
+      { deadline: 10_0000 },
+      10_0000,
+    ],
+    [
+      "passing in call options should override settings",
+      "esdb://host?defaultDeadline=100000",
+      { defaultDeadline: 10_0000 },
+      { deadline: 10 },
+      10,
+    ],
+  ])("%s", (_, connectionString, constructorOptions, callOptions, expected) => {
+    test.each([
+      [
+        "connectionString",
+        () => EventStoreDBClient.connectionString(connectionString),
+      ],
+      [
+        "constructor",
+        () =>
+          new EventStoreDBClient({
+            endpoint: "host:1234",
+            ...constructorOptions,
+          }),
+      ],
+    ])("%s", async (_, createClient) => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+      const client = createClient();
+      const before = Date.now();
+
+      try {
+        await client.restartSubsystem(callOptions);
+      } catch (_) {
+        // We're not actually connecting to anything, just triggering channel creation
+      }
+
+      const after = Date.now();
+
+      const ChannelInstance = ChannelMock.mock.instances[0];
+      const createCall = ChannelInstance.createCall as unknown as jest.Mock<
+        Channel["createCall"]
+      >;
+
+      const deadline = createCall.mock.calls[0][1].getTime();
+
+      expect(deadline).toBeGreaterThanOrEqual(before + expected);
+      expect(deadline).toBeLessThanOrEqual(after + expected);
+
+      expect(warnSpy).not.toBeCalled();
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe.each<
+    [
+      test_name: string,
+      connection_string: string,
+      constructor_options: Partial<DNSClusterOptions>
+    ]
+  >([
+    [
+      "should throw on zero",
+      "esdb://host?defaultDeadline=0",
+      { defaultDeadline: 0 },
+    ],
+    [
+      "should throw on negative",
+      "esdb://host?defaultDeadline=-1",
+      { defaultDeadline: -1 },
+    ],
+    [
+      "should throw on negative",
+      "esdb://host?defaultDeadline=-1000000000000000",
+      { defaultDeadline: -1000000000000000 },
+    ],
+  ])("%s", (_, connectionString, constructorOptions) => {
+    test.each([
+      [
+        "connectionString",
+        () => EventStoreDBClient.connectionString(connectionString),
+      ],
+      [
+        "constructor",
+        () =>
+          new EventStoreDBClient({
+            endpoint: "host:1234",
+            ...constructorOptions,
+          }),
+      ],
+    ])("%s", async (_, createClient) => {
+      expect(() => createClient()).toThrowErrorMatchingSnapshot();
+    });
+  });
+});

--- a/src/__test__/connection/parseConnectionStringMockups.ts
+++ b/src/__test__/connection/parseConnectionStringMockups.ts
@@ -371,11 +371,12 @@ export const valid: Array<
     },
   ],
   [
-    "esdb://host?maxDiscoverAttempts=200&discoveryInterval=1000&gossipTimeout=1&nodePreference=leader&tls=false&tlsVerifyCert=true&throwOnAppendFailure=false&keepAliveInterval=10",
+    "esdb://host?maxDiscoverAttempts=200&discoveryInterval=1000&gossipTimeout=1&nodePreference=leader&tls=false&tlsVerifyCert=true&throwOnAppendFailure=false&keepAliveInterval=10&defaultDeadline=10000000",
     {
       dnsDiscover: false,
       maxDiscoverAttempts: 200,
       discoveryInterval: 1000,
+      defaultDeadline: 10_000_000,
       gossipTimeout: 1,
       nodePreference: "leader",
       tls: false,
@@ -411,11 +412,12 @@ export const valid: Array<
     },
   ],
   [
-    `esdb://host?MaxDiscoverAttempts=200&discovery-interval=1000&GOSSIP_TIMEOUT=1&node_preference=ReadOnlyReplica&TLS=false&TlsVerifyCert=true&THROWOnAppendFailure=false      &   KEEPALIVEinterval=200`,
+    `esdb://host?MaxDiscoverAttempts=200&discovery-interval=1000&GOSSIP_TIMEOUT=1&node_preference=ReadOnlyReplica&TLS=false&TlsVerifyCert=true&DEFAULTdEADLINE=12&THROWOnAppendFailure=false      &   KEEPALIVEinterval=200`,
     {
       dnsDiscover: false,
       maxDiscoverAttempts: 200,
       discoveryInterval: 1000,
+      defaultDeadline: 12,
       gossipTimeout: 1,
       nodePreference: "read_only_replica",
       tls: false,

--- a/src/__test__/connection/reconnect/mid-stream.test.ts
+++ b/src/__test__/connection/reconnect/mid-stream.test.ts
@@ -57,7 +57,8 @@ describe("reconnect", () => {
 
     const reconnectedAppend = await client.appendToStream(
       "my_stream",
-      jsonEvent({ type: "reconnect-append", data: { message: "test" } }), // batch append triggers reconnect as soon as stream drops, so we need to force regular append
+      jsonEvent({ type: "reconnect-append", data: { message: "test" } }),
+      // batch append triggers reconnect as soon as stream drops, so we need to force regular append
       { credentials: { username: "admin", password: "changeit" } }
     );
     expect(reconnectedAppend).toBeDefined();

--- a/src/__test__/streams/appendToStream-errors.test.ts
+++ b/src/__test__/streams/appendToStream-errors.test.ts
@@ -14,7 +14,7 @@ import {
   StreamDeletedError,
   MaxAppendSizeExceededError,
   AccessDeniedError,
-  TimeoutError,
+  DeadlineExceededError,
 } from "@eventstore/db-client";
 
 describe("appendToStream - errors", () => {
@@ -133,28 +133,21 @@ describe("appendToStream - errors", () => {
       }
     });
 
-    optionalTest(supported)("Timeout", async () => {
-      const STREAM_NAME = `${prefix}_timeout`;
+    optionalTest(supported)("DeadlineExceeded", async () => {
+      const STREAM_NAME = `${prefix}_deadline`;
 
       try {
-        // try increasingly hard to hit the timeout
-        for (let i = 5; i < 20; i += 5) {
-          await Promise.all(
-            Array.from({ length: i }, () =>
-              timeoutClient.appendToStream(
-                STREAM_NAME,
-                jsonTestEvents(30_000),
-                {
-                  credentials,
-                }
-              )
-            )
-          );
-        }
-
+        await timeoutClient.appendToStream(
+          STREAM_NAME,
+          jsonTestEvents(30_000),
+          {
+            credentials,
+            deadline: 1,
+          }
+        );
         expect("this point").toBe("unreachable");
       } catch (error) {
-        expect(error).toBeInstanceOf(TimeoutError);
+        expect(error).toBeInstanceOf(DeadlineExceededError);
       }
     });
 

--- a/src/streams/appendToStream/batchAppend.ts
+++ b/src/streams/appendToStream/batchAppend.ts
@@ -19,6 +19,7 @@ import {
   unpackWrongExpectedVersion,
 } from "./unpackError";
 import { InternalAppendToStreamOptions } from ".";
+import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 
 const streamCache = new WeakMap<
   StreamsClient,
@@ -122,6 +123,11 @@ export const batchAppend = async function (
     const identifier = new StreamIdentifier();
     identifier.setStreamName(Uint8Array.from(Buffer.from(streamName, "utf8")));
     options.setStreamIdentifier(identifier);
+    const deadline = Timestamp.fromDate(
+      this.createDeadline(baseOptions.deadline)
+    );
+    options.setDeadline(deadline);
+
     switch (expectedRevision) {
       case "any": {
         options.setAny(new Empty());

--- a/src/streams/appendToStream/unpackError.ts
+++ b/src/streams/appendToStream/unpackError.ts
@@ -11,7 +11,7 @@ import {
   AccessDeniedError,
   MaxAppendSizeExceededError,
   StreamDeletedError,
-  TimeoutError,
+  DeadlineExceededError,
   UnknownError,
   WrongExpectedVersionError,
 } from "../..";
@@ -56,7 +56,7 @@ export const unpackToCommandError = (grpcError: Status, streamName: string) => {
     case "event_store.client.Timeout": {
       const unpacked = details.unpack(Timeout.deserializeBinary, typename);
       if (!unpacked) break;
-      return new TimeoutError();
+      return new DeadlineExceededError();
     }
     case "event_store.client.Unknown": {
       const unpacked = details.unpack(Unknown.deserializeBinary, typename);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,10 @@ export interface BaseOptions {
    * Command requires a leader node.
    */
   requiresLeader?: boolean;
+  /**
+   * An optional length of time (in milliseconds) to override the default deadline.
+   */
+  deadline?: number;
 }
 
 /**

--- a/src/utils/CommandError.ts
+++ b/src/utils/CommandError.ts
@@ -7,6 +7,7 @@ import { CurrentRevision, EndPoint, AppendExpectedRevision } from "../types";
 
 export enum ErrorType {
   TIMEOUT = "timeout",
+  DEADLINE_EXCEEDED = "deadline-exceeded",
   UNAVAILABLE = "unavailable",
   UNKNOWN = "unknown",
   NOT_LEADER = "not-leader",
@@ -49,6 +50,10 @@ abstract class CommandErrorBase extends Error {
 
 export class TimeoutError extends CommandErrorBase {
   public type: ErrorType.TIMEOUT = ErrorType.TIMEOUT;
+}
+
+export class DeadlineExceededError extends CommandErrorBase {
+  public type: ErrorType.DEADLINE_EXCEEDED = ErrorType.DEADLINE_EXCEEDED;
 }
 
 export class UnavailableError extends CommandErrorBase {
@@ -370,6 +375,7 @@ export type CommandError =
   | LoginNotFoundError
   | LoginConflictError
   | TimeoutError
+  | DeadlineExceededError
   | UnavailableError
   | UnknownError
   | UnsupportedError;
@@ -419,6 +425,8 @@ export const convertToCommandError = (error: Error): CommandError | Error => {
   switch (error.code) {
     case StatusCode.ABORTED:
       return new TimeoutError(error);
+    case StatusCode.DEADLINE_EXCEEDED:
+      return new DeadlineExceededError(error);
     case StatusCode.UNAVAILABLE:
       return new UnavailableError(error);
     case StatusCode.UNAUTHENTICATED:


### PR DESCRIPTION
- Add `defaultDeadline` global setting (constructor options and connection string)
- Add `deadline` to BaseOptions
- Add and return `DeadlineExceeded` error
- Ensure reads & subscriptions infinity timeouts are respected
- Default `defaultDeadline` is set to 10 seconds
- Pass deadline to Batch Append

fixes: #262