### PR TITLE
Increase maximum readable event size to match maximum eventsize that can be written internally

### DIFF
--- a/src/Client/index.ts
+++ b/src/Client/index.ts
@@ -448,6 +448,10 @@ export class Client {
           : this.#keepAliveInterval,
       "grpc.keepalive_timeout_ms":
         this.#keepAliveTimeout < 0 ? Number.MAX_VALUE : this.#keepAliveTimeout,
+      // EventStore allows events of up to 16mb to be written internally.
+      // While you can't write events this large through gRPC, you could do so through the TCP client, or through projections.
+      // To allow the client to read any event that EventStoreDB was able to write, we want to hardcode the max receive message length to 17mb.
+      "grpc.max_receive_message_length": 17 * 1024 * 1024,
     });
   };
 

--- a/src/__test__/extra/oversize-event.test.ts
+++ b/src/__test__/extra/oversize-event.test.ts
@@ -1,0 +1,89 @@
+import { createTestNode, delay, jsonTestEvents } from "@test-utils";
+import {
+  EventStoreDBClient,
+  jsonEvent,
+  JSONEventType,
+  RUNNING,
+} from "@eventstore/db-client";
+
+describe("oversize events", () => {
+  const node = createTestNode();
+
+  let client!: EventStoreDBClient;
+
+  beforeAll(async () => {
+    await node.up();
+    client = new EventStoreDBClient(
+      { endpoint: node.uri },
+      { rootCertificate: node.rootCertificate },
+      { username: "admin", password: "changeit" }
+    );
+  });
+
+  afterAll(async () => {
+    // await node.openInBrowser(false);
+    await node.down();
+  });
+
+  test("oversize events", async () => {
+    const STREAM_NAME = "big_event";
+    const TRIGGER = "big_event_trigger";
+    const FINISH_TEST = "big_event_finish_test";
+    const PROJECTION_NAME = "big_event_projection";
+    const doSomething = jest.fn();
+
+    const BIG_EVENT = "big_event";
+    const bigData = "r" + "e".repeat(15 * 1024 * 1024);
+
+    type BigEvent = JSONEventType<
+      typeof BIG_EVENT,
+      { message: string },
+      { message: string }
+    >;
+
+    const projection = `
+    fromStream("${STREAM_NAME}")
+      .when({
+        $init() {
+          return 0;
+        },
+        ${TRIGGER}() {
+          emit("${STREAM_NAME}_emit", "${BIG_EVENT}", { message: "r" + "e".repeat(15 * 1024 * 1024) }, {});
+        }
+      });
+`;
+
+    await client.createProjection(PROJECTION_NAME, projection, {
+      trackEmittedStreams: true,
+    });
+
+    // give it a chance to get up and running
+    await delay(1000);
+
+    const state = await client.getProjectionStatus(PROJECTION_NAME);
+    expect(state.projectionStatus).toBe(RUNNING);
+
+    await client.appendToStream(STREAM_NAME, [
+      jsonEvent({ type: TRIGGER, data: "hi" }),
+      ...jsonTestEvents(5),
+      jsonEvent({ type: FINISH_TEST, data: "hi" }),
+    ]);
+
+    // check that the big event hasn't blown it up
+    const state2 = await client.getProjectionStatus(PROJECTION_NAME);
+    expect(state2.projectionStatus).toBe(RUNNING);
+
+    const subscription = client.subscribeToStream<BigEvent>(
+      `${STREAM_NAME}_emit`
+    );
+
+    for await (const { event } of subscription) {
+      if (event?.type !== BIG_EVENT) continue;
+      doSomething(event);
+      expect(event.data.message).toBe(bigData);
+      break;
+    }
+
+    expect(doSomething).toBeCalled();
+  });
+});


### PR DESCRIPTION
- Set `grpc.max_receive_message_length`
- Add test

ref: https://github.com/EventStore/architecture-and-planning/pull/101