### PR TITLE
Fix linting for ci

### DIFF
--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -26,7 +26,6 @@ jobs:
 
   package:
     name: Package compiles as a dependency
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -67,7 +66,6 @@ jobs:
           --types node
   linting:
     name: Linting
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/src/__test__/streams/readStream.test.ts
+++ b/src/__test__/streams/readStream.test.ts
@@ -230,7 +230,7 @@ describe("readStream", () => {
       test("stream revision invalid argument lower bound", async () => {
         let count = 0;
         try {
-          for await (const e of client.readStream(STREAM_NAME,  {
+          for await (const e of client.readStream(STREAM_NAME, {
             direction: BACKWARDS,
             fromRevision: BigInt(-1),
           })) {
@@ -244,7 +244,7 @@ describe("readStream", () => {
       test("stream revision invalid argument upper bound", async () => {
         let count = 0;
         try {
-          for await (const e of client.readStream(STREAM_NAME,  {
+          for await (const e of client.readStream(STREAM_NAME, {
             direction: BACKWARDS,
             fromRevision: BigInt("18446744073709551616"),
           })) {

--- a/src/streams/readStream.ts
+++ b/src/streams/readStream.ts
@@ -14,7 +14,12 @@ import type {
   ResolvedEvent,
   StreamingRead,
 } from "../types";
-import { debug, convertGrpcEvent, createStreamIdentifier, InvalidArgumentError } from "../utils";
+import {
+  debug,
+  convertGrpcEvent,
+  createStreamIdentifier,
+  InvalidArgumentError,
+} from "../utils";
 
 import { ReadStream } from "./utils/ReadStream";
 
@@ -95,11 +100,15 @@ Client.prototype.readStream = function <
       const upperBound = BigInt("0xffffffffffffffff");
 
       if (fromRevision < lowerBound) {
-        throw new InvalidArgumentError(`fromRevision value must be a non-negative integer. Value Received: ${fromRevision}`);
+        throw new InvalidArgumentError(
+          `fromRevision value must be a non-negative integer. Value Received: ${fromRevision}`
+        );
       }
 
       if (fromRevision > upperBound) {
-        throw new InvalidArgumentError(`fromRevision value must be a non-negative integer, range from 0 to 18446744073709551615. Value Received: ${fromRevision}`);
+        throw new InvalidArgumentError(
+          `fromRevision value must be a non-negative integer, range from 0 to 18446744073709551615. Value Received: ${fromRevision}`
+        );
       }
 
       streamOptions.setRevision(fromRevision.toString(10));


### PR DESCRIPTION
- Apply prettier to fix CI
- Don't gate linting and compile checks on successful build check 
  We previously had an issue with the macos CI (#332) , which allowed an unlinted PR (#331) to slip through.
There's no need to block on it, so lets not.

fixes: DB-232