### PR TITLE
Update error type from UnknownError to NotFoundError in projections

### DIFF
--- a/samples/projection-management.ts
+++ b/samples/projection-management.ts
@@ -1,9 +1,11 @@
+/** @jest-environment ./src/__test__/utils/enableVersionCheck.ts */
+
 import { v4 as uuid } from "uuid";
 
 import { EventStoreDBClient, isCommandError } from "@eventstore/db-client";
-import { createTestNode, delay, jsonTestEvents } from "@test-utils";
+import { createTestNode, delay, jsonTestEvents, matchServerVersion, optionalDescribe } from "@test-utils";
 
-describe("[sample] projection-management", () => {
+optionalDescribe(matchServerVersion`<=23.10`)("[sample] projection-management", () => {
   const noop = (...args: unknown[]) => {
     // do nothing
   };

--- a/src/__test__/projections/deleteProjection.test.ts
+++ b/src/__test__/projections/deleteProjection.test.ts
@@ -1,4 +1,6 @@
-import { createTestNode } from "@test-utils";
+/** @jest-environment ./src/__test__/utils/enableVersionCheck.ts */
+
+import { createTestNode, matchServerVersion } from "@test-utils";
 
 import {
   EventStoreDBClient,
@@ -6,6 +8,7 @@ import {
   DELETING,
   STOPPED,
   ABORTED,
+  NotFoundError,
   UnknownError,
 } from "@eventstore/db-client";
 
@@ -80,17 +83,21 @@ describe("deleteProjection", () => {
       expect(afterDetails.projectionStatus).toBe(DELETING);
     } catch (error) {
       // projection is already deleted
-      expect(error).toBeInstanceOf(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+      expect(error).toBeInstanceOf(
+        matchServerVersion`<=23.10` ? UnknownError : NotFoundError
+      );
     }
   });
 
   describe("errors", () => {
-    test("projection doesnt exist", async () => {
+    test.only("projection doesnt exist", async () => {
       const PROJECTION_NAME = "doesnt exist";
 
       await expect(
         client.deleteProjection(PROJECTION_NAME)
-      ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+      ).rejects.toThrowError(
+        matchServerVersion`<=23.10` ? UnknownError : NotFoundError
+      );
     });
   });
 });

--- a/src/__test__/projections/disableProjection.test.ts
+++ b/src/__test__/projections/disableProjection.test.ts
@@ -5,6 +5,7 @@ import { createTestNode, matchServerVersion } from "@test-utils";
 import {
   ABORTED,
   EventStoreDBClient,
+  NotFoundError,
   RUNNING,
   STOPPED,
   UnknownError,
@@ -71,7 +72,9 @@ describe("disable / abort", () => {
 
       await expect(
         client.disableProjection(PROJECTION_NAME)
-      ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+      ).rejects.toThrowError(
+        matchServerVersion`<=23.10` ? UnknownError : NotFoundError
+      );
     });
   });
 
@@ -107,7 +110,9 @@ describe("disable / abort", () => {
 
         await expect(
           client.abortProjection(PROJECTION_NAME)
-        ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+        ).rejects.toThrowError(
+          matchServerVersion`<=23.10` ? UnknownError : NotFoundError
+        );
       });
     });
   });

--- a/src/__test__/projections/enableProjection.test.ts
+++ b/src/__test__/projections/enableProjection.test.ts
@@ -5,6 +5,7 @@ import { createTestNode, matchServerVersion } from "@test-utils";
 import {
   ABORTED,
   EventStoreDBClient,
+  NotFoundError,
   RUNNING,
   STOPPED,
   UnknownError,
@@ -69,7 +70,7 @@ describe("enableProjection", () => {
     const PROJECTION_NAME = "doesnt exist";
 
     await expect(client.enableProjection(PROJECTION_NAME)).rejects.toThrowError(
-      UnknownError
-    ); // https://github.com/EventStore/EventStore/issues/2732
+      matchServerVersion`<=23.10` ? UnknownError : NotFoundError
+    );
   });
 });

--- a/src/__test__/projections/getProjectionResult.test.ts
+++ b/src/__test__/projections/getProjectionResult.test.ts
@@ -1,10 +1,18 @@
-import { createTestNode, delay, jsonTestEvents } from "@test-utils";
+/** @jest-environment ./src/__test__/utils/enableVersionCheck.ts */
 
 import {
-  UnknownError,
+  createTestNode,
+  delay,
+  jsonTestEvents,
+  matchServerVersion,
+} from "@test-utils";
+
+import {
   RUNNING,
   EventStoreDBClient,
   jsonEvent,
+  NotFoundError,
+  UnknownError,
 } from "@eventstore/db-client";
 
 describe("getProjectionResult", () => {
@@ -162,7 +170,9 @@ describe("getProjectionResult", () => {
 
       await expect(
         client.getProjectionResult(PROJECTION_NAME)
-      ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+      ).rejects.toThrowError(
+        matchServerVersion`<=23.10` ? UnknownError : NotFoundError
+      );
     });
   });
 });

