### PR TITLE
Add `emitEnabled` option to `createProjection`

### DIFF
--- a/generated/projections_pb.d.ts
+++ b/generated/projections_pb.d.ts
@@ -94,6 +94,8 @@ export namespace CreateReq {
         export class Continuous extends jspb.Message { 
             getName(): string;
             setName(value: string): Continuous;
+            getEmitEnabled(): boolean;
+            setEmitEnabled(value: boolean): Continuous;
             getTrackEmittedStreams(): boolean;
             setTrackEmittedStreams(value: boolean): Continuous;
 
@@ -110,6 +112,7 @@ export namespace CreateReq {
         export namespace Continuous {
             export type AsObject = {
                 name: string,
+                emitEnabled: boolean,
                 trackEmittedStreams: boolean,
             }
         }

--- a/generated/projections_pb.js
+++ b/generated/projections_pb.js
@@ -1140,7 +1140,8 @@ proto.event_store.client.projections.CreateReq.Options.Continuous.prototype.toOb
 proto.event_store.client.projections.CreateReq.Options.Continuous.toObject = function(includeInstance, msg) {
   var f, obj = {
     name: jspb.Message.getFieldWithDefault(msg, 1, ""),
-    trackEmittedStreams: jspb.Message.getBooleanFieldWithDefault(msg, 2, false)
+    emitEnabled: jspb.Message.getBooleanFieldWithDefault(msg, 2, false),
+    trackEmittedStreams: jspb.Message.getBooleanFieldWithDefault(msg, 3, false)
   };
 
   if (includeInstance) {
@@ -1183,6 +1184,10 @@ proto.event_store.client.projections.CreateReq.Options.Continuous.deserializeBin
       break;
     case 2:
       var value = /** @type {boolean} */ (reader.readBool());
+      msg.setEmitEnabled(value);
+      break;
+    case 3:
+      var value = /** @type {boolean} */ (reader.readBool());
       msg.setTrackEmittedStreams(value);
       break;
     default:
@@ -1221,10 +1226,17 @@ proto.event_store.client.projections.CreateReq.Options.Continuous.serializeBinar
       f
     );
   }
-  f = message.getTrackEmittedStreams();
+  f = message.getEmitEnabled();
   if (f) {
     writer.writeBool(
       2,
+      f
+    );
+  }
+  f = message.getTrackEmittedStreams();
+  if (f) {
+    writer.writeBool(
+      3,
       f
     );
   }
@@ -1250,10 +1262,10 @@ proto.event_store.client.projections.CreateReq.Options.Continuous.prototype.setN
 
 
 /**
- * optional bool track_emitted_streams = 2;
+ * optional bool emit_enabled = 2;
  * @return {boolean}
  */
-proto.event_store.client.projections.CreateReq.Options.Continuous.prototype.getTrackEmittedStreams = function() {
+proto.event_store.client.projections.CreateReq.Options.Continuous.prototype.getEmitEnabled = function() {
   return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 2, false));
 };
 
@@ -1262,8 +1274,26 @@ proto.event_store.client.projections.CreateReq.Options.Continuous.prototype.getT
  * @param {boolean} value
  * @return {!proto.event_store.client.projections.CreateReq.Options.Continuous} returns this
  */
-proto.event_store.client.projections.CreateReq.Options.Continuous.prototype.setTrackEmittedStreams = function(value) {
+proto.event_store.client.projections.CreateReq.Options.Continuous.prototype.setEmitEnabled = function(value) {
   return jspb.Message.setProto3BooleanField(this, 2, value);
+};
+
+
+/**
+ * optional bool track_emitted_streams = 3;
+ * @return {boolean}
+ */
+proto.event_store.client.projections.CreateReq.Options.Continuous.prototype.getTrackEmittedStreams = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 3, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.event_store.client.projections.CreateReq.Options.Continuous} returns this
+ */
+proto.event_store.client.projections.CreateReq.Options.Continuous.prototype.setTrackEmittedStreams = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 3, value);
 };
 
 

--- a/protos/projections.proto
+++ b/protos/projections.proto
@@ -34,7 +34,8 @@ message CreateReq {
 		}
 		message Continuous {
 			string name = 1;
-			bool track_emitted_streams = 2;
+			bool emit_enabled = 2;
+			bool track_emitted_streams = 3;
 		}
 	}
 }

