### PR TITLE
Added a new sample file

### DIFF
--- a/samples/get-started-docs.ts
+++ b/samples/get-started-docs.ts
@@ -1,0 +1,5 @@
+import {EventStoreDBClient} from "@eventstore/db-client";
+
+// region createClient
+const client = EventStoreDBClient.connectionString`{connectionString}`;
+// endregion createClient

--- a/samples/get-started-docs.ts
+++ b/samples/get-started-docs.ts
@@ -1,5 +1,7 @@
 import {EventStoreDBClient} from "@eventstore/db-client";
 
+/*
 // region createClient
 const client = EventStoreDBClient.connectionString`{connectionString}`;
 // endregion createClient
+*/

--- a/samples/get-started-docs.ts
+++ b/samples/get-started-docs.ts
@@ -1,7 +1,0 @@
-import {EventStoreDBClient} from "@eventstore/db-client";
-
-/*
-// region createClient
-const client = EventStoreDBClient.connectionString`{connectionString}`;
-// endregion createClient
-*/

--- a/samples/get-started.ts
+++ b/samples/get-started.ts
@@ -11,11 +11,15 @@ import { v4 as uuid } from "uuid";
 const CLOUD_ID = process.env.EVENTSTORE_CLOUD_ID!;
 const STREAM_NAME = uuid();
 
+/*
+// region createClient
+const client = EventStoreDBClient.connectionString`{connectionString}`;
+// endregion createClient
+*/
+
 optionalDescribe(!!CLOUD_ID)("[sample] get-started", () => {
   test("get-started", async () => {
-    // region createClient
     const client = EventStoreDBClient.connectionString`esdb+discover://${CLOUD_ID}.mesdb.eventstore.cloud`;
-    // endregion createClient
 
     // region createEvent
     type TestEvent = JSONEventType<


### PR DESCRIPTION
The docs need to have the connection string template `{connectionString}` as it replaces the placeholder with the actual generated connection string.

As the sample uses the cloud cluster, it doesn't property render in the docs. All other samples work ok.

Therefore, I added a new file that will only be used in the docs so I don't destroy the tests.