### PR TITLE
DEV-45-4 - Pull es-gencert-cli from Cloudsmith

### DIFF
--- a/src/__test__/utils/dockerImages.ts
+++ b/src/__test__/utils/dockerImages.ts
@@ -29,6 +29,6 @@ const esdbImage = ((): string => {
 
 export const dockerImages = {
   volumesProvisioner: "hasnat/volumes-provisioner",
-  certGen: "ghcr.io/eventstore/es-gencert-cli:1.3",
+  certGen: "docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3",
   esdb: esdbImage,
 };

--- a/src/__test__/utils/dockerImages.ts
+++ b/src/__test__/utils/dockerImages.ts
@@ -29,6 +29,6 @@ const esdbImage = ((): string => {
 
 export const dockerImages = {
   volumesProvisioner: "hasnat/volumes-provisioner",
-  certGen: "docker.eventstore.com/eventstore-utils/es-gencert-cli:1.3",
+  certGen: "docker.eventstore.com/eventstore-utils/es-gencert-cli:latest",
   esdb: esdbImage,
 };


### PR DESCRIPTION
Changed: Updated everywhere to pull es-gencert-cli from Cloudsmith