--- a/src/__test__/extra/oversize-event.test.ts
+++ b/src/__test__/extra/oversize-event.test.ts
@@ -54,7 +54,7 @@ describe("oversize events", () => {
 `;
 
     await client.createProjection(PROJECTION_NAME, projection, {
-      trackEmittedStreams: true,
+      emitEnabled: true,
     });
 
     // give it a chance to get up and running

--- a/src/__test__/projections/createProjection.test.ts
+++ b/src/__test__/projections/createProjection.test.ts
@@ -1,6 +1,10 @@
-import { createTestNode } from "@test-utils";
+import { collect, createTestNode, delay } from "@test-utils";
 
-import { EventStoreDBClient } from "@eventstore/db-client";
+import {
+  EventStoreDBClient,
+  jsonEvent,
+  StreamNotFoundError,
+} from "@eventstore/db-client";
 
 describe("createProjection", () => {
   const node = createTestNode();
@@ -19,8 +23,8 @@ describe("createProjection", () => {
     await node.down();
   });
 
-  test("track emitted streams", async () => {
-    const PROJECTION_NAME = "track and field";
+  test("defaults", async () => {
+    const PROJECTION_NAME = "defaults";
 
     await expect(
       client.createProjection(
@@ -32,29 +36,90 @@ describe("createProjection", () => {
               return {};
             }
           });
-        `,
-        {
-          trackEmittedStreams: true,
-        }
+        `
       )
     ).resolves.toBeUndefined();
   });
 
-  test("do not track", async () => {
-    const PROJECTION_NAME = "do not track";
-    await expect(
-      client.createProjection(
-        PROJECTION_NAME,
-        `
-        fromAll()
-          .when({
-            $init: function (state, ev) {
-              return {};
-            }
-          });
-        `,
-        { trackEmittedStreams: false }
-      )
-    ).resolves.toBeUndefined();
+  test("emitEnabled", async () => {
+    const PROJECTION_NAME = "emit";
+    const STREAM_NAME = "emit";
+    const EVENT_TYPE = "emit_this";
+    const EMIT_STREAMNAME = "emit_emitted";
+    const EMIT_EVENT_TYPE = "emitted_this";
+    const projection = `
+      fromStream("${STREAM_NAME}")
+        .when({
+          ${EVENT_TYPE}(state, event) {
+            emit("${EMIT_STREAMNAME}", "${EMIT_EVENT_TYPE}", {}, {});
+          }
+        });
+    `;
+
+    await client.createProjection(PROJECTION_NAME, projection, {
+      emitEnabled: true,
+    });
+
+    await client.appendToStream(
+      STREAM_NAME,
+      jsonEvent({ type: EVENT_TYPE, data: "anything" })
+    );
+
+    await delay(500);
+
+    const [emitted] = await collect(client.readStream(EMIT_STREAMNAME));
+
+    expect(emitted).toBeDefined();
+    expect(emitted.event?.type).toBe(EMIT_EVENT_TYPE);
+
+    try {
+      for await (const e of client.readStream(
+        `$projections-${PROJECTION_NAME}-emittedstreams`
+      )) {
+        expect(e).toBe("UNREACHABLE");
+      }
+    } catch (error) {
+      expect(error).toBeInstanceOf(StreamNotFoundError);
+    }
+  });
+
+  test("trackEmittedStreams", async () => {
+    const PROJECTION_NAME = "track_and_field";
+    const STREAM_NAME = "track_and_field";
+    const EVENT_TYPE = "emit_this";
+    const EMIT_STREAMNAME = "track_and_field_emitted";
+    const EMIT_EVENT_TYPE = "emitted_this";
+    const projection = `
+      fromStream("${STREAM_NAME}")
+        .when({
+          ${EVENT_TYPE}(state, event) {
+            emit("${EMIT_STREAMNAME}", "${EMIT_EVENT_TYPE}", {}, {});
+          }
+        });
+    `;
+
+    await client.createProjection(PROJECTION_NAME, projection, {
+      emitEnabled: true,
+      trackEmittedStreams: true,
+    });
+
+    await client.appendToStream(
+      STREAM_NAME,
+      jsonEvent({ type: EVENT_TYPE, data: "anything" })
+    );
+
+    await delay(500);
+
+    const [emitted] = await collect(client.readStream(EMIT_STREAMNAME));
+
+    expect(emitted).toBeDefined();
+    expect(emitted.event?.type).toBe(EMIT_EVENT_TYPE);
+
+    const [emittedStream] = await collect(
+      client.readStream(`$projections-${PROJECTION_NAME}-emittedstreams`)
+    );
+
+    expect(emittedStream).toBeDefined();
+    expect(emittedStream.event?.type).toBe("$StreamTracked");
   });
 });

--- a/src/__test__/projections/getProjectionResult.test.ts
+++ b/src/__test__/projections/getProjectionResult.test.ts
@@ -112,7 +112,7 @@ describe("getProjectionResult", () => {
       await client.createProjection(
         PARTITION_PROJECTION_NAME,
         paritionProjection,
-        { trackEmittedStreams: true }
+        { emitEnabled: true }
       );
 
       const partitionStats = await client.getProjectionStatistics(

--- a/src/__test__/projections/getProjectionState.test.ts
+++ b/src/__test__/projections/getProjectionState.test.ts
@@ -110,7 +110,7 @@ describe("getProjectionState", () => {
       await client.createProjection(
         PARTITION_PROJECTION_NAME,
         paritionProjection,
-        { trackEmittedStreams: true }
+        { emitEnabled: true }
       );
 
       const partitionStats = await client.getProjectionStatistics(

--- a/src/__test__/streams/readAll.test.ts
+++ b/src/__test__/streams/readAll.test.ts
@@ -110,7 +110,7 @@ describe("readAll", () => {
             linkTo('a-' + ev.data.some, ev)
           }
         });`,
-        { trackEmittedStreams: true }
+        { emitEnabled: true }
       );
 
       // Append an event that will be linked

--- a/src/__test__/streams/readStream.test.ts
+++ b/src/__test__/streams/readStream.test.ts
@@ -164,7 +164,7 @@ describe("readStream", () => {
               linkTo('a-' + ev.data.some, ev)
             }
           });`,
-          { trackEmittedStreams: true }
+          { emitEnabled: true }
         );
 
         // Append an event that will be linked


### PR DESCRIPTION
Due to a bug on the server, previously, the `trackEmittedStreams` option was setting `emitEnabled`, and not `trackEmittedStreams`
This change adds the `emitEnabled` option, corrects the behaviour of `trackEmittedStreams`, with a polyfill for earlier server versions.

- Update projections proto to latest
- Add `emitEnabled` option
- Add HTTP polyfill for `trackEmittedStreams`
- Apply breaking change to existing tests
- Add more, and better tests for `createProjection`

fix: #303 