### PR TITLE
Incorrect type for acl in stream metadata

### DIFF
--- a/src/__test__/streams/setStreamMetadata.test.ts
+++ b/src/__test__/streams/setStreamMetadata.test.ts
@@ -3,7 +3,6 @@ import {
   EventStoreDBClient,
   StreamMetadata,
   START,
-  SYSTEM_STREAM_ACL,
 } from "@eventstore/db-client";
 
 describe("setStreamMetadata", () => {
@@ -118,22 +117,6 @@ describe("setStreamMetadata", () => {
 
       expect(warnSpy.mock.calls).toHaveLength(1);
       warnSpy.mockRestore();
-    });
-
-    test("string acls", async () => {
-      const STREAM_NAME = "string_acls";
-
-      const metadata: StreamMetadata = {
-        acl: SYSTEM_STREAM_ACL,
-      };
-
-      await client.setStreamMetadata(STREAM_NAME, metadata);
-
-      const { metadata: readMetadata } = await client.getStreamMetadata(
-        STREAM_NAME
-      );
-
-      expect(readMetadata!.acl).toEqual(SYSTEM_STREAM_ACL);
     });
 
     test("metadata goes to the right place", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export * from "./types";
 export * from "./utils/filter";
 export * from "./utils/CommandError";
 
-export type { StreamMetadata } from "./streams/utils/streamMetadata";
+export type { StreamMetadata, StreamACL } from "./streams/utils/streamMetadata";
 export * from "./streams/utils/systemStreams";
 export {
   PersistentSubscriptionSettings,

--- a/src/streams/utils/streamMetadata.ts
+++ b/src/streams/utils/streamMetadata.ts
@@ -1,9 +1,4 @@
-import type {
-  END,
-  START,
-  SYSTEM_STREAM_ACL,
-  USER_STREAM_ACL,
-} from "../../constants";
+import type { END, START } from "../../constants";
 
 const MAX_AGE = "$maxAge";
 const MAX_COUNT = "$maxCount";
@@ -67,7 +62,7 @@ export interface SystemStreamMetadata {
   /**
    * The optional ACL for the stream.
    */
-  acl?: typeof USER_STREAM_ACL | typeof SYSTEM_STREAM_ACL | StreamACL;
+  acl?: StreamACL;
 
   /**
    * The optional maximum number of events allowed in the stream.


### PR DESCRIPTION
ACL is incorrectly typed in `StreamMetadata`