### PR TITLE
Expose `Options` types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import "./persistentSubscription";
-import "./projections";
-import "./streams";
+export * from "./persistentSubscription";
+export * from "./projections";
+export * from "./streams";
 
 export {
   Client as EventStoreDBClient,

--- a/src/streams/appendToStream/append.ts
+++ b/src/streams/appendToStream/append.ts
@@ -14,16 +14,17 @@ import {
   createStreamIdentifier,
   createUUID,
   debug,
+  InternalOptions,
   WrongExpectedVersionError,
 } from "../../utils";
 
-import type { InternalAppendToStreamOptions } from ".";
+import type { AppendToStreamOptions } from ".";
 
 export const append = async function (
   this: Client,
   streamName: string,
   events: EventData[],
-  { expectedRevision, ...baseOptions }: InternalAppendToStreamOptions
+  { expectedRevision, ...baseOptions }: InternalOptions<AppendToStreamOptions>
 ): Promise<AppendResult> {
   const header = new AppendReq();
   const options = new AppendReq.Options();

--- a/src/streams/appendToStream/batchAppend.ts
+++ b/src/streams/appendToStream/batchAppend.ts
@@ -14,13 +14,15 @@ import {
   convertToCommandError,
   backpressuredWrite,
   createStreamIdentifier,
+  InternalOptions,
 } from "../../utils";
 
 import {
   unpackToCommandError,
   unpackWrongExpectedVersion,
 } from "./unpackError";
-import type { InternalAppendToStreamOptions } from ".";
+
+import type { AppendToStreamOptions } from ".";
 
 const streamCache = new WeakMap<
   StreamsClient,
@@ -40,7 +42,7 @@ export const batchAppend = async function (
     expectedRevision,
     batchAppendSize,
     ...baseOptions
-  }: InternalAppendToStreamOptions
+  }: InternalOptions<AppendToStreamOptions>
 ): Promise<AppendResult> {
   const correlationId = uuid();
 

--- a/src/streams/appendToStream/index.ts
+++ b/src/streams/appendToStream/index.ts
@@ -26,11 +26,6 @@ export interface AppendToStreamOptions extends BaseOptions {
   batchAppendSize?: number;
 }
 
-export type InternalAppendToStreamOptions = Required<
-  Omit<AppendToStreamOptions, keyof BaseOptions>
-> &
-  BaseOptions;
-
 declare module "../../Client" {
   interface Client {
     /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from "./debug";
 export * from "./filter";
 export * from "./grpcStreamIdentifier";
 export * from "./grpcUUID";
+export * from "./utilityTypes";

--- a/src/utils/utilityTypes.ts
+++ b/src/utils/utilityTypes.ts
@@ -1,0 +1,6 @@
+import type { BaseOptions } from "../types";
+
+export type InternalOptions<T extends BaseOptions> = Required<
+  Omit<T, keyof BaseOptions>
+> &
+  BaseOptions;


### PR DESCRIPTION
- Export method directories to expose options types.
- Add `InternalOptions` type to remove the need for `appendToStream` internal options type. (so it isn't exported).


![image](https://user-images.githubusercontent.com/11861797/155305175-204e263b-21e8-463d-9411-57f91a76ebfd.png)
