### PR TITLE
Fix out of bounds value for stream revision (DB-94)

### DIFF
--- a/src/__test__/streams/readStream.test.ts
+++ b/src/__test__/streams/readStream.test.ts
@@ -20,6 +20,7 @@ import {
   LinkEvent,
   Position,
   AppendResult,
+  InvalidArgumentError,
 } from "@eventstore/db-client";
 
 describe("readStream", () => {
@@ -223,6 +224,34 @@ describe("readStream", () => {
           if (error instanceof StreamNotFoundError) {
             expect(error.streamName).toBe(NO_STREAM_NAME);
           }
+        }
+      });
+
+      test("stream revision invalid argument lower bound", async () => {
+        let count = 0;
+        try {
+          for await (const e of client.readStream(STREAM_NAME,  {
+            direction: BACKWARDS,
+            fromRevision: BigInt(-1),
+          })) {
+            count++;
+          }
+        } catch (error) {
+          expect(error).toBeInstanceOf(InvalidArgumentError);
+        }
+      });
+
+      test("stream revision invalid argument upper bound", async () => {
+        let count = 0;
+        try {
+          for await (const e of client.readStream(STREAM_NAME,  {
+            direction: BACKWARDS,
+            fromRevision: BigInt("18446744073709551616"),
+          })) {
+            count++;
+          }
+        } catch (error) {
+          expect(error).toBeInstanceOf(InvalidArgumentError);
         }
       });
 

--- a/src/streams/readStream.ts
+++ b/src/streams/readStream.ts
@@ -14,7 +14,7 @@ import type {
   ResolvedEvent,
   StreamingRead,
 } from "../types";
-import { debug, convertGrpcEvent, createStreamIdentifier } from "../utils";
+import { debug, convertGrpcEvent, createStreamIdentifier, InvalidArgumentError } from "../utils";
 
 import { ReadStream } from "./utils/ReadStream";
 
@@ -91,6 +91,17 @@ Client.prototype.readStream = function <
       break;
     }
     default: {
+      const lowerBound = BigInt("0");
+      const upperBound = BigInt("0xffffffffffffffff");
+
+      if (fromRevision < lowerBound) {
+        throw new InvalidArgumentError(`fromRevision value must be a non-negative integer. Value Received: ${fromRevision}`);
+      }
+
+      if (fromRevision > upperBound) {
+        throw new InvalidArgumentError(`fromRevision value must be a non-negative integer, range from 0 to 18446744073709551615. Value Received: ${fromRevision}`);
+      }
+
       streamOptions.setRevision(fromRevision.toString(10));
       break;
     }

--- a/src/utils/CommandError.ts
+++ b/src/utils/CommandError.ts
@@ -18,6 +18,7 @@ export enum ErrorType {
   STREAM_NOT_FOUND = "stream-not-found",
   NO_STREAM = "no-stream",
   ACCESS_DENIED = "access-denied",
+  INVALID_ARGUMENT = "invalid-argument",
   INVALID_TRANSACTION = "invalid-transaction",
   STREAM_DELETED = "stream-deleted",
   SCAVENGE_NOT_FOUND = "scavenge-not-found",
@@ -385,11 +386,22 @@ export class UnsupportedError extends CommandErrorBase {
   }
 }
 
+export class InvalidArgumentError extends CommandErrorBase {
+  public type: ErrorType.INVALID_ARGUMENT = ErrorType.INVALID_ARGUMENT;
+  public errorMessage: string;
+
+  constructor(error: string) {
+    super(undefined, error);
+    this.errorMessage = error;
+  }
+}
+
 export type CommandError =
   | NotLeaderError
   | StreamNotFoundError
   | NoStreamError
   | AccessDeniedError
+  | InvalidArgumentError
   | InvalidTransactionError
   | StreamDeletedError
   | ScavengeNotFoundError


### PR DESCRIPTION
Fixed: Fix out of bounds value for stream revision

Fixes https://github.com/EventStore/EventStore/issues/2781

Currently the streamRevision is accepting the negative values which results in serialization issue. The goal of this PR is to add validation check for the streamRevision value. 

The user will see the following error message in case of out of bounds value. 

<img width="593" alt="image" src="https://user-images.githubusercontent.com/25709924/236343865-2c07d44a-807e-4f0e-b3cd-e490c7f9892a.png">
