### PR TITLE
Improve event typing

### DIFF
--- a/src/__test__/extra/typedEvents-more.test.ts
+++ b/src/__test__/extra/typedEvents-more.test.ts
@@ -1,0 +1,319 @@
+import { v4 as uuid } from "uuid";
+
+import { createTestNode } from "@test-utils";
+import {
+  AppendResult,
+  EventStoreDBClient,
+  EventType,
+  jsonEvent,
+  JSONEventType,
+  RecordedEvent,
+  ResolvedEvent,
+  StreamingRead,
+} from "@eventstore/db-client";
+
+describe("typed events should compile", () => {
+  const node = createTestNode();
+  let client!: EventStoreDBClient;
+
+  beforeAll(async () => {
+    await node.up();
+    client = new EventStoreDBClient(
+      { endpoint: node.uri },
+      { rootCertificate: node.rootCertificate },
+      { username: "admin", password: "changeit" }
+    );
+  });
+
+  afterAll(async () => {
+    await node.down();
+  });
+
+  test("stream agregator", async () => {
+    type EventAggregator<Aggregate, E extends EventType> = (
+      currentState: Aggregate | undefined,
+      event: RecordedEvent<E>
+    ) => Aggregate;
+
+    const createStreamAggregator =
+      <Entity, StreamEvents extends EventType>(
+        when: EventAggregator<Entity, StreamEvents>
+      ) =>
+      async (
+        eventStream: StreamingRead<ResolvedEvent<StreamEvents>>
+      ): Promise<Entity> => {
+        let currentState: Entity | undefined = undefined;
+        for await (const { event } of eventStream) {
+          if (!event) continue;
+          currentState = when(currentState, event);
+        }
+        if (currentState == null) throw "oh no";
+        return currentState;
+      };
+
+    interface ProductItem {
+      productId: string;
+      quantity: number;
+    }
+
+    // bare interface
+    interface ShoppingCartOpened {
+      type: "shopping-cart-opened";
+      data: {
+        shoppingCartId: string;
+        clientId: string;
+        openedAt: string;
+      };
+    }
+
+    // using JSONEventType
+    type ProductItemAddedToShoppingCart = JSONEventType<
+      "product-item-added-to-shopping-cart",
+      {
+        shoppingCartId: string;
+        productItem: ProductItem;
+      }
+    >;
+
+    type ProductItemRemovedFromShoppingCart = JSONEventType<
+      "product-item-removed-from-shopping-cart",
+      {
+        shoppingCartId: string;
+        productItem: ProductItem;
+      }
+    >;
+
+    type ShoppingCartConfirmed = JSONEventType<
+      "shopping-cart-confirmed",
+      {
+        shoppingCartId: string;
+        confirmedAt: string;
+      }
+    >;
+
+    type ShoppingCartEvent =
+      | ShoppingCartOpened
+      | ProductItemAddedToShoppingCart
+      | ProductItemRemovedFromShoppingCart
+      | ShoppingCartConfirmed;
+
+    enum ShoppingCartStatus {
+      Opened = 1,
+      Confirmed = 2,
+      Cancelled = 4,
+      Closed = Confirmed | Cancelled,
+    }
+
+    type ProductItems = Map<string, ProductItem>;
+
+    interface ShoppingCart {
+      id: string;
+      clientId: string;
+      status: ShoppingCartStatus;
+      productItems: ProductItems;
+      openedAt: Date;
+      confirmedAt?: Date;
+    }
+
+    const enum ShoppingCartErrors {
+      OPENED_EXISTING_CART = "OPENED_EXISTING_CART",
+      CART_NOT_FOUND = "CART_NOT_FOUND",
+      PRODUCT_ITEM_NOT_FOUND = "PRODUCT_ITEM_NOT_FOUND",
+      UNKNOWN_EVENT_TYPE = "UNKNOWN_EVENT_TYPE",
+    }
+
+    const addProductItem = (
+      inventory: ProductItems,
+      { productId, quantity }: ProductItem
+    ): ProductItems => {
+      const current = inventory.get(productId);
+
+      if (!current) {
+        return inventory.set(productId, { productId, quantity });
+      }
+
+      return inventory.set(productId, {
+        ...current,
+        quantity: current.quantity + quantity,
+      });
+    };
+
+    const removeProductItem = (
+      inventory: ProductItems,
+      { productId, quantity }: ProductItem
+    ): ProductItems => {
+      const current = inventory.get(productId);
+
+      if (!current || current.quantity < quantity) {
+        throw ShoppingCartErrors.PRODUCT_ITEM_NOT_FOUND;
+      }
+
+      if (current.quantity === quantity) {
+        inventory.delete(productId);
+        return inventory;
+      }
+
+      return inventory.set(productId, {
+        ...current,
+        quantity: current.quantity - quantity,
+      });
+    };
+
+    const create =
+      <Command, StreamEvent extends JSONEventType>(
+        client: EventStoreDBClient,
+        handle: (command: Command) => StreamEvent
+      ) =>
+      (streamName: string, command: Command): Promise<AppendResult> => {
+        const event = handle(command);
+        const eventData = jsonEvent<StreamEvent>(event);
+        return client.appendToStream<StreamEvent>(streamName, eventData);
+      };
+
+    create<string, ShoppingCartEvent>(client, () => ({
+      type: "shopping-cart-opened",
+      data: {
+        shoppingCartId: uuid(),
+        clientId: uuid(),
+        openedAt: new Date().toJSON(),
+      },
+    }));
+
+    const shoppingCartAggregator = createStreamAggregator<
+      ShoppingCart,
+      ShoppingCartEvent
+    >((currentState, event) => {
+      if (event.type === "shopping-cart-opened") {
+        if (currentState != null) throw ShoppingCartErrors.OPENED_EXISTING_CART;
+        return {
+          id: event.data.shoppingCartId,
+          clientId: event.data.clientId,
+          openedAt: new Date(event.data.openedAt),
+          productItems: new Map(),
+          status: ShoppingCartStatus.Opened,
+        };
+      }
+
+      if (currentState == null) throw ShoppingCartErrors.CART_NOT_FOUND;
+
+      switch (event.type) {
+        case "product-item-added-to-shopping-cart":
+          return {
+            ...currentState,
+            productItems: addProductItem(
+              currentState.productItems,
+              event.data.productItem
+            ),
+          };
+        case "product-item-removed-from-shopping-cart":
+          return {
+            ...currentState,
+            productItems: removeProductItem(
+              currentState.productItems,
+              event.data.productItem
+            ),
+          };
+        case "shopping-cart-confirmed":
+          return {
+            ...currentState,
+            status: ShoppingCartStatus.Confirmed,
+            confirmedAt: new Date(event.data.confirmedAt),
+          };
+        default: {
+          const _: never = event;
+          throw ShoppingCartErrors.UNKNOWN_EVENT_TYPE;
+        }
+      }
+    });
+
+    const enum ProductsIds {
+      T_SHIRT = "team-building-excercise-2022",
+      SHOES = "air-jordan",
+    }
+
+    const clientId = "client_123";
+    const shoppingCartId = "cart_456";
+    const events: ShoppingCartEvent[] = [
+      {
+        type: "shopping-cart-opened",
+        data: {
+          shoppingCartId,
+          clientId,
+          openedAt: new Date().toJSON(),
+        },
+      },
+      {
+        type: "product-item-added-to-shopping-cart",
+        data: {
+          shoppingCartId,
+          productItem: {
+            productId: ProductsIds.SHOES,
+            quantity: 100,
+          },
+        },
+      },
+      {
+        type: "product-item-added-to-shopping-cart",
+        data: {
+          shoppingCartId,
+          productItem: {
+            productId: ProductsIds.T_SHIRT,
+            quantity: 1,
+          },
+        },
+      },
+      {
+        type: "product-item-removed-from-shopping-cart",
+        data: {
+          shoppingCartId,
+          productItem: {
+            productId: ProductsIds.SHOES,
+            quantity: 100,
+          },
+        },
+      },
+      {
+        type: "product-item-added-to-shopping-cart",
+        data: {
+          shoppingCartId,
+          productItem: {
+            productId: ProductsIds.T_SHIRT,
+            quantity: 1,
+          },
+        },
+      },
+      {
+        type: "shopping-cart-confirmed",
+        data: {
+          shoppingCartId,
+          confirmedAt: new Date().toJSON(),
+        },
+      },
+    ];
+
+    const jsonEvents = events.map((e) => jsonEvent<ShoppingCartEvent>(e));
+
+    await client.appendToStream<ShoppingCartEvent>(
+      `shoppingcart-${shoppingCartId}`,
+      jsonEvents
+    );
+
+    const shoppingCartStream = client.readStream<ShoppingCartEvent>(
+      `shoppingcart-${shoppingCartId}`
+    );
+
+    const cart = await shoppingCartAggregator(shoppingCartStream);
+
+    expect(cart).toMatchObject({
+      id: shoppingCartId,
+      clientId,
+      openedAt: expect.any(Date),
+      status: ShoppingCartStatus.Confirmed,
+      confirmedAt: expect.any(Date),
+    });
+
+    expect(Array.from(cart.productItems)).toEqual([
+      [ProductsIds.T_SHIRT, { productId: ProductsIds.T_SHIRT, quantity: 2 }],
+    ]);
+  });
+});

