### PR TITLE
Close channels when they fail

### DIFF
--- a/src/Client/discovery.ts
+++ b/src/Client/discovery.ts
@@ -164,6 +164,9 @@ function listClusterMembers(
 
   return new Promise((resolve, reject) => {
     client.read(new Empty(), new Metadata(), { deadline }, (error, info) => {
+      // regardless of the outcome, we are done with this client.
+      client.close();
+
       if (error) return reject(error);
 
       const members: MemberInfo[] = [];

--- a/src/Client/index.ts
+++ b/src/Client/index.ts
@@ -486,6 +486,7 @@ export class Client {
 
     const [_protocol, address, port] = failedChannel.getTarget().split(":");
 
+    failedChannel.close();
     this.#grpcClients.clear();
     this.#channel = undefined;
     this.#serverFeatures = undefined;


### PR DESCRIPTION
`@grpc/js` keeps a reference to all open channels, calling close causes it to drop this reference.

![image](https://user-images.githubusercontent.com/11861797/161250901-b91e1fbb-930b-4f25-bbb6-3ebf1d02fa6c.png)

Test code:
<details>
  <summary>memory_3.mjs</summary>
  
```js
import { EventStoreDBClient } from "@eventstore/db-client";
import { finished } from "stream";

const client = new EventStoreDBClient(
  {
    endpoint: "localhost:2113",
  },
  {
    insecure: true,
  }
);

const logMem = () => {
  console.log(
    Math.round((process.memoryUsage().heapUsed / 1024 / 1024) * 100) / 100
  );
};

async function backoffConnect(maxRetries) {
  let i = 0;
  while (i++ <= maxRetries) {
    try {
      await new Promise((resolve, reject) => {
        finished(
          client.subscribeToPersistentSubscriptionToStream("demo", "demo", {
            bufferSize: 1,
          }),
          (err) => {
            if (err) return reject(err);
            return resolve();
          }
        );
      });
    } catch (error) {
      //
    }

    global.gc();
    logMem();
  }
}

try {
  await backoffConnect(50000);
} catch (error) {
  // it failed :(
}

global.gc();
logMem();
```
</details> 

fixes: #289 