### PR TITLE
Refactor execute and GRPCStreamCreator methods

### DIFF
--- a/src/persistentSubscription/subscribeToPersistentSubscriptionToAll.ts
+++ b/src/persistentSubscription/subscribeToPersistentSubscriptionToAll.ts
@@ -51,48 +51,49 @@ Client.prototype.subscribeToPersistentSubscriptionToAll = function (
   duplexOptions: DuplexOptions = {}
 ): PersistentSubscriptionToAll {
   return new PersistentSubscriptionImpl(
-    this.GRPCStreamCreator(
-      PersistentSubscriptionsClient,
-      "subscribeToPersistentSubscriptionToAll",
-      async (client) => {
-        if (
-          !(await this.supports(PersistentSubscriptionsService.read, "all"))
-        ) {
-          throw new UnsupportedError(
-            "subscribeToPersistentSubscriptionToAll",
-            "21.10"
+    () =>
+      this.execute(
+        PersistentSubscriptionsClient,
+        "subscribeToPersistentSubscriptionToAll",
+        async (client) => {
+          if (
+            !(await this.supports(PersistentSubscriptionsService.read, "all"))
+          ) {
+            throw new UnsupportedError(
+              "subscribeToPersistentSubscriptionToAll",
+              "21.10"
+            );
+          }
+
+          const req = new ReadReq();
+          const options = new ReadReq.Options();
+          const uuidOption = new ReadReq.Options.UUIDOption();
+          uuidOption.setString(new Empty());
+
+          options.setAll(new Empty());
+          options.setGroupName(groupName);
+          options.setBufferSize(bufferSize);
+          options.setUuidOption(uuidOption);
+          req.setOptions(options);
+
+          debug.command("subscribeToPersistentSubscriptionToAll: %O", {
+            groupName,
+            options: {
+              bufferSize,
+              ...baseOptions,
+            },
+          });
+          debug.command_grpc("subscribeToPersistentSubscriptionToAll: %g", req);
+
+          const stream = client.read(
+            ...this.callArguments(baseOptions, {
+              deadline: Infinity,
+            })
           );
+          stream.write(req);
+          return stream;
         }
-
-        const req = new ReadReq();
-        const options = new ReadReq.Options();
-        const uuidOption = new ReadReq.Options.UUIDOption();
-        uuidOption.setString(new Empty());
-
-        options.setAll(new Empty());
-        options.setGroupName(groupName);
-        options.setBufferSize(bufferSize);
-        options.setUuidOption(uuidOption);
-        req.setOptions(options);
-
-        debug.command("subscribeToPersistentSubscriptionToAll: %O", {
-          groupName,
-          options: {
-            bufferSize,
-            ...baseOptions,
-          },
-        });
-        debug.command_grpc("subscribeToPersistentSubscriptionToAll: %g", req);
-
-        const stream = client.read(
-          ...this.callArguments(baseOptions, {
-            deadline: Infinity,
-          })
-        );
-        stream.write(req);
-        return stream;
-      }
-    ),
+      ),
     convertPersistentSubscriptionGrpcEvent,
     duplexOptions
   );

--- a/src/persistentSubscription/subscribeToPersistentSubscriptionToStream.ts
+++ b/src/persistentSubscription/subscribeToPersistentSubscriptionToStream.ts
@@ -56,44 +56,45 @@ Client.prototype.subscribeToPersistentSubscriptionToStream = function <
   duplexOptions: DuplexOptions = {}
 ): PersistentSubscriptionToStream<E> {
   return new PersistentSubscriptionImpl(
-    this.GRPCStreamCreator(
-      PersistentSubscriptionsClient,
-      "subscribeToPersistentSubscriptionToStream",
-      (client) => {
-        const req = new ReadReq();
-        const options = new ReadReq.Options();
-        const identifier = createStreamIdentifier(streamName);
-        const uuidOption = new ReadReq.Options.UUIDOption();
+    () =>
+      this.execute(
+        PersistentSubscriptionsClient,
+        "subscribeToPersistentSubscriptionToStream",
+        (client) => {
+          const req = new ReadReq();
+          const options = new ReadReq.Options();
+          const identifier = createStreamIdentifier(streamName);
+          const uuidOption = new ReadReq.Options.UUIDOption();
 
-        uuidOption.setString(new Empty());
-        options.setStreamIdentifier(identifier);
-        options.setGroupName(groupName);
-        options.setBufferSize(bufferSize);
-        options.setUuidOption(uuidOption);
-        req.setOptions(options);
+          uuidOption.setString(new Empty());
+          options.setStreamIdentifier(identifier);
+          options.setGroupName(groupName);
+          options.setBufferSize(bufferSize);
+          options.setUuidOption(uuidOption);
+          req.setOptions(options);
 
-        debug.command("subscribeToPersistentSubscriptionToStream: %O", {
-          streamName,
-          groupName,
-          options: {
-            bufferSize,
-            ...baseOptions,
-          },
-        });
-        debug.command_grpc(
-          "subscribeToPersistentSubscriptionToStream: %g",
-          req
-        );
+          debug.command("subscribeToPersistentSubscriptionToStream: %O", {
+            streamName,
+            groupName,
+            options: {
+              bufferSize,
+              ...baseOptions,
+            },
+          });
+          debug.command_grpc(
+            "subscribeToPersistentSubscriptionToStream: %g",
+            req
+          );
 
-        const stream = client.read(
-          ...this.callArguments(baseOptions, {
-            deadline: Infinity,
-          })
-        );
-        stream.write(req);
-        return stream;
-      }
-    ),
+          const stream = client.read(
+            ...this.callArguments(baseOptions, {
+              deadline: Infinity,
+            })
+          );
+          stream.write(req);
+          return stream;
+        }
+      ),
     convertPersistentSubscriptionGrpcEvent,
     duplexOptions
   );

--- a/src/streams/appendToStream/batchAppend.ts
+++ b/src/streams/appendToStream/batchAppend.ts
@@ -46,7 +46,7 @@ export const batchAppend = async function (
 ): Promise<AppendResult> {
   const correlationId = uuid();
 
-  const stream = await this.GRPCStreamCreator(
+  const stream = await this.execute(
     StreamsClient,
     "appendToStream",
     (client) =>
@@ -116,7 +116,7 @@ export const batchAppend = async function (
           promiseBank.clear();
         }),
     streamCache
-  )();
+  );
 
   return new Promise(async (...batchPromise) => {
     promiseBank.set(correlationId, batchPromise);

--- a/src/streams/readAll.ts
+++ b/src/streams/readAll.ts
@@ -124,17 +124,15 @@ Client.prototype.readAll = function (
   });
   debug.command_grpc("readAll: %g", req);
 
-  const createGRPCStream = this.GRPCStreamCreator(
-    StreamsClient,
-    "readAll",
-    (client) =>
+  const createGRPCStream = () =>
+    this.execute(StreamsClient, "readAll", (client) =>
       client.read(
         req,
         ...this.callArguments(baseOptions, {
           deadline: Infinity,
         })
       )
-  );
+    );
 
   return new ReadStream(createGRPCStream, convertGrpcEvent, readableOptions);
 };

--- a/src/streams/readStream.ts
+++ b/src/streams/readStream.ts
@@ -147,17 +147,15 @@ Client.prototype.readStream = function <
   });
   debug.command_grpc("readStream: %g", req);
 
-  const createGRPCStream = this.GRPCStreamCreator(
-    StreamsClient,
-    "readStream",
-    (client) =>
+  const createGRPCStream = () =>
+    this.execute(StreamsClient, "readStream", (client) =>
       client.read(
         req,
         ...this.callArguments(baseOptions, {
           deadline: Infinity,
         })
       )
-  );
+    );
 
   return new ReadStream(createGRPCStream, convertGrpcEvent, readableOptions);
 };