--- a/src/events/binaryEvent.ts
+++ b/src/events/binaryEvent.ts
@@ -1,49 +1,28 @@
 import { v4 as uuid } from "uuid";
-import { BinaryEventData, BinaryEventType, MetadataType } from "../types";
+import { BinaryEventType, EventData } from "../types";
 import { convertMetadata } from "./convertMetadata";
 
-// https://github.com/Microsoft/TypeScript/issues/12400
-type OptionalMetadata<E extends BinaryEventType> =
-  E["metadata"] extends MetadataType
-    ? {
-        /**
-         * The metadata of the event.
-         */
-        metadata: E["metadata"];
-      }
-    : {
-        /**
-         * The metadata of the event.
-         */
-        metadata?: E["metadata"];
-      };
-
-export type BinaryEventOptions<E extends BinaryEventType> = {
+export type BinaryEventOptions<E extends BinaryEventType> = E & {
   /**
    * The id to this event. By default, the id will be generated.
    */
   id?: string;
   /**
-   * The event type.
-   */
-  type: E["type"];
-  /**
    * The binary data of the event.
    */
   data: Uint8Array | Buffer;
-} & OptionalMetadata<E>;
+};
 
 export const binaryEvent = <E extends BinaryEventType = BinaryEventType>({
   type,
   data,
   metadata,
   id = uuid(),
-}: BinaryEventOptions<E>): BinaryEventData<E> => ({
-  id,
-  contentType: "application/octet-stream",
-  type,
-  data: Uint8Array.from(data),
-  metadata: convertMetadata<E["metadata"]>(
-    metadata
-  ) as BinaryEventData<E>["metadata"],
-});
+}: BinaryEventOptions<E>): EventData<E> =>
+  ({
+    id,
+    contentType: "application/octet-stream",
+    type,
+    data: Uint8Array.from(data),
+    metadata: convertMetadata<E["metadata"]>(metadata),
+  } as EventData<E>);

