### PR TITLE
Update CI server versions

### DIFF
--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build and lint
 
 on:
   pull_request:

--- a/.github/workflows/test_LTS.yml
+++ b/.github/workflows/test_LTS.yml
@@ -1,4 +1,4 @@
-name: "20.10"
+name: "LTS"
 
 on:
   pull_request:
@@ -13,7 +13,7 @@ jobs:
     name: Test
     uses: EventStore/EventStore-Client-NodeJS/.github/workflows/tests.yml@master
     with:
-      version: "20.10.5-buster-slim"
+      version: "21.10.1-focal"
     secrets:
       eventstore_cloud_id: ${{ secrets.EVENTSTORE_CLOUD_ID }}
       tailscale_auth: ${{ secrets.TAILSCALE_AUTH }}

--- a/.github/workflows/test_next.yml
+++ b/.github/workflows/test_next.yml
@@ -1,4 +1,4 @@
-name: "21.6"
+name: "Next feature version"
 
 on:
   pull_request:
@@ -6,14 +6,14 @@ on:
     branches:
       - master
   schedule:
-    - cron: "0 3 * * 0" # Every sunday at 3am UTC.
+    - cron: "0 * * * 0" # Every day at 3am UTC.
 
 jobs:
   test:
     name: Test
     uses: EventStore/EventStore-Client-NodeJS/.github/workflows/tests.yml@master
     with:
-      version: "21.6.0-buster-slim"
+      version: "ci"
     secrets:
       eventstore_cloud_id: ${{ secrets.EVENTSTORE_CLOUD_ID }}
       tailscale_auth: ${{ secrets.TAILSCALE_AUTH }}

--- a/.github/workflows/test_previous_LTS.yml
+++ b/.github/workflows/test_previous_LTS.yml
@@ -1,4 +1,4 @@
-name: "21.10"
+name: "previous LTS"
 
 on:
   pull_request:
@@ -13,7 +13,7 @@ jobs:
     name: Test
     uses: EventStore/EventStore-Client-NodeJS/.github/workflows/tests.yml@master
     with:
-      version: "21.10.0-buster-slim"
+      version: "20.10.5-focal"
     secrets:
       eventstore_cloud_id: ${{ secrets.EVENTSTORE_CLOUD_ID }}
       tailscale_auth: ${{ secrets.TAILSCALE_AUTH }}


### PR DESCRIPTION
- Remove testing against `21.6`
- Add testing against server CI build
- rename "CI" check to "Build and lint" to be more descriptive
- Rename workflows to match server names
- Test against CI nightly


ref: https://github.com/EventStore/architecture-and-planning/discussions/98