--- a/src/__test__/projections/getProjectionState.test.ts
+++ b/src/__test__/projections/getProjectionState.test.ts
@@ -1,8 +1,16 @@
-import { createTestNode, delay, jsonTestEvents } from "@test-utils";
+/** @jest-environment ./src/__test__/utils/enableVersionCheck.ts */
+
+import {
+  createTestNode,
+  delay,
+  jsonTestEvents,
+  matchServerVersion,
+} from "@test-utils";
 
 import {
   EventStoreDBClient,
   jsonEvent,
+  NotFoundError,
   RUNNING,
   UnknownError,
 } from "@eventstore/db-client";
@@ -161,6 +169,8 @@ describe("getProjectionState", () => {
 
     await expect(
       client.getProjectionState(PROJECTION_NAME)
-    ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+    ).rejects.toThrowError(
+      matchServerVersion`<=23.10` ? UnknownError : NotFoundError
+    );
   });
 });

--- a/src/__test__/projections/getProjectionStatus.test.ts
+++ b/src/__test__/projections/getProjectionStatus.test.ts
@@ -1,6 +1,12 @@
-import { createTestNode } from "@test-utils";
+/** @jest-environment ./src/__test__/utils/enableVersionCheck.ts */
 
-import { EventStoreDBClient, UnknownError } from "@eventstore/db-client";
+import { createTestNode, matchServerVersion } from "@test-utils";
+
+import {
+  EventStoreDBClient,
+  NotFoundError,
+  UnknownError,
+} from "@eventstore/db-client";
 
 describe("getProjectionStatus", () => {
   const node = createTestNode();
@@ -48,7 +54,9 @@ describe("getProjectionStatus", () => {
       const REQUESTED_NAME = "some-non-existant-projection";
       await expect(
         client.getProjectionStatus(REQUESTED_NAME)
-      ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+      ).rejects.toThrowError(
+        matchServerVersion`<=23.10` ? UnknownError : NotFoundError
+      );
     });
   });
 });

--- a/src/__test__/projections/resetProjection.test.ts
+++ b/src/__test__/projections/resetProjection.test.ts
@@ -1,6 +1,12 @@
-import { createTestNode } from "@test-utils";
+/** @jest-environment ./src/__test__/utils/enableVersionCheck.ts */
 
-import { EventStoreDBClient, UnknownError } from "@eventstore/db-client";
+import { createTestNode, matchServerVersion } from "@test-utils";
+
+import {
+  EventStoreDBClient,
+  NotFoundError,
+  UnknownError,
+} from "@eventstore/db-client";
 
 describe("resetProjection", () => {
   const node = createTestNode();
@@ -41,7 +47,9 @@ describe("resetProjection", () => {
       const PROJECTION_NAME = "doesnt exist";
       await expect(
         client.resetProjection(PROJECTION_NAME)
-      ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+      ).rejects.toThrowError(
+        matchServerVersion`<=23.10` ? UnknownError : NotFoundError
+      );
     });
   });
 });

--- a/src/__test__/projections/updateProjection.test.ts
+++ b/src/__test__/projections/updateProjection.test.ts
@@ -1,6 +1,12 @@
-import { createTestNode } from "@test-utils";
+/** @jest-environment ./src/__test__/utils/enableVersionCheck.ts */
 
-import { EventStoreDBClient, UnknownError } from "@eventstore/db-client";
+import { createTestNode, matchServerVersion } from "@test-utils";
+
+import {
+  EventStoreDBClient,
+  NotFoundError,
+  UnknownError,
+} from "@eventstore/db-client";
 
 describe("resetProjection", () => {
   const node = createTestNode();
@@ -62,7 +68,9 @@ describe("resetProjection", () => {
       const PROJECTION_NAME = "doesnt exist";
       await expect(
         client.updateProjection(PROJECTION_NAME, projection)
-      ).rejects.toThrowError(UnknownError); // https://github.com/EventStore/EventStore/issues/2732
+      ).rejects.toThrowError(
+        matchServerVersion`<=23.10` ? UnknownError : NotFoundError
+      );
     });
   });
 });

--- a/src/utils/CommandError.ts
+++ b/src/utils/CommandError.ts
@@ -19,6 +19,7 @@ export enum ErrorType {
   NOT_LEADER = "not-leader",
   STREAM_NOT_FOUND = "stream-not-found",
   NO_STREAM = "no-stream",
+  NOT_FOUND = "not-found",
   ACCESS_DENIED = "access-denied",
   INVALID_ARGUMENT = "invalid-argument",
   INVALID_TRANSACTION = "invalid-transaction",
@@ -69,6 +70,10 @@ export class UnavailableError extends CommandErrorBase {
 
 export class CancelledError extends CommandErrorBase {
   public type: ErrorType.CANCELLED = ErrorType.CANCELLED;
+}
+
+export class NotFoundError extends CommandErrorBase {
+  public type: ErrorType.NOT_FOUND = ErrorType.NOT_FOUND;
 }
 
 export class UnknownError extends CommandErrorBase {
@@ -479,6 +484,8 @@ export const convertToCommandError = (error: Error): CommandError | Error => {
       return new UnavailableError(error);
     case StatusCode.UNAUTHENTICATED:
       return new AccessDeniedError(error);
+    case StatusCode.NOT_FOUND:
+      return new NotFoundError(error);
     case StatusCode.CANCELLED: {
       if (isClientCancellationError(error)) break;
       return new CancelledError(error);


### PR DESCRIPTION
Changed: Update error type from UnknownError to NotFoundError in projections

This change only affects clients using EventStoreDB version 242.0 and above.