### PR TITLE
[BREAKING CHANGE] Update to grpc v1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     ]
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.4.5",
+    "@grpc/grpc-js": "1.9.0",
     "@types/debug": "^4.1.7",
     "@types/google-protobuf": "^3.15.5",
     "@types/node": "^16.11.4",

--- a/src/Client/index.ts
+++ b/src/Client/index.ts
@@ -605,7 +605,8 @@ export class Client {
   };
 
   protected createDeadline(deadline: number = this.#defaultDeadline): Date {
-    return new Date(Date.now() + deadline);
+    // grpcJS chokes on an invalid date, so we cap the deadline to max 1 year.
+    return new Date(Date.now() + Math.min(deadline, 0x757b12c00));
   }
 
   protected get capabilities(): Promise<ServerFeatures> {

--- a/src/Client/index.ts
+++ b/src/Client/index.ts
@@ -30,6 +30,7 @@ import type {
   BaseOptions,
 } from "../types";
 import {
+  CancelledError,
   convertToCommandError,
   debug,
   NotLeaderError,
@@ -463,7 +464,12 @@ export class Client {
       return [true, error.leader];
     }
 
-    return [error instanceof UnavailableError];
+    return [
+      // Server is unavailable to take request
+      error instanceof UnavailableError ||
+        // Server has cancelled a long running request
+        error instanceof CancelledError,
+    ];
   };
 
   protected handleError = async (

--- a/src/__test__/connection/reconnect/mid-stream.test.ts
+++ b/src/__test__/connection/reconnect/mid-stream.test.ts
@@ -7,7 +7,7 @@ import {
 import {
   jsonEvent,
   EventStoreDBClient,
-  UnavailableError,
+  CancelledError,
 } from "@eventstore/db-client";
 
 // This test can take time.
@@ -50,7 +50,7 @@ describe("reconnect", () => {
 
       expect(i).toBe("unreachable");
     } catch (error) {
-      expect(error).toBeInstanceOf(UnavailableError);
+      expect(error).toBeInstanceOf(CancelledError);
     }
 
     // wait for leader to be ready

--- a/src/__test__/extra/write-after-end.test.ts
+++ b/src/__test__/extra/write-after-end.test.ts
@@ -7,7 +7,11 @@ import {
   matchServerVersion,
   optionalTest,
 } from "@test-utils";
-import { EventStoreDBClient, UnavailableError } from "@eventstore/db-client";
+import {
+  CancelledError,
+  EventStoreDBClient,
+  UnavailableError,
+} from "@eventstore/db-client";
 
 // These tests can take time.
 jest.setTimeout(120_000);
@@ -89,7 +93,7 @@ describe("write after end", () => {
       await node.killNode(node.endpoints[0]);
 
       const error = await errorPromise;
-      expect(error).toBeInstanceOf(UnavailableError);
+      expect(error).toBeInstanceOf(CancelledError);
 
       // wait for any unhandled rejections
       await delay(5_000);

--- a/src/persistentSubscription/utils/PersistentSubscriptionImpl.ts
+++ b/src/persistentSubscription/utils/PersistentSubscriptionImpl.ts
@@ -1,6 +1,6 @@
 import { Transform, TransformCallback, TransformOptions } from "stream";
 
-import { ClientDuplexStream, ServiceError, status } from "@grpc/grpc-js";
+import type { ClientDuplexStream, ServiceError } from "@grpc/grpc-js";
 
 import { ReadReq, ReadResp } from "../../../generated/persistent_pb";
 
@@ -9,6 +9,7 @@ import {
   ConvertGrpcEvent,
   createUUID,
   backpressuredWrite,
+  isClientCancellationError,
 } from "../../utils";
 import type {
   PersistentAction,
@@ -40,7 +41,7 @@ export class PersistentSubscriptionImpl<E>
     try {
       (await this.#grpcStream)
         .on("error", (err: ServiceError) => {
-          if (err.code === status.CANCELLED) return;
+          if (isClientCancellationError(err)) return;
           const error = convertToCommandError(err);
           this.emit("error", error);
         })

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from "./filter";
 export * from "./grpcStreamIdentifier";
 export * from "./grpcUUID";
 export * from "./utilityTypes";
+export * from "./isClientCancellationError";

--- a/src/utils/isClientCancellationError.ts
+++ b/src/utils/isClientCancellationError.ts
@@ -1,0 +1,11 @@
+import { ServiceError, status } from "@grpc/grpc-js";
+
+const isServiceError = (error: Error): error is ServiceError => "code" in error;
+export const isClientCancellationError = (err: unknown): boolean => {
+  return (
+    err instanceof Error &&
+    isServiceError(err) &&
+    err.code === status.CANCELLED &&
+    err.details === "Cancelled on client"
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,24 +333,24 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@grpc/grpc-js@^1.4.5":
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.4.5.tgz#0cd840b47180624eeedf066f2cdc422d052401f8"
-  integrity sha512-A6cOzSu7dqXZ7rzvh/9JZf+Jg/MOpLEMP0IdT8pT8hrWJZ6TB4ydN/MRuqOtAugInJe/VQ9F8BPricUpYZSaZA==
+"@grpc/grpc-js@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.0.tgz#bdb599e339adabb16aa7243e70c311f75a572867"
+  integrity sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==
   dependencies:
-    "@grpc/proto-loader" "^0.6.4"
+    "@grpc/proto-loader" "^0.7.0"
     "@types/node" ">=12.12.47"
 
-"@grpc/proto-loader@^0.6.4":
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.6.6.tgz#d8e51ea808ec5fa54d9defbecbf859336fb2da71"
-  integrity sha512-cdMaPZ8AiFz6ua6PUbP+LKbhwJbFXnrQ/mlnKGUyzDUZ3wp7vPLksnmLCBX6SHgSmjX7CbNVNLFYD5GmmjO4GQ==
+"@grpc/proto-loader@^0.7.0":
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.8.tgz#c050bbeae5f000a1919507f195a1b094e218036e"
+  integrity sha512-GU12e2c8dmdXb7XUlOgYWZ2o2i+z9/VeACkxTA/zzAe2IjclC5PnVL0lpgjhrqfpDYHzM8B1TF6pqWegMYAzlA==
   dependencies:
     "@types/long" "^4.0.1"
     lodash.camelcase "^4.3.0"
     long "^4.0.0"
-    protobufjs "^6.10.0"
-    yargs "^16.1.1"
+    protobufjs "^7.2.4"
+    yargs "^17.7.2"
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
@@ -1192,6 +1192,15 @@ cliui@^7.0.2:
   dependencies:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
 co@^4.6.0:
@@ -2824,6 +2833,11 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
+long@^5.0.0:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
+  integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -3234,10 +3248,10 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-protobufjs@^6.10.0:
-  version "6.11.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.3.tgz#637a527205a35caa4f3e2a9a4a13ddffe0e7af74"
-  integrity sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==
+protobufjs@^7.2.4:
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.4.tgz#3fc1ec0cdc89dd91aef9ba6037ba07408485c3ae"
+  integrity sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -3249,9 +3263,8 @@ protobufjs@^6.10.0:
     "@protobufjs/path" "^1.1.2"
     "@protobufjs/pool" "^1.1.0"
     "@protobufjs/utf8" "^1.1.0"
-    "@types/long" "^4.0.1"
     "@types/node" ">=13.7.0"
-    long "^4.0.0"
+    long "^5.0.0"
 
 psl@^1.1.33:
   version "1.8.0"
@@ -4062,7 +4075,12 @@ yargs-parser@20.x, yargs-parser@^20.2.2:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs@^16.1.1, yargs@^16.2.0:
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
@@ -4074,3 +4092,16 @@ yargs@^16.1.1, yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"


### PR DESCRIPTION
- update to grpcJS v1.9.0
- prevent invalid dates on very long deadlines
- Update error handling to correctly handle `CANCELLED `

GRPCjs now throws a `CANCELLED` error when a stream is cancelled by the server, where previously it would throw a `UNAVAILABLE` status.
We now handle this error internally in the same way as an `UNAVAILABLE` error, but throw a `CancelledError`.
If users are catching `UnavailableError` on a stream for this situation, they should now be looking for a `CancelledError`.

Before:

``` ts
try {
  for await (const event of client.readStream("my_stream")) {
    // do something
  }
} catch (error) {
  if (isCommandError(error)) {
    if (error.type === ErrorType.UNAVAILABLE) {
      // Server is unavailable to take request
      // _OR_
      // Stream was cancelled by server
    }
  }
}
```

After:

``` ts
try {
  for await (const event of client.readStream("my_stream")) {
    // do something
  }
} catch (error) {
  if (isCommandError(error)) {
    if (error.type === ErrorType.CANCELLED) {
      // Stream was cancelled by server
    }

    if (error.type === ErrorType.UNAVAILABLE) {
      // Server is unavailable to take request
    }
  }
}
```
