### PR TITLE
Destroy read stream if stream is not found

### DIFF
--- a/src/streams/utils/ReadStream.ts
+++ b/src/streams/utils/ReadStream.ts
@@ -50,14 +50,16 @@ export class ReadStream<E> extends Transform implements StreamingRead<E> {
 
     if (resp.hasStreamNotFound?.()) {
       const streamNotFound = resp.getStreamNotFound()!;
-
-      this.emit(
-        "error",
-        new StreamNotFoundError(
-          null as never,
-          streamNotFound.getStreamIdentifier()?.getStreamName()
-        )
-      );
+      this.#grpcStream.then((stream) => {
+        stream.destroy(
+          new StreamNotFoundError(
+            null as never,
+            streamNotFound.getStreamIdentifier()?.getStreamName()
+          )
+        );
+        next();
+      });
+      return;
     }
 
     if (resp.hasEvent?.()) {


### PR DESCRIPTION
As `streamNotFound` is a control message, not an error, it doesn't close the readstream, causing the stream to stick around.

This PR destroys the stream with `StreamNotFoundError`, allowing the stream to close and be garbage collected.

![image](https://user-images.githubusercontent.com/11861797/185359058-8ccf9bbc-a4dc-4693-8746-c735ff2424be.png)


fixes: #294 

