### PR TITLE
[DEV-204] Upgrade grpc-js to 1.9.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     ]
   },
   "dependencies": {
-    "@grpc/grpc-js": "1.9.0",
+    "@grpc/grpc-js": "^1.9.12",
     "@types/debug": "^4.1.12",
     "@types/google-protobuf": "^3.15.12",
     "@types/node": "^16.18.67",

--- a/src/__test__/connection/reconnect/mid-stream.test.ts
+++ b/src/__test__/connection/reconnect/mid-stream.test.ts
@@ -1,13 +1,17 @@
+/** @jest-environment ./src/__test__/utils/enableVersionCheck.ts */
+
 import {
   createTestCluster,
   delay,
   getCurrentConnection,
   jsonTestEvents,
+  matchServerVersion,
 } from "@test-utils";
 import {
   jsonEvent,
   EventStoreDBClient,
   CancelledError,
+  UnavailableError,
 } from "@eventstore/db-client";
 
 // This test can take time.
@@ -50,7 +54,22 @@ describe("reconnect", () => {
 
       expect(i).toBe("unreachable");
     } catch (error) {
-      expect(error).toBeInstanceOf(CancelledError);
+      if (matchServerVersion`<=23.10`) {
+        // In ESDB versions below 24, the default value for
+        // HostOptions.ShutdownTimeout in the .NET runtime is 5 seconds.  This
+        // means the client will wait for 5 seconds for a server response before
+        // timing out. If the server shuts down during this period, the client
+        // will encounter a CancelledError. Previously, a CancelledError was
+        // incorrectly thrown for keep alive ping errors due to a lack of error
+        // handling in grpc-js. This issue was addressed in
+        // https://github.com/grpc/grpc-node/pull/2563/commits/83789c15dbe9de3bc9069bc0d7c63f13d71f5b6e
+        expect(error).toBeInstanceOf(CancelledError);
+      } else {
+        // Starting with ESDB version 24, the default ShutdownTimeout value has
+        // been increased to 30 seconds. This change gives us a longer grace
+        // period for the client to handle server shutdowns.
+        expect(error).toBeInstanceOf(UnavailableError);
+      }
     }
 
     // wait for leader to be ready

--- a/src/__test__/extra/write-after-end.test.ts
+++ b/src/__test__/extra/write-after-end.test.ts
@@ -93,7 +93,13 @@ describe("write after end", () => {
       await node.killNode(node.endpoints[0]);
 
       const error = await errorPromise;
-      expect(error).toBeInstanceOf(CancelledError);
+
+      // The reason for this discrepancy is explained in mid-stream.test.ts
+      if (matchServerVersion`<=23.10`) {
+        expect(error).toBeInstanceOf(CancelledError);
+      } else {
+        expect(error).toBeInstanceOf(UnavailableError);
+      }
 
       // wait for any unhandled rejections
       await delay(5_000);

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,22 +561,21 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@grpc/grpc-js@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.0.tgz#bdb599e339adabb16aa7243e70c311f75a572867"
-  integrity sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==
+"@grpc/grpc-js@^1.9.12":
+  version "1.9.12"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.12.tgz#a45b23a7d9ee1eadc9fa8fe480e27edbc6544cdd"
+  integrity sha512-Um5MBuge32TS3lAKX02PGCnFM4xPT996yLgZNb5H03pn6NyJ4Iwn5YcPq6Jj9yxGRk7WOgaZFtVRH5iTdYBeUg==
   dependencies:
-    "@grpc/proto-loader" "^0.7.0"
+    "@grpc/proto-loader" "^0.7.8"
     "@types/node" ">=12.12.47"
 
-"@grpc/proto-loader@^0.7.0":
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.8.tgz#c050bbeae5f000a1919507f195a1b094e218036e"
-  integrity sha512-GU12e2c8dmdXb7XUlOgYWZ2o2i+z9/VeACkxTA/zzAe2IjclC5PnVL0lpgjhrqfpDYHzM8B1TF6pqWegMYAzlA==
+"@grpc/proto-loader@^0.7.8":
+  version "0.7.10"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.10.tgz#6bf26742b1b54d0a473067743da5d3189d06d720"
+  integrity sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==
   dependencies:
-    "@types/long" "^4.0.1"
     lodash.camelcase "^4.3.0"
-    long "^4.0.0"
+    long "^5.0.0"
     protobufjs "^7.2.4"
     yargs "^17.7.2"
 
@@ -1013,11 +1012,6 @@
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
-
-"@types/long@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
-  integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
 "@types/ms@*":
   version "0.7.31"
@@ -3168,11 +3162,6 @@ lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-long@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
-  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
 long@^5.0.0:
   version "5.2.3"


### PR DESCRIPTION
Changed: Upgraded gRPC-JS version from 1.9.0 to 1.9.12.

Fixed: Linting issues
Added: Explanations for the discrepancy in the keepalive ping error. [DEV-204](https://linear.app/eventstore/issue/DEV-204/upgrade-grpc-js-to-1911)