### PR TITLE
fix: improve leader failover reconnection and error mapping

### DIFF
--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@eventstore/db-client": "^6.2.1",
-    "@kurrent/bridge": "^0.1.3",
+    "@kurrent/bridge": "^0.1.5",
     "tinybench": "^3.1.1"
   },
   "devDependencies": {

--- a/packages/db-client/package.json
+++ b/packages/db-client/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.14.3",
-    "@kurrent/bridge": "^0.1.3",
+    "@kurrent/bridge": "^0.1.5",
     "@types/debug": "^4.1.12",
     "@types/google-protobuf": "^3.15.12",
     "@types/node": "^22.10.2",

--- a/packages/db-client/src/utils/CommandError.ts
+++ b/packages/db-client/src/utils/CommandError.ts
@@ -640,6 +640,8 @@ export const convertToCommandError = (error: Error): CommandError | Error => {
     case StatusCode.DEADLINE_EXCEEDED:
       return new DeadlineExceededError(error);
     case StatusCode.UNAVAILABLE:
+    case StatusCode.INTERNAL:
+    case StatusCode.DATA_LOSS:
       return new UnavailableError(error);
     case StatusCode.UNAUTHENTICATED:
       return new AccessDeniedError(error);

--- a/packages/db-client/src/utils/convertBridgeError.ts
+++ b/packages/db-client/src/utils/convertBridgeError.ts
@@ -3,43 +3,32 @@ import {
   StreamNotFoundError,
   StreamDeletedError,
   AccessDeniedError,
+  UnavailableError,
+  DeadlineExceededError,
+  UnknownError,
 } from "./CommandError";
 import { ServiceError } from "@grpc/grpc-js";
-
-// export const convertBridgeError = (
-//   error: ServiceError,
-//   streamName?: string
-// ) => {
-//   const stream = streamName ?? "unknown stream";
-//
-//   switch (error.name) {
-//     case StreamNotFoundError.name:
-//       throw new StreamNotFoundError(error, stream);
-//     case StreamDeletedError.name:
-//       throw StreamDeletedError.fromStreamName(stream);
-//     case NotLeaderError.name:
-//       throw new NotLeaderError(error);
-//     case AccessDeniedError.name:
-//       throw new AccessDeniedError(error);
-//     default:
-//       throw error;
-//   }
-// };
 
 export const convertBridgeError = (error: Error, streamName?: string) => {
   const stream = streamName ?? "unknown stream";
   const serviceError = error as ServiceError;
 
   switch (error.name) {
-    case StreamNotFoundError.name:
+    case "StreamNotFoundError":
       return new StreamNotFoundError(serviceError, stream);
-    case StreamDeletedError.name:
+    case "StreamDeletedError":
       return StreamDeletedError.fromStreamName(stream);
-    case NotLeaderError.name:
+    case "NotLeaderError":
       return new NotLeaderError(serviceError);
-    case AccessDeniedError.name:
+    case "AccessDeniedError":
       return new AccessDeniedError(serviceError);
+    case "UnavailableError":
+      return new UnavailableError(serviceError);
+    case "DeadlineExceededError":
+      return new DeadlineExceededError(serviceError);
+    case "UnknownError":
+      return new UnknownError(serviceError);
     default:
-      return error;
+      return new UnknownError(serviceError);
   }
 };

--- a/packages/db-client/src/utils/convertBridgeError.ts
+++ b/packages/db-client/src/utils/convertBridgeError.ts
@@ -7,10 +7,15 @@ import {
   DeadlineExceededError,
   UnknownError,
 } from "./CommandError";
+import { debug } from "./debug";
 import { ServiceError } from "@grpc/grpc-js";
 
 export const convertBridgeError = (error: Error, streamName?: string) => {
   const stream = streamName ?? "unknown stream";
+
+  // Bridge errors are plain Error objects from the Rust native addon with
+  // name, message, and metadata (plain object). They lack gRPC-specific
+  // ServiceError properties (code, details) but CommandErrorBase handles this.
   const serviceError = error as ServiceError;
 
   switch (error.name) {
@@ -26,9 +31,12 @@ export const convertBridgeError = (error: Error, streamName?: string) => {
       return new UnavailableError(serviceError);
     case "DeadlineExceededError":
       return new DeadlineExceededError(serviceError);
-    case "UnknownError":
-      return new UnknownError(serviceError);
     default:
+      debug.connection(
+        "Unrecognized bridge error type '%s': %s",
+        error.name,
+        error.message
+      );
       return new UnknownError(serviceError);
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1065,66 +1065,66 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kurrent/bridge-darwin-arm64@npm:0.1.3":
-  version: 0.1.3
-  resolution: "@kurrent/bridge-darwin-arm64@npm:0.1.3"
+"@kurrent/bridge-darwin-arm64@npm:0.1.5":
+  version: 0.1.5
+  resolution: "@kurrent/bridge-darwin-arm64@npm:0.1.5"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@kurrent/bridge-darwin-x64@npm:0.1.3":
-  version: 0.1.3
-  resolution: "@kurrent/bridge-darwin-x64@npm:0.1.3"
+"@kurrent/bridge-darwin-x64@npm:0.1.5":
+  version: 0.1.5
+  resolution: "@kurrent/bridge-darwin-x64@npm:0.1.5"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@kurrent/bridge-linux-arm64-gnu@npm:0.1.3":
-  version: 0.1.3
-  resolution: "@kurrent/bridge-linux-arm64-gnu@npm:0.1.3"
+"@kurrent/bridge-linux-arm64-gnu@npm:0.1.5":
+  version: 0.1.5
+  resolution: "@kurrent/bridge-linux-arm64-gnu@npm:0.1.5"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@kurrent/bridge-linux-arm64-musl@npm:0.1.3":
-  version: 0.1.3
-  resolution: "@kurrent/bridge-linux-arm64-musl@npm:0.1.3"
+"@kurrent/bridge-linux-arm64-musl@npm:0.1.5":
+  version: 0.1.5
+  resolution: "@kurrent/bridge-linux-arm64-musl@npm:0.1.5"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@kurrent/bridge-linux-x64-gnu@npm:0.1.3":
-  version: 0.1.3
-  resolution: "@kurrent/bridge-linux-x64-gnu@npm:0.1.3"
+"@kurrent/bridge-linux-x64-gnu@npm:0.1.5":
+  version: 0.1.5
+  resolution: "@kurrent/bridge-linux-x64-gnu@npm:0.1.5"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@kurrent/bridge-linux-x64-musl@npm:0.1.3":
-  version: 0.1.3
-  resolution: "@kurrent/bridge-linux-x64-musl@npm:0.1.3"
+"@kurrent/bridge-linux-x64-musl@npm:0.1.5":
+  version: 0.1.5
+  resolution: "@kurrent/bridge-linux-x64-musl@npm:0.1.5"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@kurrent/bridge-win32-x64-msvc@npm:0.1.3":
-  version: 0.1.3
-  resolution: "@kurrent/bridge-win32-x64-msvc@npm:0.1.3"
+"@kurrent/bridge-win32-x64-msvc@npm:0.1.5":
+  version: 0.1.5
+  resolution: "@kurrent/bridge-win32-x64-msvc@npm:0.1.5"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@kurrent/bridge@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "@kurrent/bridge@npm:0.1.3"
+"@kurrent/bridge@npm:^0.1.5":
+  version: 0.1.5
+  resolution: "@kurrent/bridge@npm:0.1.5"
   dependencies:
-    "@kurrent/bridge-darwin-arm64": "npm:0.1.3"
-    "@kurrent/bridge-darwin-x64": "npm:0.1.3"
-    "@kurrent/bridge-linux-arm64-gnu": "npm:0.1.3"
-    "@kurrent/bridge-linux-arm64-musl": "npm:0.1.3"
-    "@kurrent/bridge-linux-x64-gnu": "npm:0.1.3"
-    "@kurrent/bridge-linux-x64-musl": "npm:0.1.3"
-    "@kurrent/bridge-win32-x64-msvc": "npm:0.1.3"
+    "@kurrent/bridge-darwin-arm64": "npm:0.1.5"
+    "@kurrent/bridge-darwin-x64": "npm:0.1.5"
+    "@kurrent/bridge-linux-arm64-gnu": "npm:0.1.5"
+    "@kurrent/bridge-linux-arm64-musl": "npm:0.1.5"
+    "@kurrent/bridge-linux-x64-gnu": "npm:0.1.5"
+    "@kurrent/bridge-linux-x64-musl": "npm:0.1.5"
+    "@kurrent/bridge-win32-x64-msvc": "npm:0.1.5"
     "@neon-rs/load": "npm:^0.1.82"
   dependenciesMeta:
     "@kurrent/bridge-darwin-arm64":
@@ -1141,7 +1141,7 @@ __metadata:
       optional: true
     "@kurrent/bridge-win32-x64-msvc":
       optional: true
-  checksum: 10c0/76c89f2fd392577a815c23d81332f052e1c3d30984c34e64ca6b7271ca2e1d713348dd44454e5d33d5b7935b33d7d143382c82c396bfa25c168678e05b3e387d
+  checksum: 10c0/8f1941011c17cd81b29e78b4743097fa8c6452abe2c80acee23c24d4b665ae027172bbb31d805d21a15ab42caa5e8ac83699a040434a53a0df14bcf7cf4a69b9
   languageName: node
   linkType: hard
 
@@ -1150,7 +1150,7 @@ __metadata:
   resolution: "@kurrent/kurrentdb-client@workspace:packages/db-client"
   dependencies:
     "@grpc/grpc-js": "npm:^1.14.3"
-    "@kurrent/bridge": "npm:^0.1.3"
+    "@kurrent/bridge": "npm:^0.1.5"
     "@types/debug": "npm:^4.1.12"
     "@types/google-protobuf": "npm:^3.15.12"
     "@types/node": "npm:^22.10.2"
@@ -2740,7 +2740,7 @@ __metadata:
   resolution: "benchmark@workspace:packages/benchmark"
   dependencies:
     "@eventstore/db-client": "npm:^6.2.1"
-    "@kurrent/bridge": "npm:^0.1.3"
+    "@kurrent/bridge": "npm:^0.1.5"
     "@kurrent/kurrentdb-client": "workspace:^"
     clinic: "npm:^13.0.0"
     tinybench: "npm:^3.1.1"


### PR DESCRIPTION
## Summary
- Map gRPC `INTERNAL` and `DATA_LOSS` status codes to `UnavailableError` so the client retries on these transient failures during leader failover
- Improve bridge error conversion to handle `UnavailableError`, `DeadlineExceededError`, and `UnknownError`, use string literals for error name matching, and default unrecognized errors to `UnknownError`
- Bump `@kurrent/bridge` from 0.1.3 to 0.1.5