--- a/src/events/jsonEvent.ts
+++ b/src/events/jsonEvent.ts
@@ -1,49 +1,24 @@
 import { v4 as uuid } from "uuid";
-import { JSONEventData, JSONEventType, MetadataType } from "../types";
+import { EventData, JSONEventType } from "../types";
 import { convertMetadata } from "./convertMetadata";
-
-// https://github.com/Microsoft/TypeScript/issues/12400
-type OptionalMetadata<E extends JSONEventType> =
-  E["metadata"] extends MetadataType
-    ? {
-        /**
-         * The metadata of the event.
-         */
-        metadata: E["metadata"];
-      }
-    : {
-        /**
-         * The metadata of the event.
-         */
-        metadata?: E["metadata"];
-      };
 
 export type JSONEventOptions<E extends JSONEventType> = {
   /**
    * The id to this event. By default, the id will be generated.
    */
   id?: string;
-  /**
-   * The event type.
-   */
-  type: E["type"];
-  /**
-   * The data of the event.
-   */
-  data: E["data"];
-} & OptionalMetadata<E>;
+} & E;
 
 export const jsonEvent = <E extends JSONEventType>({
   type,
   data,
   metadata,
   id = uuid(),
-}: JSONEventOptions<E>): JSONEventData<E> => ({
-  id,
-  contentType: "application/json",
-  type,
-  data: data as JSONEventData<E>["data"],
-  metadata: convertMetadata<E["metadata"]>(
-    metadata
-  ) as JSONEventData<E>["metadata"],
-});
+}: JSONEventOptions<E>): EventData<E> =>
+  ({
+    id,
+    contentType: "application/json",
+    type,
+    data: data,
+    metadata: convertMetadata<E["metadata"]>(metadata),
+  } as EventData<E>);

