### PR TITLE
Ensure rediscovery is not run when the server returns a timeout

### DIFF
--- a/src/Client/index.ts
+++ b/src/Client/index.ts
@@ -25,7 +25,6 @@ import {
   convertToCommandError,
   debug,
   NotLeaderError,
-  TimeoutError,
   UnavailableError,
 } from "../utils";
 import { discoverEndpoint } from "./discovery";
@@ -399,7 +398,7 @@ export class Client {
       return [true, error.leader];
     }
 
-    return [error instanceof UnavailableError || error instanceof TimeoutError];
+    return [error instanceof UnavailableError];
   };
 
   protected handleError = async (

--- a/src/__test__/connection/reconnect/no-reconnection.test.ts
+++ b/src/__test__/connection/reconnect/no-reconnection.test.ts
@@ -1,8 +1,9 @@
-import { createTestCluster } from "@test-utils";
+import { createTestCluster, createTestNode, jsonTestEvents } from "@test-utils";
 import {
   jsonEvent,
   EventStoreDBClient,
   StreamNotFoundError,
+  TimeoutError,
 } from "@eventstore/db-client";
 
 // This test can take time.
@@ -51,5 +52,62 @@ describe("reconnect", () => {
     expect(priorChannel).toBe(afterChannel);
 
     await cluster.down();
+  });
+
+  test("no reconnection for TimeoutError", async () => {
+    const timeoutNode = createTestNode()
+      .setOption("EVENTSTORE_COMMIT_TIMEOUT_MS", 1)
+      .setOption("EVENTSTORE_PREPARE_TIMEOUT_MS", 1);
+
+    await timeoutNode.up();
+
+    const credentials = { username: "admin", password: "changeit" };
+    const STREAM_NAME = "try_get_timeout";
+
+    const client = new EventStoreDBClient(
+      {
+        endpoint: timeoutNode.uri,
+        // The timing of this test can be a bit variable,
+        // so it's better not to have deadlines here to force the errors we are testing.
+        defaultDeadline: Infinity,
+      },
+      { rootCertificate: timeoutNode.rootCertificate }
+    );
+
+    // make successful append to connect to node
+    const firstAppend = await client.appendToStream(
+      "my_stream",
+      jsonEvent({ type: "first-append", data: { message: "test" } }),
+      // batch append triggers reconnect as soon as stream drops, so we need to force regular append
+      { credentials }
+    );
+    expect(firstAppend).toBeDefined();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const priorChannel = await (client as any).getChannel();
+
+    try {
+      // try increasingly hard to hit the timeout
+      for (let i = 5; i < 20; i += 5) {
+        await Promise.all(
+          Array.from({ length: i }, () =>
+            client.appendToStream(STREAM_NAME, jsonTestEvents(30_000), {
+              credentials,
+            })
+          )
+        );
+      }
+
+      expect("this point").toBe("unreachable");
+    } catch (error) {
+      expect(error).toBeInstanceOf(TimeoutError);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const afterChannel = await (client as any).getChannel();
+
+    expect(priorChannel).toBe(afterChannel);
+
+    await timeoutNode.down();
   });
 });

--- a/src/__test__/streams/appendToStream-errors.test.ts
+++ b/src/__test__/streams/appendToStream-errors.test.ts
@@ -19,28 +19,18 @@ import {
 
 describe("appendToStream - errors", () => {
   const node = createTestNode();
-  const timeoutNode = createTestNode()
-    .setOption("EVENTSTORE_COMMIT_TIMEOUT_MS", 1)
-    .setOption("EVENTSTORE_PREPARE_TIMEOUT_MS", 1);
   let client!: EventStoreDBClient;
-  let timeoutClient!: EventStoreDBClient;
 
   beforeAll(async () => {
     await node.up();
-    await timeoutNode.up();
     client = new EventStoreDBClient(
       { endpoint: node.uri, throwOnAppendFailure: true },
       { rootCertificate: node.rootCertificate }
-    );
-    timeoutClient = new EventStoreDBClient(
-      { endpoint: timeoutNode.uri, throwOnAppendFailure: true },
-      { rootCertificate: timeoutNode.rootCertificate }
     );
   });
 
   afterAll(async () => {
     await node.down();
-    await timeoutNode.down();
   });
 
   describe.each([
@@ -137,14 +127,10 @@ describe("appendToStream - errors", () => {
       const STREAM_NAME = `${prefix}_deadline`;
 
       try {
-        await timeoutClient.appendToStream(
-          STREAM_NAME,
-          jsonTestEvents(30_000),
-          {
-            credentials,
-            deadline: 1,
-          }
-        );
+        await client.appendToStream(STREAM_NAME, jsonTestEvents(30_000), {
+          credentials,
+          deadline: 1,
+        });
         expect("this point").toBe("unreachable");
       } catch (error) {
         expect(error).toBeInstanceOf(DeadlineExceededError);


### PR DESCRIPTION
- remove `TimeoutError` from redescoverable errors
- add test

fixes: #275 