### PR TITLE
Testing improvements / Fix flaky tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:eslint": "eslint \"src/**/*.ts\"",
     "prettier:fix": "prettier --write \"src/**/**/!(*.d).{ts,json}\"",
     "test": "jest",
-    "test:debug": "yarn cross-env NODE_OPTIONS=\"--no-deprecation\" DEBUG=\"esdb:*\" DEBUG_DEPTH=6 jest --verbose --run-in-band",
+    "test:debug": "yarn cross-env NODE_OPTIONS=\"--no-deprecation\" DEBUG=\"esdb:*\" DEBUG_DEPTH=6 DEBUG_COLORS=\"true\" jest --verbose --run-in-band",
     "test:flake": "jest --testSequencer=./src/__test__/utils/FlakeFinder.js",
     "generate": "run-s generate:*",
     "generate:sed-append": "shx sed -i \"s/int64 ([A-z_]*) = ([0-9]*) \\[deprecated = true\\];/int64 \\$1 = \\$2 [deprecated = true, jstype = JS_STRING];/g\" ./protos/*",

--- a/src/__test__/connection/reconnect/NotLeaderError.test.ts
+++ b/src/__test__/connection/reconnect/NotLeaderError.test.ts
@@ -17,7 +17,13 @@ describe("reconnect", () => {
     await cluster.up();
 
     const client = new EventStoreDBClient(
-      { endpoints: cluster.endpoints, nodePreference: FOLLOWER },
+      {
+        endpoints: cluster.endpoints,
+        nodePreference: FOLLOWER,
+        // The timing of this test can be a bit variable,
+        // so it's better not to have deadlines here to force the errors we are testing.
+        defaultDeadline: Infinity,
+      },
       { rootCertificate: cluster.rootCertificate }
     );
 

--- a/src/__test__/connection/reconnect/UnavailableError.test.ts
+++ b/src/__test__/connection/reconnect/UnavailableError.test.ts
@@ -21,7 +21,12 @@ describe("reconnect", () => {
     await cluster.up();
 
     const client = new EventStoreDBClient(
-      { endpoints: cluster.endpoints },
+      {
+        endpoints: cluster.endpoints,
+        // The timing of this test can be a bit variable,
+        // so it's better not to have deadlines here to force the errors we are testing.
+        defaultDeadline: Infinity,
+      },
       { rootCertificate: cluster.rootCertificate }
     );
 

--- a/src/__test__/connection/reconnect/all-nodes-down.test.ts
+++ b/src/__test__/connection/reconnect/all-nodes-down.test.ts
@@ -15,7 +15,12 @@ describe("reconnect", () => {
     await cluster.up();
 
     const client = new EventStoreDBClient(
-      { endpoints: cluster.endpoints },
+      {
+        endpoints: cluster.endpoints,
+        // The timing of this test can be a bit variable,
+        // so it's better not to have deadlines here to force the errors we are testing.
+        defaultDeadline: Infinity,
+      },
       { rootCertificate: cluster.rootCertificate }
     );
 

--- a/src/__test__/connection/reconnect/no-reconnection.test.ts
+++ b/src/__test__/connection/reconnect/no-reconnection.test.ts
@@ -15,7 +15,12 @@ describe("reconnect", () => {
     await cluster.up();
 
     const client = new EventStoreDBClient(
-      { endpoints: cluster.endpoints },
+      {
+        endpoints: cluster.endpoints,
+        // The timing of this test can be a bit variable,
+        // so it's better not to have deadlines here to force the errors we are testing.
+        defaultDeadline: Infinity,
+      },
       { rootCertificate: cluster.rootCertificate }
     );
 

--- a/src/__test__/streams/subscribeToAll-filters.test.ts
+++ b/src/__test__/streams/subscribeToAll-filters.test.ts
@@ -276,8 +276,9 @@ describe("subscribeToAll", () => {
       expect(events.length).toBe(384);
 
       // 384 / (32 * 2 (checkpointInterval) ) = 6;
-      expect(checkpointReached).toBeCalledTimes(6);
-      expect(checkpoints).toHaveLength(6);
+      expect(checkpointReached.mock.calls.length).toBeGreaterThanOrEqual(6);
+      // sometimes we can have a catch up checkpoint
+      expect(checkpointReached.mock.calls.length).toBeLessThanOrEqual(7);
 
       for (const { commit, prepare } of checkpoints) {
         expect(typeof commit).toBe("bigint");

--- a/src/__test__/tsconfig.json
+++ b/src/__test__/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "noUnusedLocals": false,
     "paths": {
       "@eventstore/db-client": ["../"],
       "@test-utils": ["./utils"]

--- a/src/__test__/utils/debug.ts
+++ b/src/__test__/utils/debug.ts
@@ -1,0 +1,3 @@
+import createDebug from "debug";
+
+export const testDebug = createDebug("esdb").extend("tests");


### PR DESCRIPTION
Testing improvements: 
- Allow unused code when running tests, to make developing less annoying. (unused code will still fail builds)
- add `testDebug` util to add test logs to `DEBUG`. #228 
- add Cluster method to output docker logs to console
- add `inspect` method to keep cluster up after tests finish (easier to remember than `openInBrowser(false)`)

Fix subscribeToAll-filters flaky test: #246 
- Account for occasional extra checkpoint

Prevent deadline errors from throwing off reconnect test timing: #246  
- Set `defaultDeadline` to infinity in affected tests

fixes: #246 
fixes: #228 