### PR TITLE
Fix macos runner & deprecated way of setting workflow output (DB-84)

### DIFF
--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-10.15]
+        os: [ubuntu-latest, windows-2019, macos-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -42,8 +42,8 @@ jobs:
       - name: Create package
         id: package
         run: |
-          echo "::set-output name=package::$(echo $PWD)$(echo "/")$(npm pack)"
-          echo "::set-output name=file::$(echo $PWD)$(echo "/.github/files/package_check.txt")"
+          echo "package=$(echo $PWD)$(echo "/")$(npm pack)" >> $GITHUB_OUTPUT
+          echo "file=$(echo $PWD)$(echo "/.github/files/package_check.txt")" >> $GITHUB_OUTPUT
       - name: Create test project
         run: |
           cd ../


### PR DESCRIPTION
Fixed: Using deprecated `macos-10.15` runner
Changed: Use `$GITHUB_OUTPUT` for workflow output.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