--- a/src/streams/subscribeToAll.ts
+++ b/src/streams/subscribeToAll.ts
@@ -147,17 +147,15 @@ Client.prototype.subscribeToAll = function (
   });
   debug.command_grpc("subscribeToAll: %g", req);
 
-  const createGRPCStream = this.GRPCStreamCreator(
-    StreamsClient,
-    "subscribeToAll",
-    (client) =>
+  const createGRPCStream = () =>
+    this.execute(StreamsClient, "subscribeToAll", (client) =>
       client.read(
         req,
         ...this.callArguments(baseOptions, {
           deadline: Infinity,
         })
       )
-  );
+    );
 
   return new Subscription(
     createGRPCStream,

--- a/src/streams/subscribeToStream.ts
+++ b/src/streams/subscribeToStream.ts
@@ -103,17 +103,15 @@ Client.prototype.subscribeToStream = function <
   });
   debug.command_grpc("subscribeToStream: %g", req);
 
-  const createGRPCStream = this.GRPCStreamCreator(
-    StreamsClient,
-    "subscribeToStream",
-    (client) =>
+  const createGRPCStream = () =>
+    this.execute(StreamsClient, "subscribeToStream", (client) =>
       client.read(
         req,
         ...this.callArguments(baseOptions, {
           deadline: Infinity,
         })
       )
-  );
+    );
 
   return new Subscription(createGRPCStream, convertGrpcEvent, readableOptions);
 };


### PR DESCRIPTION
Changed: Refactor execute and GRPCStreamCreator into a single method