--- a/src/streams/appendToStream/index.ts
+++ b/src/streams/appendToStream/index.ts
@@ -7,6 +7,7 @@ import {
   AppendResult,
   AppendExpectedRevision,
   EventData,
+  EventType,
 } from "../../types";
 
 import { append } from "./append";
@@ -38,18 +39,20 @@ declare module "../../Client" {
      * @param events Events or event to write.
      * @param options Writing options.
      */
-    appendToStream(
+    appendToStream<KnownEventType extends EventType = EventType>(
       streamName: string,
-      events: EventData | EventData[],
+      events: EventData<KnownEventType> | EventData<KnownEventType>[],
       options?: AppendToStreamOptions
     ): Promise<AppendResult>;
   }
 }
 
-Client.prototype.appendToStream = async function (
+Client.prototype.appendToStream = async function <
+  KnownEventType extends EventType = EventType
+>(
   this: Client,
   streamName: string,
-  event: EventData | EventData[],
+  event: EventData<KnownEventType> | EventData<KnownEventType>[],
   {
     expectedRevision = ANY,
     batchAppendSize = 3 * 1024 * 1024,


### PR DESCRIPTION
## Allow skipping metadata key in `EventType`

Previously, to use `JSONEventType` or `BinaryEventType` you would have to provide a metadata key, event if you typed it as `unknown` or `never`.

### Before:

```typescript
type MyEvent = JSONEventType<"my-event", { some: string }>;

// Property 'metadata' is missing in type '{ type: "my-event"; data: { some: string; }; }' but required in type 'JSONEventType<"my-event", { some: string; }, unknown>'.ts(2741)
const myEventData: MyEvent = {
    type: "my-event",
    { some: "data" }
}
```

### After:

```typescript
type MyEvent = JSONEventType<"my-event", { some: string }>;

const myEventData: MyEvent = {
    type: "my-event",
    { some: "data" }
}
```

## Retain ability to descriminate event type unions after converting types

Previously, if you had a union of event types, you would lose the ability it descriminate them after converting them to `EventData` or a `RecordedEvent` due to typescript combining them into an intersection of the types.

### Before:

```typescript
type MyFirstEvent = JSONEventType<
  "my-first-type",
  { some: string; other: string }
>;
type MySecondEvent = JSONEventType<
  "my-second-event",
  { other: string; another: boolean }
>;

type MyEvents = MyFirstEvent | MySecondEvent;
```

We can descriminate based on the `type` key.

```typescript
const descriminateType = (eventData: MyEvents) => {
  if (eventData.type === "my-first-type") {
    // { some: string; other: string; }
    eventData.data;
  } else {
    //  { other: string; another: boolean }
    eventData.data;
  }
};
```

However, this breaks down when `MyEvents` is passed directly to `JSONEventData` or a `JSONRecordedEvent`.

```typescript
const descriminateType = (eventData: JSONRecordedEvent<MyEvents>) => {
  if (eventData.type === "my-first-type") {
    // { some: string; other: string; } | { other: string; another: boolean }
    eventData.data;
  } else {
    // { some: string; other: string; } | { other: string; another: boolean }
    eventData.data;
  }
};
```

You would have to use the helper type `EventTypeToRecordedEvent` to retain correct descrimination.

```typescript
const descriminateType = (eventData: EventTypeToRecordedEvent<MyEvents>) => {
  if (eventData.type === "my-first-type") {
    // { some: string; other: string; }
    eventData.data;
  } else {
    // { other: string; another: boolean }
    eventData.data;
  }
};
```

### After:

You can now pass your union directly to `JSONRecordedEvent`, `BinaryRecordedEvent` or the now generic `RecordedEvent` without losing the ability to descriminate the union:

```typescript
const descriminateType = (eventData: RecordedEvent<MyEvents>) => {
  if (eventData.type === "my-first-type") {
    // { some: string; other: string; }
    eventData.data;
  } else {
    // { other: string; another: boolean }
    eventData.data;
  }
};
```

All converter types (`EventTypeToRecordedEvent`, `RecordedEventToEventType`, `EventTypeToEventData`, `EventDataToEventType`, `RecordedEventToEventData`, `EventDataToRecordedEvent`) are still available.


## Allow enforcing types on `appendToStream`

You can now enforce the types you append to a stream:

``` typescript
await client.appendToStream<MyEvents>(
    `my_stream`,
    jsonEvents
);
```