### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
           curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/eoan.list | sudo tee /etc/apt/sources.list.d/tailscale.list
           sudo apt-get update
           sudo apt-get install tailscale
-          sudo tailscale up --authkey ${{ secrets.tailscale_auth }} --hostname "node-client-ci-${{ inputs.version }}-$(date +'%Y-%m-%dT%H:%M:%S')" --advertise-tags=tag:ci --accept-routes
+          sudo tailscale up --authkey ${{ secrets.tailscale_auth }} --hostname "node-client-ci-${{ inputs.version }}-$(date +'%Y-%m-%d-%H-%M-%S')" --advertise-tags=tag:ci --accept-routes
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/src/__test__/extra/http.test.ts
+++ b/src/__test__/extra/http.test.ts
@@ -32,7 +32,7 @@ describe("http api", () => {
       );
 
       const result = await ping.call(client);
-      expect(result).toEqual(goodPing);
+      expect(result).toMatchObject(goodPing);
     });
 
     test("ip", async () => {
@@ -47,7 +47,7 @@ describe("http api", () => {
       );
 
       const result = await ping.call(client);
-      expect(result).toEqual(goodPing);
+      expect(result).toMatchObject(goodPing);
     });
 
     test("error transform", async () => {
@@ -102,7 +102,7 @@ describe("http api", () => {
       );
 
       const result = await ping.call(client);
-      expect(result).toEqual(goodPing);
+      expect(result).toMatchObject(goodPing);
     });
 
     test("ip", async () => {
@@ -117,7 +117,7 @@ describe("http api", () => {
       );
 
       const result = await ping.call(client);
-      expect(result).toEqual(goodPing);
+      expect(result).toMatchObject(goodPing);
     });
 
     test("error transform", async () => {


### PR DESCRIPTION
- Remove offending `:` from tailscale label
- Reduce matching strictness in http ping tests to account for new shape