### PR TITLE
Add `retryCount` to persistent subscription events

### DIFF
--- a/samples/persistent-subscriptions.ts
+++ b/samples/persistent-subscriptions.ts
@@ -94,6 +94,9 @@ describe("[sample] persistent-subscriptions", () => {
     try {
       for await (const event of subscription) {
         try {
+          console.log(
+            `handling event ${event.event?.type} with retryCount ${event.retryCount}`
+          );
           await handleEvent(event);
           await subscription.ack(event);
         } catch (error) {
@@ -153,6 +156,9 @@ describe("[sample] persistent-subscriptions", () => {
 
       try {
         for await (const event of subscription) {
+          console.log(
+            `handling event ${event.event?.type} with retryCount ${event.retryCount}`
+          );
           await handleEvent(event);
           await subscription.ack(event);
         }
@@ -197,6 +203,9 @@ describe("[sample] persistent-subscriptions", () => {
     try {
       for await (const event of subscription) {
         try {
+          console.log(
+            `handling event ${event.event?.type} with retryCount ${event.retryCount}`
+          );
           await handleEvent(event);
           await subscription.ack(event);
         } catch (error) {

--- a/src/persistentSubscription/subscribeToPersistentSubscriptionToAll.ts
+++ b/src/persistentSubscription/subscribeToPersistentSubscriptionToAll.ts
@@ -8,7 +8,11 @@ import {
 } from "../../generated/persistent_grpc_pb";
 
 import type { BaseOptions, PersistentSubscriptionToAll } from "../types";
-import { convertAllStreamGrpcEvent, debug, UnsupportedError } from "../utils";
+import {
+  convertPersistentSubscriptionToAllGrpcEvent,
+  debug,
+  UnsupportedError,
+} from "../utils";
 import { Client } from "../Client";
 import { PersistentSubscriptionImpl } from "./utils/PersistentSubscriptionImpl";
 
@@ -89,7 +93,7 @@ Client.prototype.subscribeToPersistentSubscriptionToAll = function (
         return stream;
       }
     ),
-    convertAllStreamGrpcEvent,
+    convertPersistentSubscriptionToAllGrpcEvent,
     duplexOptions
   );
 };

--- a/src/persistentSubscription/subscribeToPersistentSubscriptionToStream.ts
+++ b/src/persistentSubscription/subscribeToPersistentSubscriptionToStream.ts
@@ -9,7 +9,11 @@ import type {
   BaseOptions,
   EventType,
 } from "../types";
-import { debug, convertGrpcEvent, createStreamIdentifier } from "../utils";
+import {
+  debug,
+  convertPersistentSubscriptionToStreamGrpcEvent,
+  createStreamIdentifier,
+} from "../utils";
 import { Client } from "../Client";
 import { PersistentSubscriptionImpl } from "./utils/PersistentSubscriptionImpl";
 
@@ -104,7 +108,7 @@ Client.prototype.subscribeToPersistentSubscriptionToStream = function <
         return stream;
       }
     ),
-    convertGrpcEvent,
+    convertPersistentSubscriptionToStreamGrpcEvent,
     duplexOptions
   );
 };

--- a/src/persistentSubscription/utils/PersistentSubscriptionImpl.ts
+++ b/src/persistentSubscription/utils/PersistentSubscriptionImpl.ts
@@ -23,11 +23,11 @@ export class PersistentSubscriptionImpl<E>
   implements PersistentSubscriptionBase<E>
 {
   #grpcStream: Promise<ClientDuplexStream<ReadReq, ReadResp>>;
-  #convertGrpcEvent: ConvertGrpcEvent<E>;
+  #convertGrpcEvent: ConvertGrpcEvent<ReadResp.ReadEvent, E>;
 
   constructor(
     createGRPCStream: CreateGRPCStream,
-    convertGrpcEvent: ConvertGrpcEvent<E>,
+    convertGrpcEvent: ConvertGrpcEvent<ReadResp.ReadEvent, E>,
     options: TransformOptions
   ) {
     super({ ...options, objectMode: true });

--- a/src/streams/utils/ReadStream.ts
+++ b/src/streams/utils/ReadStream.ts
@@ -15,12 +15,12 @@ import {
 type CreateGRPCStream = () => Promise<ClientReadableStream<ReadResp>>;
 
 export class ReadStream<E> extends Transform implements StreamingRead<E> {
-  #convertGrpcEvent: ConvertGrpcEvent<E>;
+  #convertGrpcEvent: ConvertGrpcEvent<ReadResp.ReadEvent, E>;
   #grpcStream: Promise<ClientReadableStream<ReadResp>>;
 
   constructor(
     createGRPCStream: CreateGRPCStream,
-    convertGrpcEvent: ConvertGrpcEvent<E>,
+    convertGrpcEvent: ConvertGrpcEvent<ReadResp.ReadEvent, E>,
     options: TransformOptions
   ) {
     super({ ...options, objectMode: true });

--- a/src/streams/utils/Subscription.ts
+++ b/src/streams/utils/Subscription.ts
@@ -14,13 +14,13 @@ export class Subscription<E>
   extends Transform
   implements ReadableSubscription<E>
 {
-  #convertGrpcEvent: ConvertGrpcEvent<E>;
+  #convertGrpcEvent: ConvertGrpcEvent<ReadResp.ReadEvent, E>;
   #grpcStream: Promise<ClientReadableStream<ReadResp>>;
   #checkpointReached?: Filter["checkpointReached"];
 
   constructor(
     createGRPCStream: CreateGRPCStream,
-    convertGrpcEvent: ConvertGrpcEvent<E>,
+    convertGrpcEvent: ConvertGrpcEvent<ReadResp.ReadEvent, E>,
     options: TransformOptions,
     checkpointReached?: Filter["checkpointReached"]
   ) {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -176,7 +176,7 @@ export interface ResolvedEvent<Event extends EventType = EventType> {
 }
 
 /**
- * A structure representing a single event or an resolved link event.
+ * A structure representing a single event or a resolved link event from a persistent subscription to a stream.
  */
 export interface PersistentSubscriptionToStreamResolvedEvent<
   Event extends EventType = EventType
@@ -208,7 +208,7 @@ export interface AllStreamResolvedEvent {
 }
 
 /**
- * A structure representing a single event or an resolved link event.
+ * A structure representing a single event or a resolved link event from a persistent subscription to $all.
  */
 export interface PersistentSubscriptionToAllResolvedEvent
   extends AllStreamResolvedEvent {

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -178,6 +178,18 @@ export interface ResolvedEvent<Event extends EventType = EventType> {
 /**
  * A structure representing a single event or an resolved link event.
  */
+export interface PersistentSubscriptionToStreamResolvedEvent<
+  Event extends EventType = EventType
+> extends ResolvedEvent<Event> {
+  /**
+   * The number of times this event has been retried.
+   */
+  retryCount: number;
+}
+
+/**
+ * A structure representing a single event or an resolved link event.
+ */
 export interface AllStreamResolvedEvent {
   /**
    * The event, or the resolved link event if this {@link ResolvedEvent} is a link event.
@@ -193,6 +205,17 @@ export interface AllStreamResolvedEvent {
    * Commit position of the record.
    */
   commitPosition?: bigint;
+}
+
+/**
+ * A structure representing a single event or an resolved link event.
+ */
+export interface PersistentSubscriptionToAllResolvedEvent
+  extends AllStreamResolvedEvent {
+  /**
+   * The number of times this event has been retried.
+   */
+  retryCount: number;
 }
 
 export type EventTypeToRecordedEvent<T extends EventType> =

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,8 @@ import type {
   ResolvedEvent,
   AllStreamResolvedEvent,
   EventType,
+  PersistentSubscriptionToAllResolvedEvent,
+  PersistentSubscriptionToStreamResolvedEvent,
 } from "./events";
 
 import type * as constants from "../constants";
@@ -458,22 +460,26 @@ export interface PersistentSubscriptionBase<E> extends ReadableSubscription<E> {
   /**
    * Acknowledge events as handled.
    */
-  ack(...events: E[]): Promise<void>;
+  ack(...events: ResolvedEvent[]): Promise<void>;
 
   /**
    * "Not Acknowledge" the event.
    */
-  nack(action: PersistentAction, reason: string, ...events: E[]): Promise<void>;
+  nack(
+    action: PersistentAction,
+    reason: string,
+    ...events: ResolvedEvent[]
+  ): Promise<void>;
 }
 
 export type PersistentSubscriptionToStream<E extends EventType = EventType> =
-  PersistentSubscriptionBase<ResolvedEvent<E>>;
+  PersistentSubscriptionBase<PersistentSubscriptionToStreamResolvedEvent<E>>;
 /**
  * @deprecated Renamed to {@link PersistentSubscriptionToStream}.
  */
 export type PersistentSubscription = PersistentSubscriptionToStream;
 export type PersistentSubscriptionToAll =
-  PersistentSubscriptionBase<AllStreamResolvedEvent>;
+  PersistentSubscriptionBase<PersistentSubscriptionToAllResolvedEvent>;
 
 export type StreamSubscription<E extends EventType = EventType> =
   ReadableSubscription<ResolvedEvent<E>>;


### PR DESCRIPTION
- Add `PersistentSubscriptionToStreamResolvedEvent` and `PersistentSubscriptionToAllResolvedEvent` types
- Update `PersistentSubscriptionToStream` and `PersistentSubscriptionToAll` types
- Split apart event converter function types
- Add converters for persistent subscritions
- Use new types in `ReadStream`, `Subscription`, and `PersistentSubscriptionImpl`
- Use new converters in `subscribeToPersistentSubscriptionToStream` and `subscribeToPersistentSubscriptionToAll`
- Add tests for `retryCount` in `subscribeToPersistentSubscriptionToStream` and `subscribeToPersistentSubscriptionToAll`
- Update samples to show `retryCount`